### PR TITLE
Add data editing components and Excel export

### DIFF
--- a/EconToolbox.Desktop.csproj
+++ b/EconToolbox.Desktop.csproj
@@ -5,4 +5,7 @@
     <UseWPF>true</UseWPF>
     <Nullable>enable</Nullable>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="ClosedXML" Version="0.102.4" />
+  </ItemGroup>
 </Project>

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -26,7 +26,8 @@
                 <TextBlock Text="Periods" Grid.Row="1" Margin="0,0,5,5"/>
                 <TextBox Text="{Binding Periods}" Grid.Row="1" Grid.Column="1" Margin="0,0,0,5"
                          ToolTip="Number of periods. More periods lower each payment."/>
-                <Button Content="Compute" Command="{Binding ComputeCommand}" Grid.Row="2" Grid.ColumnSpan="2" Margin="0,5,0,5"/>
+                <Button Content="Compute" Command="{Binding ComputeCommand}" Grid.Row="2" Grid.Column="0" Margin="0,5,5,5"/>
+                <Button Content="Export" Command="{Binding ExportCommand}" Grid.Row="2" Grid.Column="1" Margin="0,5,0,5"/>
                 <TextBlock Text="{Binding Result}" Grid.Row="3" Grid.ColumnSpan="2"/>
             </Grid>
         </TabItem>
@@ -128,10 +129,15 @@
                 <TextBlock Text="Annual Benefits" Grid.Row="3" Margin="0,0,5,5"/>
                 <TextBox Text="{Binding AnnualBenefits}" Grid.Row="3" Grid.Column="1" Margin="0,0,0,5"
                          ToolTip="Expected annual benefits."/>
-                <TextBlock Text="Future Costs (cost:year,...)" Grid.Row="4" Margin="0,0,5,5"/>
-                <TextBox Text="{Binding FutureCosts}" Grid.Row="4" Grid.Column="1" Margin="0,0,0,5"
-                         ToolTip="Comma-separated future cost:year pairs."/>
-                <Button Content="Compute" Command="{Binding ComputeCommand}" Grid.Row="5" Grid.ColumnSpan="2" Margin="0,5,0,5"/>
+                <TextBlock Text="Future Costs" Grid.Row="4" Margin="0,0,5,5"/>
+                <DataGrid ItemsSource="{Binding FutureCosts}" Grid.Row="4" Grid.Column="1" AutoGenerateColumns="False" Height="100" Margin="0,0,0,5">
+                    <DataGrid.Columns>
+                        <DataGridTextColumn Header="Cost" Binding="{Binding Cost}"/>
+                        <DataGridTextColumn Header="Year" Binding="{Binding Year}"/>
+                    </DataGrid.Columns>
+                </DataGrid>
+                <Button Content="Compute" Command="{Binding ComputeCommand}" Grid.Row="5" Grid.Column="0" Margin="0,5,5,5"/>
+                <Button Content="Export" Command="{Binding ExportCommand}" Grid.Row="5" Grid.Column="1" Margin="0,5,0,5"/>
                 <TextBlock Text="{Binding Idc, StringFormat=IDC: {0:F2}}" Grid.Row="6" Grid.ColumnSpan="2"/>
                 <TextBlock Text="{Binding TotalInvestment, StringFormat=Total Investment: {0:F2}}" Grid.Row="7" Grid.ColumnSpan="2"/>
                 <TextBlock Text="{Binding Crf, StringFormat=CRF: {0:F4}}" Grid.Row="8" Grid.ColumnSpan="2"/>
@@ -153,14 +159,19 @@
                     <ColumnDefinition Width="Auto"/>
                     <ColumnDefinition Width="*"/>
                 </Grid.ColumnDefinitions>
-                <TextBlock Text="Historical (year:demand,...)" Margin="0,0,5,5"/>
-                <TextBox Text="{Binding HistoricalData}" Grid.Column="1" Margin="0,0,0,5"
-                         ToolTip="Comma-separated year:demand pairs."/>
+                <TextBlock Text="Historical Data" Margin="0,0,5,5"/>
+                <DataGrid ItemsSource="{Binding HistoricalData}" Grid.Column="1" AutoGenerateColumns="False" Height="100" Margin="0,0,0,5">
+                    <DataGrid.Columns>
+                        <DataGridTextColumn Header="Year" Binding="{Binding Year}"/>
+                        <DataGridTextColumn Header="Demand" Binding="{Binding Demand}"/>
+                    </DataGrid.Columns>
+                </DataGrid>
                 <TextBlock Text="Forecast Years" Grid.Row="1" Margin="0,0,5,5"/>
                 <TextBox Text="{Binding ForecastYears}" Grid.Row="1" Grid.Column="1" Margin="0,0,0,5"
                          ToolTip="Number of years to forecast."/>
                 <CheckBox Content="Use Growth Rate" Grid.Row="2" Grid.ColumnSpan="2" IsChecked="{Binding UseGrowthRate}" Margin="0,0,0,5"/>
-                <Button Content="Forecast" Command="{Binding ForecastCommand}" Grid.Row="3" Grid.ColumnSpan="2" Margin="0,5,0,5"/>
+                <Button Content="Forecast" Command="{Binding ForecastCommand}" Grid.Row="3" Grid.Column="0" Margin="0,5,5,5"/>
+                <Button Content="Export" Command="{Binding ExportCommand}" Grid.Row="3" Grid.Column="1" Margin="0,5,0,5"/>
                 <DataGrid ItemsSource="{Binding Results}" Grid.Row="4" Grid.ColumnSpan="2" AutoGenerateColumns="True" Height="150" Margin="0,0,0,5"/>
                 <Canvas Grid.Row="5" Grid.ColumnSpan="2" Height="150" Width="300">
                     <Polyline Points="{Binding ChartPoints}" Stroke="Blue" StrokeThickness="2"/>

--- a/Models/DemandEntry.cs
+++ b/Models/DemandEntry.cs
@@ -1,0 +1,20 @@
+namespace EconToolbox.Desktop.Models
+{
+    public class DemandEntry : ObservableObject
+    {
+        private int _year;
+        private double _demand;
+
+        public int Year
+        {
+            get => _year;
+            set { _year = value; OnPropertyChanged(); }
+        }
+
+        public double Demand
+        {
+            get => _demand;
+            set { _demand = value; OnPropertyChanged(); }
+        }
+    }
+}

--- a/Models/FutureCostEntry.cs
+++ b/Models/FutureCostEntry.cs
@@ -1,0 +1,20 @@
+namespace EconToolbox.Desktop.Models
+{
+    public class FutureCostEntry : ObservableObject
+    {
+        private double _cost;
+        private int _year;
+
+        public double Cost
+        {
+            get => _cost;
+            set { _cost = value; OnPropertyChanged(); }
+        }
+
+        public int Year
+        {
+            get => _year;
+            set { _year = value; OnPropertyChanged(); }
+        }
+    }
+}

--- a/Models/ObservableObject.cs
+++ b/Models/ObservableObject.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace EconToolbox.Desktop.Models
+{
+    public abstract class ObservableObject : INotifyPropertyChanged
+    {
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        protected void OnPropertyChanged([CallerMemberName] string? name = null)
+            => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+    }
+}

--- a/Services/ExcelExporter.cs
+++ b/Services/ExcelExporter.cs
@@ -1,0 +1,76 @@
+using System.Collections.Generic;
+using ClosedXML.Excel;
+using EconToolbox.Desktop.Models;
+using System.Linq;
+
+namespace EconToolbox.Desktop.Services
+{
+    public static class ExcelExporter
+    {
+        public static void ExportCapitalRecovery(double rate, int periods, double factor, string filePath)
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.Worksheets.Add("CapitalRecovery");
+            ws.Cell(1,1).Value = "Rate";
+            ws.Cell(1,2).Value = rate;
+            ws.Cell(2,1).Value = "Periods";
+            ws.Cell(2,2).Value = periods;
+            ws.Cell(3,1).Value = "Factor";
+            ws.Cell(3,2).Value = factor;
+            wb.SaveAs(filePath);
+        }
+
+        public static void ExportWaterDemand(IEnumerable<DemandEntry> data, string filePath)
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.Worksheets.Add("WaterDemand");
+            ws.Cell(1,1).Value = "Year";
+            ws.Cell(1,2).Value = "Demand";
+            int row = 2;
+            foreach(var d in data)
+            {
+                ws.Cell(row,1).Value = d.Year;
+                ws.Cell(row,2).Value = d.Demand;
+                row++;
+            }
+            wb.SaveAs(filePath);
+        }
+
+        public static void ExportAnnualizer(double firstCost, double rate, double annualOm, double annualBenefits, IEnumerable<FutureCostEntry> future, double idc, double totalInvestment, double crf, double annualCost, double bcr, string filePath)
+        {
+            using var wb = new XLWorkbook();
+            var summary = wb.Worksheets.Add("Summary");
+            var data = new Dictionary<string, object>
+            {
+                {"First Cost", firstCost},
+                {"Rate", rate},
+                {"Annual O&M", annualOm},
+                {"Annual Benefits", annualBenefits},
+                {"IDC", idc},
+                {"Total Investment", totalInvestment},
+                {"CRF", crf},
+                {"Annual Cost", annualCost},
+                {"BCR", bcr}
+            };
+            int row = 1;
+            foreach(var kv in data)
+            {
+                summary.Cell(row,1).Value = kv.Key;
+                summary.Cell(row,2).Value = kv.Value;
+                row++;
+            }
+
+            var fcSheet = wb.Worksheets.Add("FutureCosts");
+            fcSheet.Cell(1,1).Value = "Cost";
+            fcSheet.Cell(1,2).Value = "Year";
+            row = 2;
+            foreach(var f in future)
+            {
+                fcSheet.Cell(row,1).Value = f.Cost;
+                fcSheet.Cell(row,2).Value = f.Year;
+                row++;
+            }
+            wb.SaveAs(filePath);
+        }
+    }
+}

--- a/ViewModels/CapitalRecoveryViewModel.cs
+++ b/ViewModels/CapitalRecoveryViewModel.cs
@@ -1,5 +1,6 @@
 using EconToolbox.Desktop.Models;
 using System.Windows.Input;
+using EconToolbox.Desktop.Services;
 
 namespace EconToolbox.Desktop.ViewModels
 {
@@ -28,16 +29,32 @@ namespace EconToolbox.Desktop.ViewModels
         }
 
         public ICommand ComputeCommand { get; }
+        public ICommand ExportCommand { get; }
 
         public CapitalRecoveryViewModel()
         {
             ComputeCommand = new RelayCommand(Compute);
+            ExportCommand = new RelayCommand(Export);
         }
 
         private void Compute()
         {
             double crf = CapitalRecoveryModel.Calculate(Rate / 100.0, Periods);
             Result = $"Capital recovery factor: {crf:F6}";
+        }
+
+        private void Export()
+        {
+            var dlg = new Microsoft.Win32.SaveFileDialog
+            {
+                Filter = "Excel Workbook (*.xlsx)|*.xlsx",
+                FileName = "capital_recovery.xlsx"
+            };
+            if (dlg.ShowDialog() == true)
+            {
+                double crf = CapitalRecoveryModel.Calculate(Rate / 100.0, Periods);
+                Services.ExcelExporter.ExportCapitalRecovery(Rate, Periods, crf, dlg.FileName);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Introduce observable data entry models and Excel export helpers using ClosedXML
- Replace manual parsing in Annualizer and Water Demand calculators with ObservableCollection-backed grids
- Add Excel export commands to Capital Recovery, Annualizer, and Water Demand view models and update UI

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c3040eb14c833093070f1964be109d