### PR TITLE
refactor: replace EAD inputs with grid and charts

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -31,26 +31,7 @@
             </Grid>
         </TabItem>
         <TabItem Header="EAD" DataContext="{Binding Ead}">
-            <Grid Margin="10">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="*"/>
-                </Grid.RowDefinitions>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto"/>
-                    <ColumnDefinition Width="*"/>
-                </Grid.ColumnDefinitions>
-                <TextBlock Text="Probabilities" Margin="0,0,5,5"/>
-                <TextBox Text="{Binding Probabilities}" Grid.Column="1" Margin="0,0,0,5"
-                         ToolTip="Comma-separated probabilities in descending order."/>
-                <TextBlock Text="Damages" Grid.Row="1" Margin="0,0,5,5"/>
-                <TextBox Text="{Binding Damages}" Grid.Row="1" Grid.Column="1" Margin="0,0,0,5"
-                         ToolTip="Comma-separated damages matching the probabilities."/>
-                <Button Content="Compute" Command="{Binding ComputeCommand}" Grid.Row="2" Grid.ColumnSpan="2" Margin="0,5,0,5"/>
-                <TextBlock Text="{Binding Result}" Grid.Row="3" Grid.ColumnSpan="2"/>
-            </Grid>
+            <views:EadView/>
         </TabItem>
         <TabItem Header="Storage Cost" DataContext="{Binding StorageCost}">
             <Grid Margin="10">

--- a/ViewModels/EadViewModel.cs
+++ b/ViewModels/EadViewModel.cs
@@ -1,54 +1,200 @@
 using System;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
 using System.Linq;
+using System.Windows;
 using System.Windows.Input;
+using System.Windows.Media;
 using EconToolbox.Desktop.Models;
 
 namespace EconToolbox.Desktop.ViewModels
 {
+    /// <summary>
+    /// View model for Expected Annual Damage calculations. Users enter
+    /// frequency, optional stage data and any number of damage columns
+    /// using a grid. Results can be charted against stage and frequency.
+    /// </summary>
     public class EadViewModel : BaseViewModel
     {
-        private string _probabilities = string.Empty;
-        private string _damages = string.Empty;
+        public ObservableCollection<EadRow> Rows { get; } = new();
+        public ObservableCollection<string> DamageColumns { get; } = new();
+
+        private bool _useStage;
+        public bool UseStage
+        {
+            get => _useStage;
+            set { _useStage = value; OnPropertyChanged(); }
+        }
+
         private string _result = string.Empty;
-
-        public string Probabilities
-        {
-            get => _probabilities;
-            set { _probabilities = value; OnPropertyChanged(); }
-        }
-
-        public string Damages
-        {
-            get => _damages;
-            set { _damages = value; OnPropertyChanged(); }
-        }
-
         public string Result
         {
             get => _result;
             set { _result = value; OnPropertyChanged(); }
         }
 
+        private PointCollection _stageDamagePoints = new();
+        public PointCollection StageDamagePoints
+        {
+            get => _stageDamagePoints;
+            set { _stageDamagePoints = value; OnPropertyChanged(); }
+        }
+
+        private PointCollection _frequencyDamagePoints = new();
+        public PointCollection FrequencyDamagePoints
+        {
+            get => _frequencyDamagePoints;
+            set { _frequencyDamagePoints = value; OnPropertyChanged(); }
+        }
+
+        public ICommand AddDamageColumnCommand { get; }
+        public ICommand RemoveDamageColumnCommand => _removeDamageColumnCommand;
         public ICommand ComputeCommand { get; }
+
+        private readonly RelayCommand _removeDamageColumnCommand;
 
         public EadViewModel()
         {
+            Rows.CollectionChanged += Rows_CollectionChanged;
+            AddDamageColumnCommand = new RelayCommand(AddDamageColumn);
+            _removeDamageColumnCommand = new RelayCommand(RemoveDamageColumn, () => DamageColumns.Count > 1);
             ComputeCommand = new RelayCommand(Compute);
+            AddDamageColumn(); // start with one damage column
+        }
+
+        private void Rows_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        {
+            if (e.NewItems != null)
+            {
+                foreach (EadRow row in e.NewItems)
+                {
+                    while (row.Damages.Count < DamageColumns.Count)
+                        row.Damages.Add(0);
+                }
+            }
+        }
+
+        private void AddDamageColumn()
+        {
+            DamageColumns.Add($"Damage {DamageColumns.Count + 1}");
+            foreach (var row in Rows)
+                row.Damages.Add(0);
+            _removeDamageColumnCommand.RaiseCanExecuteChanged();
+        }
+
+        private void RemoveDamageColumn()
+        {
+            if (DamageColumns.Count == 0) return;
+            int idx = DamageColumns.Count - 1;
+            DamageColumns.RemoveAt(idx);
+            foreach (var row in Rows)
+            {
+                if (row.Damages.Count > idx)
+                    row.Damages.RemoveAt(idx);
+            }
+            _removeDamageColumnCommand.RaiseCanExecuteChanged();
         }
 
         private void Compute()
         {
             try
             {
-                var p = _probabilities.Split(',', StringSplitOptions.RemoveEmptyEntries).Select(s => double.Parse(s.Trim())).ToArray();
-                var d = _damages.Split(',', StringSplitOptions.RemoveEmptyEntries).Select(s => double.Parse(s.Trim())).ToArray();
-                double ead = EadModel.Compute(p, d);
-                Result = $"Expected annual damage: {ead:F2}";
+                if (Rows.Count == 0 || DamageColumns.Count == 0)
+                {
+                    Result = "No data";
+                    StageDamagePoints = new PointCollection();
+                    FrequencyDamagePoints = new PointCollection();
+                    return;
+                }
+
+                var probabilities = Rows.Select(r => 1.0 / r.Frequency).ToArray();
+                var results = new System.Collections.Generic.List<string>();
+                for (int i = 0; i < DamageColumns.Count; i++)
+                {
+                    var damages = Rows.Select(r => r.Damages[i]).ToArray();
+                    double ead = EadModel.Compute(probabilities, damages);
+                    results.Add($"{DamageColumns[i]}: {ead:F2}");
+                }
+                Result = string.Join(" | ", results);
+                UpdateCharts();
             }
             catch (Exception ex)
             {
                 Result = $"Error: {ex.Message}";
+                StageDamagePoints = new PointCollection();
+                FrequencyDamagePoints = new PointCollection();
             }
+        }
+
+        private void UpdateCharts()
+        {
+            if (Rows.Count == 0) return;
+
+            var freqData = Rows
+                .Where(r => r.Damages.Count > 0)
+                .Select(r => (X: r.Frequency, Y: r.Damages[0]))
+                .ToList();
+            FrequencyDamagePoints = CreatePointCollection(freqData);
+
+            if (UseStage)
+            {
+                var stageData = Rows
+                    .Where(r => r.Stage.HasValue && r.Damages.Count > 0)
+                    .Select(r => (X: r.Stage!.Value, Y: r.Damages[0]))
+                    .ToList();
+                StageDamagePoints = CreatePointCollection(stageData);
+            }
+            else
+            {
+                StageDamagePoints = new PointCollection();
+            }
+        }
+
+        private static PointCollection CreatePointCollection(System.Collections.Generic.List<(double X, double Y)> data)
+        {
+            PointCollection points = new();
+            if (data.Count == 0) return points;
+
+            double minX = data.Min(p => p.X);
+            double maxX = data.Max(p => p.X);
+            double minY = data.Min(p => p.Y);
+            double maxY = data.Max(p => p.Y);
+
+            double width = 300;
+            double height = 150;
+            double xRange = maxX - minX;
+            if (xRange == 0) xRange = 1;
+            double yRange = maxY - minY;
+            if (yRange == 0) yRange = 1;
+
+            foreach (var p in data)
+            {
+                double x = (p.X - minX) / xRange * width;
+                double y = height - (p.Y - minY) / yRange * height;
+                points.Add(new System.Windows.Point(x, y));
+            }
+
+            return points;
+        }
+
+        public class EadRow : BaseViewModel
+        {
+            private double _frequency;
+            private double? _stage;
+
+            public double Frequency
+            {
+                get => _frequency;
+                set { _frequency = value; OnPropertyChanged(); }
+            }
+
+            public double? Stage
+            {
+                get => _stage;
+                set { _stage = value; OnPropertyChanged(); }
+            }
+
+            public ObservableCollection<double> Damages { get; } = new();
         }
     }
 }

--- a/Views/EadView.xaml
+++ b/Views/EadView.xaml
@@ -1,0 +1,28 @@
+<UserControl x:Class="EconToolbox.Desktop.Views.EadView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <StackPanel Orientation="Horizontal" Grid.Row="0" Margin="0,0,0,5">
+            <Button Content="Add Damage Column" Command="{Binding AddDamageColumnCommand}" Margin="0,0,5,0"/>
+            <Button Content="Remove Damage Column" Command="{Binding RemoveDamageColumnCommand}" Margin="0,0,5,0"/>
+            <CheckBox Content="Include Stage" IsChecked="{Binding UseStage}" Margin="0,0,5,0"/>
+            <Button Content="Compute" Command="{Binding ComputeCommand}"/>
+        </StackPanel>
+        <DataGrid x:Name="EadDataGrid" ItemsSource="{Binding Rows}" Grid.Row="1" AutoGenerateColumns="False"
+                  CanUserAddRows="True" CanUserDeleteRows="True" Height="120" Margin="0,0,0,5"/>
+        <Canvas Grid.Row="2" Height="150" Width="300" Margin="0,0,0,5">
+            <Polyline Points="{Binding StageDamagePoints}" Stroke="Blue" StrokeThickness="2"/>
+        </Canvas>
+        <Canvas Grid.Row="3" Height="150" Width="300" Margin="0,0,0,5">
+            <Polyline Points="{Binding FrequencyDamagePoints}" Stroke="Red" StrokeThickness="2"/>
+        </Canvas>
+        <TextBlock Grid.Row="4" Text="{Binding Result}"/>
+    </Grid>
+</UserControl>

--- a/Views/EadView.xaml.cs
+++ b/Views/EadView.xaml.cs
@@ -1,0 +1,71 @@
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using EconToolbox.Desktop.ViewModels;
+
+namespace EconToolbox.Desktop.Views
+{
+    public partial class EadView : UserControl
+    {
+        public EadView()
+        {
+            InitializeComponent();
+            DataContextChanged += OnDataContextChanged;
+        }
+
+        private void OnDataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            if (e.OldValue is EadViewModel oldVm)
+            {
+                oldVm.DamageColumns.CollectionChanged -= DamageColumns_CollectionChanged;
+                oldVm.PropertyChanged -= Vm_PropertyChanged;
+            }
+            if (e.NewValue is EadViewModel vm)
+            {
+                vm.DamageColumns.CollectionChanged += DamageColumns_CollectionChanged;
+                vm.PropertyChanged += Vm_PropertyChanged;
+                RebuildColumns(vm);
+            }
+        }
+
+        private void DamageColumns_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        {
+            if (DataContext is EadViewModel vm)
+                RebuildColumns(vm);
+        }
+
+        private void Vm_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(EadViewModel.UseStage) && DataContext is EadViewModel vm)
+                RebuildColumns(vm);
+        }
+
+        private void RebuildColumns(EadViewModel vm)
+        {
+            EadDataGrid.Columns.Clear();
+            EadDataGrid.Columns.Add(new DataGridTextColumn
+            {
+                Header = "Frequency",
+                Binding = new Binding("Frequency")
+            });
+            if (vm.UseStage)
+            {
+                EadDataGrid.Columns.Add(new DataGridTextColumn
+                {
+                    Header = "Stage",
+                    Binding = new Binding("Stage")
+                });
+            }
+            for (int i = 0; i < vm.DamageColumns.Count; i++)
+            {
+                EadDataGrid.Columns.Add(new DataGridTextColumn
+                {
+                    Header = vm.DamageColumns[i],
+                    Binding = new Binding($"Damages[{i}]")
+                });
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Replace EAD text boxes with a grid that supports an arbitrary number of damage columns and optional stage data
- Add simple charts for stage–damage and frequency–damage relationships
- Wire new EAD view into the main window

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 when attempting to install dotnet)*


------
https://chatgpt.com/codex/tasks/task_e_68c302a42cd883309770bd99afcc45ce