### PR TITLE
Add project annualizer calculations and UI

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -115,5 +115,47 @@
                 <TextBlock Text="{Binding Result}" Grid.Row="6" Grid.ColumnSpan="2"/>
             </Grid>
         </TabItem>
+        <TabItem Header="Project Annualizer" DataContext="{Binding Annualizer}">
+            <Grid Margin="10">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+                <TextBlock Text="First Cost" Margin="0,0,5,5"/>
+                <TextBox Text="{Binding FirstCost}" Grid.Column="1" Margin="0,0,0,5"
+                         ToolTip="Initial project cost."/>
+                <TextBlock Text="Rate (%)" Grid.Row="1" Margin="0,0,5,5"/>
+                <TextBox Text="{Binding Rate}" Grid.Row="1" Grid.Column="1" Margin="0,0,0,5"
+                         ToolTip="Discount rate in percent."/>
+                <TextBlock Text="Annual O&amp;M" Grid.Row="2" Margin="0,0,5,5"/>
+                <TextBox Text="{Binding AnnualOm}" Grid.Row="2" Grid.Column="1" Margin="0,0,0,5"
+                         ToolTip="Annual operations and maintenance cost."/>
+                <TextBlock Text="Annual Benefits" Grid.Row="3" Margin="0,0,5,5"/>
+                <TextBox Text="{Binding AnnualBenefits}" Grid.Row="3" Grid.Column="1" Margin="0,0,0,5"
+                         ToolTip="Expected annual benefits."/>
+                <TextBlock Text="Future Costs (cost:year,...)" Grid.Row="4" Margin="0,0,5,5"/>
+                <TextBox Text="{Binding FutureCosts}" Grid.Row="4" Grid.Column="1" Margin="0,0,0,5"
+                         ToolTip="Comma-separated future cost:year pairs."/>
+                <Button Content="Compute" Command="{Binding ComputeCommand}" Grid.Row="5" Grid.ColumnSpan="2" Margin="0,5,0,5"/>
+                <TextBlock Text="{Binding Idc, StringFormat=IDC: {0:F2}}" Grid.Row="6" Grid.ColumnSpan="2"/>
+                <TextBlock Text="{Binding TotalInvestment, StringFormat=Total Investment: {0:F2}}" Grid.Row="7" Grid.ColumnSpan="2"/>
+                <TextBlock Text="{Binding Crf, StringFormat=CRF: {0:F4}}" Grid.Row="8" Grid.ColumnSpan="2"/>
+                <TextBlock Text="{Binding AnnualCost, StringFormat=Annual Cost: {0:F2}}" Grid.Row="9" Grid.ColumnSpan="2"/>
+                <TextBlock Text="{Binding Bcr, StringFormat=BCR: {0:F2}}" Grid.Row="10" Grid.ColumnSpan="2"/>
+            </Grid>
+        </TabItem>
     </TabControl>
 </Window>

--- a/Models/AnnualizerModel.cs
+++ b/Models/AnnualizerModel.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+
+namespace EconToolbox.Desktop.Models
+{
+    public static class AnnualizerModel
+    {
+        public record Result(double Idc, double TotalInvestment, double Crf, double AnnualCost, double Bcr);
+
+        public static Result Compute(
+            double firstCost,
+            double rate,
+            double annualOm,
+            double annualBenefits,
+            IEnumerable<(double cost, int year)>? futureCosts = null,
+            int constructionMonths = 12)
+        {
+            double idc = InterestDuringConstructionModel.Compute(firstCost, rate, constructionMonths);
+
+            double pvFuture = 0.0;
+            int maxYear = 0;
+            if (futureCosts != null)
+            {
+                foreach (var (cost, year) in futureCosts)
+                {
+                    double pvFactor = 1.0 / Math.Pow(1.0 + rate, year);
+                    pvFuture += cost * pvFactor;
+                    if (year > maxYear) maxYear = year;
+                }
+            }
+
+            double totalInvestment = firstCost + idc + pvFuture;
+            int periods = Math.Max(1, maxYear);
+            double crf = CapitalRecoveryModel.Calculate(rate, periods);
+            double annualConstruction = totalInvestment * crf;
+            double annualCost = annualConstruction + annualOm;
+            double bcr = annualCost == 0 ? double.NaN : annualBenefits / annualCost;
+
+            return new Result(idc, totalInvestment, crf, annualCost, bcr);
+        }
+    }
+}
+

--- a/ViewModels/AnnualizerViewModel.cs
+++ b/ViewModels/AnnualizerViewModel.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using System.Windows.Input;
+using EconToolbox.Desktop.Models;
+
+namespace EconToolbox.Desktop.ViewModels
+{
+    public class AnnualizerViewModel : BaseViewModel
+    {
+        private double _firstCost;
+        private double _rate = 5.0;
+        private double _annualOm;
+        private double _annualBenefits;
+        private string _futureCosts = string.Empty;
+
+        private double _idc;
+        private double _totalInvestment;
+        private double _crf;
+        private double _annualCost;
+        private double _bcr;
+
+        public double FirstCost
+        {
+            get => _firstCost;
+            set { _firstCost = value; OnPropertyChanged(); }
+        }
+
+        public double Rate
+        {
+            get => _rate;
+            set { _rate = value; OnPropertyChanged(); }
+        }
+
+        public double AnnualOm
+        {
+            get => _annualOm;
+            set { _annualOm = value; OnPropertyChanged(); }
+        }
+
+        public double AnnualBenefits
+        {
+            get => _annualBenefits;
+            set { _annualBenefits = value; OnPropertyChanged(); }
+        }
+
+        public string FutureCosts
+        {
+            get => _futureCosts;
+            set { _futureCosts = value; OnPropertyChanged(); }
+        }
+
+        public double Idc
+        {
+            get => _idc;
+            set { _idc = value; OnPropertyChanged(); }
+        }
+
+        public double TotalInvestment
+        {
+            get => _totalInvestment;
+            set { _totalInvestment = value; OnPropertyChanged(); }
+        }
+
+        public double Crf
+        {
+            get => _crf;
+            set { _crf = value; OnPropertyChanged(); }
+        }
+
+        public double AnnualCost
+        {
+            get => _annualCost;
+            set { _annualCost = value; OnPropertyChanged(); }
+        }
+
+        public double Bcr
+        {
+            get => _bcr;
+            set { _bcr = value; OnPropertyChanged(); }
+        }
+
+        public ICommand ComputeCommand { get; }
+
+        public AnnualizerViewModel()
+        {
+            ComputeCommand = new RelayCommand(Compute);
+        }
+
+        private void Compute()
+        {
+            try
+            {
+                List<(double cost, int year)> future = new();
+                if (!string.IsNullOrWhiteSpace(FutureCosts))
+                {
+                    var items = FutureCosts.Split(',', StringSplitOptions.RemoveEmptyEntries);
+                    foreach (var item in items)
+                    {
+                        var parts = item.Split(':', '@');
+                        if (parts.Length == 2)
+                        {
+                            double c = double.Parse(parts[0].Trim());
+                            int y = int.Parse(parts[1].Trim());
+                            future.Add((c, y));
+                        }
+                    }
+                }
+
+                var result = AnnualizerModel.Compute(FirstCost, Rate / 100.0, AnnualOm, AnnualBenefits, future);
+                Idc = result.Idc;
+                TotalInvestment = result.TotalInvestment;
+                Crf = result.Crf;
+                AnnualCost = result.AnnualCost;
+                Bcr = result.Bcr;
+            }
+            catch (Exception ex)
+            {
+                Idc = TotalInvestment = Crf = AnnualCost = Bcr = double.NaN;
+            }
+        }
+    }
+}
+

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -6,5 +6,6 @@ namespace EconToolbox.Desktop.ViewModels
         public EadViewModel Ead { get; } = new();
         public StorageCostViewModel StorageCost { get; } = new();
         public InterestDuringConstructionViewModel Idc { get; } = new();
+        public AnnualizerViewModel Annualizer { get; } = new();
     }
 }


### PR DESCRIPTION
## Summary
- implement AnnualizerModel to combine IDC, capital recovery and benefit-cost calculations
- add AnnualizerViewModel exposing project cost inputs and computed metrics
- wire up new Project Annualizer tab in main window

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c2ff202c0c83308fd680084bd66534