### PR TITLE
Fix ClosedXML cell value assignment in ExcelExporter

### DIFF
--- a/Services/ExcelExporter.cs
+++ b/Services/ExcelExporter.cs
@@ -40,7 +40,7 @@ namespace EconToolbox.Desktop.Services
         {
             using var wb = new XLWorkbook();
             var summary = wb.Worksheets.Add("Summary");
-            var data = new Dictionary<string, object>
+            var data = new Dictionary<string, double>
             {
                 {"First Cost", firstCost},
                 {"Rate", rate},


### PR DESCRIPTION
## Summary
- fix ClosedXML cell value assignment by using a strongly typed dictionary in Excel exporter

## Testing
- `dotnet build EconToolbox.Desktop.csproj /property:GenerateFullPaths=true /consoleloggerparameters:NoSummary /p:Configuration=Debug /p:Platform="AnyCPU"` *(fails: command not found)*
- `apt-get update` *(fails: repository 403, not signed)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c30ecc8b98833087ebd68841812d28