### PR TITLE
Add water demand forecasting feature

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -158,6 +158,34 @@
                 <TextBlock Text="{Binding Bcr, StringFormat=BCR: {0:F2}}" Grid.Row="10" Grid.ColumnSpan="2"/>
             </Grid>
         </TabItem>
+        <TabItem Header="Water Demand" DataContext="{Binding WaterDemand}">
+            <Grid Margin="10">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+                <TextBlock Text="Historical (year:demand,...)" Margin="0,0,5,5"/>
+                <TextBox Text="{Binding HistoricalData}" Grid.Column="1" Margin="0,0,0,5"
+                         ToolTip="Comma-separated year:demand pairs."/>
+                <TextBlock Text="Forecast Years" Grid.Row="1" Margin="0,0,5,5"/>
+                <TextBox Text="{Binding ForecastYears}" Grid.Row="1" Grid.Column="1" Margin="0,0,0,5"
+                         ToolTip="Number of years to forecast."/>
+                <CheckBox Content="Use Growth Rate" Grid.Row="2" Grid.ColumnSpan="2" IsChecked="{Binding UseGrowthRate}" Margin="0,0,0,5"/>
+                <Button Content="Forecast" Command="{Binding ForecastCommand}" Grid.Row="3" Grid.ColumnSpan="2" Margin="0,5,0,5"/>
+                <DataGrid ItemsSource="{Binding Results}" Grid.Row="4" Grid.ColumnSpan="2" AutoGenerateColumns="True" Height="150" Margin="0,0,0,5"/>
+                <Canvas Grid.Row="5" Grid.ColumnSpan="2" Height="150" Width="300">
+                    <Polyline Points="{Binding ChartPoints}" Stroke="Blue" StrokeThickness="2"/>
+                </Canvas>
+            </Grid>
+        </TabItem>
         <TabItem Header="Unit Day Value" DataContext="{Binding Udv}">
             <views:UdvView/>
         </TabItem>

--- a/Models/WaterDemandModel.cs
+++ b/Models/WaterDemandModel.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace EconToolbox.Desktop.Models
+{
+    /// <summary>
+    /// Provides simple water demand forecasting utilities.
+    /// Supports linear regression and average growth rate methods.
+    /// </summary>
+    public static class WaterDemandModel
+    {
+        /// <summary>
+        /// Forecasts future demand using linear regression.
+        /// </summary>
+        /// <param name="historical">Historical data as year and demand pairs.</param>
+        /// <param name="yearsToProject">Number of future years to project.</param>
+        /// <returns>List containing historical and forecasted demand.</returns>
+        public static List<(int Year, double Demand)> LinearRegressionForecast(
+            List<(int Year, double Demand)> historical,
+            int yearsToProject)
+        {
+            if (historical.Count == 0)
+                return new List<(int Year, double Demand)>();
+
+            // Compute slope and intercept for y = a*x + b
+            int n = historical.Count;
+            double sumX = historical.Sum(p => (double)p.Year);
+            double sumY = historical.Sum(p => p.Demand);
+            double sumXY = historical.Sum(p => p.Year * p.Demand);
+            double sumX2 = historical.Sum(p => (double)p.Year * p.Year);
+
+            double denominator = n * sumX2 - sumX * sumX;
+            double slope = denominator == 0 ? 0 : (n * sumXY - sumX * sumY) / denominator;
+            double intercept = (sumY - slope * sumX) / n;
+
+            var result = new List<(int Year, double Demand)>(historical);
+            int lastYear = historical[^1].Year;
+            for (int i = 1; i <= yearsToProject; i++)
+            {
+                int year = lastYear + i;
+                double demand = slope * year + intercept;
+                result.Add((year, demand));
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Forecasts future demand using the compound annual growth rate
+        /// based on the first and last historical observation.
+        /// </summary>
+        /// <param name="historical">Historical data ordered by year.</param>
+        /// <param name="yearsToProject">Number of future years to project.</param>
+        /// <returns>List containing historical and forecasted demand.</returns>
+        public static List<(int Year, double Demand)> GrowthRateForecast(
+            List<(int Year, double Demand)> historical,
+            int yearsToProject)
+        {
+            var result = new List<(int Year, double Demand)>(historical);
+            if (historical.Count < 2)
+                return result;
+
+            double first = historical.First().Demand;
+            double last = historical.Last().Demand;
+            double yearSpan = historical.Last().Year - historical.First().Year;
+            if (yearSpan <= 0 || first <= 0)
+                return result;
+
+            double rate = Math.Pow(last / first, 1.0 / yearSpan) - 1.0;
+            int lastYear = historical.Last().Year;
+            double previous = last;
+            for (int i = 1; i <= yearsToProject; i++)
+            {
+                previous = previous * (1.0 + rate);
+                result.Add((lastYear + i, previous));
+            }
+            return result;
+        }
+    }
+}
+

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -8,5 +8,6 @@ namespace EconToolbox.Desktop.ViewModels
         public InterestDuringConstructionViewModel Idc { get; } = new();
         public AnnualizerViewModel Annualizer { get; } = new();
         public UdvViewModel Udv { get; } = new();
+        public WaterDemandViewModel WaterDemand { get; } = new();
     }
 }

--- a/ViewModels/WaterDemandViewModel.cs
+++ b/ViewModels/WaterDemandViewModel.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.Windows.Input;
+using System.Windows.Media;
+using EconToolbox.Desktop.Models;
+
+namespace EconToolbox.Desktop.ViewModels
+{
+    /// <summary>
+    /// View model allowing users to enter historical demand data and
+    /// project future demand using either linear regression or growth
+    /// rate methods. Results can be displayed in a simple chart.
+    /// </summary>
+    public class WaterDemandViewModel : BaseViewModel
+    {
+        private string _historicalData = string.Empty;
+        private int _forecastYears = 5;
+        private bool _useGrowthRate;
+        private ObservableCollection<DemandPoint> _results = new();
+        private PointCollection _chartPoints = new();
+
+        public string HistoricalData
+        {
+            get => _historicalData;
+            set { _historicalData = value; OnPropertyChanged(); }
+        }
+
+        public int ForecastYears
+        {
+            get => _forecastYears;
+            set { _forecastYears = value; OnPropertyChanged(); }
+        }
+
+        public bool UseGrowthRate
+        {
+            get => _useGrowthRate;
+            set { _useGrowthRate = value; OnPropertyChanged(); }
+        }
+
+        public ObservableCollection<DemandPoint> Results
+        {
+            get => _results;
+            set { _results = value; OnPropertyChanged(); }
+        }
+
+        public PointCollection ChartPoints
+        {
+            get => _chartPoints;
+            set { _chartPoints = value; OnPropertyChanged(); }
+        }
+
+        public ICommand ForecastCommand { get; }
+
+        public WaterDemandViewModel()
+        {
+            ForecastCommand = new RelayCommand(Forecast);
+        }
+
+        private void Forecast()
+        {
+            try
+            {
+                var hist = ParseHistorical(HistoricalData);
+                List<(int Year, double Demand)> forecast = UseGrowthRate
+                    ? WaterDemandModel.GrowthRateForecast(hist, ForecastYears)
+                    : WaterDemandModel.LinearRegressionForecast(hist, ForecastYears);
+
+                Results = new ObservableCollection<DemandPoint>();
+                foreach (var p in forecast)
+                    Results.Add(new DemandPoint { Year = p.Year, Demand = p.Demand });
+
+                ChartPoints = CreatePointCollection(forecast);
+            }
+            catch
+            {
+                Results = new ObservableCollection<DemandPoint>();
+                ChartPoints = new PointCollection();
+            }
+        }
+
+        private static List<(int Year, double Demand)> ParseHistorical(string text)
+        {
+            List<(int Year, double Demand)> list = new();
+            if (string.IsNullOrWhiteSpace(text))
+                return list;
+
+            var items = text.Split(',', StringSplitOptions.RemoveEmptyEntries);
+            foreach (var item in items)
+            {
+                var parts = item.Split(':', StringSplitOptions.RemoveEmptyEntries);
+                if (parts.Length == 2 &&
+                    int.TryParse(parts[0].Trim(), out int year) &&
+                    double.TryParse(parts[1].Trim(), NumberStyles.Any, CultureInfo.InvariantCulture, out double demand))
+                {
+                    list.Add((year, demand));
+                }
+            }
+            list.Sort((a, b) => a.Year.CompareTo(b.Year));
+            return list;
+        }
+
+        private static PointCollection CreatePointCollection(List<(int Year, double Demand)> data)
+        {
+            PointCollection points = new();
+            if (data.Count == 0) return points;
+
+            double minYear = data[0].Year;
+            double maxYear = data[^1].Year;
+            double minDemand = double.MaxValue;
+            double maxDemand = double.MinValue;
+            foreach (var d in data)
+            {
+                if (d.Demand < minDemand) minDemand = d.Demand;
+                if (d.Demand > maxDemand) maxDemand = d.Demand;
+            }
+
+            double width = 300; // Canvas width used in XAML
+            double height = 150; // Canvas height used in XAML
+            double yearRange = maxYear - minYear;
+            if (yearRange == 0) yearRange = 1;
+            double demandRange = maxDemand - minDemand;
+            if (demandRange == 0) demandRange = 1;
+
+            foreach (var d in data)
+            {
+                double x = (d.Year - minYear) / yearRange * width;
+                double y = height - (d.Demand - minDemand) / demandRange * height;
+                points.Add(new System.Windows.Point(x, y));
+            }
+
+            return points;
+        }
+
+        public class DemandPoint
+        {
+            public int Year { get; set; }
+            public double Demand { get; set; }
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement `WaterDemandModel` with linear regression and growth-rate forecasting
- add `WaterDemandViewModel` for input, projection, and simple charting
- integrate new water demand tab into main window and view model

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c301aeb0148330968a5775087370af