### PR TITLE
Connect toolbox tabs to unified calculate and export actions

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -12,7 +12,7 @@
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
-        <TabControl Margin="10" SelectedItem="{Binding SelectedViewModel}" Grid.Row="0">
+        <TabControl Margin="10" SelectedIndex="{Binding SelectedIndex}" Grid.Row="0">
             <TabItem Header="EAD" DataContext="{Binding Ead}">
                 <views:EadView/>
             </TabItem>
@@ -20,96 +20,102 @@
                 <views:UpdatedCostView/>
             </TabItem>
             <TabItem Header="Cost Annualization" DataContext="{Binding Annualizer}">
-                <Grid Margin="10">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="*"/>
-                </Grid.RowDefinitions>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto"/>
-                    <ColumnDefinition Width="*"/>
-                </Grid.ColumnDefinitions>
-                <TextBlock Text="First Cost" Margin="0,0,5,5"/>
-                <TextBox Text="{Binding FirstCost}" Grid.Column="1" Margin="0,0,0,5"
-                         ToolTip="Initial project cost."/>
-                <TextBlock Text="Rate (%)" Grid.Row="1" Margin="0,0,5,5"/>
-                <TextBox Text="{Binding Rate}" Grid.Row="1" Grid.Column="1" Margin="0,0,0,5"
-                         ToolTip="Discount rate in percent."/>
-                <TextBlock Text="Base Year" Grid.Row="2" Margin="0,0,5,5"/>
-                <TextBox Text="{Binding BaseYear}" Grid.Row="2" Grid.Column="1" Margin="0,0,0,5"/>
-                <TextBlock Text="Analysis Period" Grid.Row="3" Margin="0,0,5,5"/>
-                <TextBox Text="{Binding AnalysisPeriod}" Grid.Row="3" Grid.Column="1" Margin="0,0,0,5"
-                         ToolTip="Number of periods for capital recovery."/>
-                <TextBlock Text="Annual O&amp;M" Grid.Row="4" Margin="0,0,5,5"/>
-                <TextBox Text="{Binding AnnualOm}" Grid.Row="4" Grid.Column="1" Margin="0,0,0,5"
-                         ToolTip="Annual operations and maintenance cost."/>
-                <TextBlock Text="Annual Benefits" Grid.Row="5" Margin="0,0,5,5"/>
-                <TextBox Text="{Binding AnnualBenefits}" Grid.Row="5" Grid.Column="1" Margin="0,0,0,5"
-                         ToolTip="Expected annual benefits."/>
-                <TextBlock Text="Construction Months" Grid.Row="6" Margin="0,0,5,5"/>
-                <TextBox Text="{Binding ConstructionMonths}" Grid.Row="6" Grid.Column="1" Margin="0,0,0,5"/>
-                <TextBlock Text="IDC Costs" Grid.Row="7" Margin="0,0,5,5"/>
-                <TextBox Text="{Binding IdcCosts}" Grid.Row="7" Grid.Column="1" Margin="0,0,0,5"/>
-                <TextBlock Text="IDC Timings" Grid.Row="8" Margin="0,0,5,5"/>
-                <TextBox Text="{Binding IdcTimings}" Grid.Row="8" Grid.Column="1" Margin="0,0,0,5"/>
-                <TextBlock Text="Future Costs" Grid.Row="9" Margin="0,0,5,5"/>
-                <DataGrid ItemsSource="{Binding FutureCosts}" Grid.Row="9" Grid.Column="1" AutoGenerateColumns="False" Height="100" Margin="0,0,0,5">
-                    <DataGrid.Columns>
-                        <DataGridTextColumn Header="Cost" Binding="{Binding Cost}"/>
-                        <DataGridTextColumn Header="Year" Binding="{Binding Year}"/>
-                    </DataGrid.Columns>
-                </DataGrid>
-                <TextBlock Text="{Binding Idc, StringFormat=IDC: {0:F2}}" Grid.Row="10" Grid.ColumnSpan="2"/>
-                <TextBlock Text="{Binding TotalInvestment, StringFormat=Total Investment: {0:F2}}" Grid.Row="11" Grid.ColumnSpan="2"/>
-                <TextBlock Text="{Binding Crf, StringFormat=CRF: {0:F4}}" Grid.Row="12" Grid.ColumnSpan="2"/>
-                <TextBlock Text="{Binding AnnualCost, StringFormat=Annual Cost: {0:F2}}" Grid.Row="13" Grid.ColumnSpan="2"/>
-                <TextBlock Text="{Binding Bcr, StringFormat=BCR: {0:F2}}" Grid.Row="14" Grid.ColumnSpan="2"/>
-            </Grid>
-        </TabItem>
-        <TabItem Header="Water Demand" DataContext="{Binding WaterDemand}">
-            <Grid Margin="10">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="*"/>
-                </Grid.RowDefinitions>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto"/>
-                    <ColumnDefinition Width="*"/>
-                </Grid.ColumnDefinitions>
-                <TextBlock Text="Historical Data" Margin="0,0,5,5"/>
-                <DataGrid ItemsSource="{Binding HistoricalData}" Grid.Column="1" AutoGenerateColumns="False" Height="100" Margin="0,0,0,5">
-                    <DataGrid.Columns>
-                        <DataGridTextColumn Header="Year" Binding="{Binding Year}"/>
-                        <DataGridTextColumn Header="Demand" Binding="{Binding Demand}"/>
-                    </DataGrid.Columns>
-                </DataGrid>
-                <TextBlock Text="Forecast Years" Grid.Row="1" Margin="0,0,5,5"/>
-                <TextBox Text="{Binding ForecastYears}" Grid.Row="1" Grid.Column="1" Margin="0,0,0,5"
-                         ToolTip="Number of years to forecast."/>
-                <CheckBox Content="Use Growth Rate" Grid.Row="2" Grid.ColumnSpan="2" IsChecked="{Binding UseGrowthRate}" Margin="0,0,0,5"/>
-                <Button Content="Forecast" Command="{Binding ForecastCommand}" Grid.Row="3" Grid.Column="0" Margin="0,5,5,5"/>
-                <Button Content="Export" Command="{Binding ExportCommand}" Grid.Row="3" Grid.Column="1" Margin="0,5,0,5"/>
-                <DataGrid ItemsSource="{Binding Results}" Grid.Row="4" Grid.ColumnSpan="2" AutoGenerateColumns="True" Height="150" Margin="0,0,0,5"/>
-                <Canvas Grid.Row="5" Grid.ColumnSpan="2" Height="150" Width="300">
-                    <Polyline Points="{Binding ChartPoints}" Stroke="Blue" StrokeThickness="2"/>
-                </Canvas>
-            </Grid>
-        </TabItem>
+                <StackPanel Margin="10">
+                    <TextBlock Text="Enter cost data and parameters. Future cost years must be in ascending order." TextWrapping="Wrap" Margin="0,0,0,10"/>
+                    <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <TextBlock Text="First Cost" Margin="0,0,5,5"/>
+                    <TextBox Text="{Binding FirstCost}" Grid.Column="1" Margin="0,0,0,5"
+                             ToolTip="Initial project cost."/>
+                    <TextBlock Text="Rate (%)" Grid.Row="1" Margin="0,0,5,5"/>
+                    <TextBox Text="{Binding Rate}" Grid.Row="1" Grid.Column="1" Margin="0,0,0,5"
+                             ToolTip="Discount rate in percent."/>
+                    <TextBlock Text="Base Year" Grid.Row="2" Margin="0,0,5,5"/>
+                    <TextBox Text="{Binding BaseYear}" Grid.Row="2" Grid.Column="1" Margin="0,0,0,5"/>
+                    <TextBlock Text="Analysis Period" Grid.Row="3" Margin="0,0,5,5"/>
+                    <TextBox Text="{Binding AnalysisPeriod}" Grid.Row="3" Grid.Column="1" Margin="0,0,0,5"
+                             ToolTip="Number of periods for capital recovery."/>
+                    <TextBlock Text="Annual O&amp;M" Grid.Row="4" Margin="0,0,5,5"/>
+                    <TextBox Text="{Binding AnnualOm}" Grid.Row="4" Grid.Column="1" Margin="0,0,0,5"
+                             ToolTip="Annual operations and maintenance cost."/>
+                    <TextBlock Text="Annual Benefits" Grid.Row="5" Margin="0,0,5,5"/>
+                    <TextBox Text="{Binding AnnualBenefits}" Grid.Row="5" Grid.Column="1" Margin="0,0,0,5"
+                             ToolTip="Expected annual benefits."/>
+                    <TextBlock Text="Construction Months" Grid.Row="6" Margin="0,0,5,5"/>
+                    <TextBox Text="{Binding ConstructionMonths}" Grid.Row="6" Grid.Column="1" Margin="0,0,0,5"/>
+                    <TextBlock Text="IDC Costs" Grid.Row="7" Margin="0,0,5,5"/>
+                    <TextBox Text="{Binding IdcCosts}" Grid.Row="7" Grid.Column="1" Margin="0,0,0,5"/>
+                    <TextBlock Text="IDC Timings" Grid.Row="8" Margin="0,0,5,5"/>
+                    <TextBox Text="{Binding IdcTimings}" Grid.Row="8" Grid.Column="1" Margin="0,0,0,5"/>
+                    <TextBlock Text="Future Costs" Grid.Row="9" Margin="0,0,5,5"/>
+                    <DataGrid ItemsSource="{Binding FutureCosts}" Grid.Row="9" Grid.Column="1" AutoGenerateColumns="False" Height="100" Margin="0,0,0,5">
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Header="Cost" Binding="{Binding Cost}"/>
+                            <DataGridTextColumn Header="Year" Binding="{Binding Year}"/>
+                        </DataGrid.Columns>
+                    </DataGrid>
+                    <TextBlock Text="{Binding Idc, StringFormat=IDC: {0:F2}}" Grid.Row="10" Grid.ColumnSpan="2"/>
+                    <TextBlock Text="{Binding TotalInvestment, StringFormat=Total Investment: {0:F2}}" Grid.Row="11" Grid.ColumnSpan="2"/>
+                    <TextBlock Text="{Binding Crf, StringFormat=CRF: {0:F4}}" Grid.Row="12" Grid.ColumnSpan="2"/>
+                    <TextBlock Text="{Binding AnnualCost, StringFormat=Annual Cost: {0:F2}}" Grid.Row="13" Grid.ColumnSpan="2"/>
+                    <TextBlock Text="{Binding Bcr, StringFormat=BCR: {0:F2}}" Grid.Row="14" Grid.ColumnSpan="2"/>
+                    </Grid>
+                </StackPanel>
+            </TabItem>
+            <TabItem Header="Water Demand" DataContext="{Binding WaterDemand}">
+                <StackPanel Margin="10">
+                    <TextBlock Text="Provide historical demand data with years in ascending order and choose forecast length." TextWrapping="Wrap" Margin="0,0,0,10"/>
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="*"/>
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Text="Historical Data" Margin="0,0,5,5"/>
+                        <DataGrid ItemsSource="{Binding HistoricalData}" Grid.Column="1" AutoGenerateColumns="False" Height="100" Margin="0,0,0,5">
+                            <DataGrid.Columns>
+                                <DataGridTextColumn Header="Year" Binding="{Binding Year}"/>
+                                <DataGridTextColumn Header="Demand" Binding="{Binding Demand}"/>
+                            </DataGrid.Columns>
+                        </DataGrid>
+                        <TextBlock Text="Forecast Years" Grid.Row="1" Margin="0,0,5,5"/>
+                        <TextBox Text="{Binding ForecastYears}" Grid.Row="1" Grid.Column="1" Margin="0,0,0,5"
+                                 ToolTip="Number of years to forecast."/>
+                        <CheckBox Content="Use Growth Rate" Grid.Row="2" Grid.ColumnSpan="2" IsChecked="{Binding UseGrowthRate}" Margin="0,0,0,5"/>
+                        <Button Content="Forecast" Command="{Binding ForecastCommand}" Grid.Row="3" Grid.Column="0" Margin="0,5,5,5"/>
+                        <Button Content="Export" Command="{Binding ExportCommand}" Grid.Row="3" Grid.Column="1" Margin="0,5,0,5"/>
+                        <DataGrid ItemsSource="{Binding Results}" Grid.Row="4" Grid.ColumnSpan="2" AutoGenerateColumns="True" Height="150" Margin="0,0,0,5"/>
+                        <Canvas Grid.Row="5" Grid.ColumnSpan="2" Height="150" Width="300">
+                            <Polyline Points="{Binding ChartPoints}" Stroke="Blue" StrokeThickness="2"/>
+                        </Canvas>
+                    </Grid>
+                </StackPanel>
+            </TabItem>
         <TabItem Header="Unit Day Value" DataContext="{Binding Udv}">
             <views:UdvView/>
         </TabItem>

--- a/Services/ExcelExporter.cs
+++ b/Services/ExcelExporter.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using ClosedXML.Excel;
 using EconToolbox.Desktop.Models;
 using System.Linq;
+using EconToolbox.Desktop.ViewModels;
 
 namespace EconToolbox.Desktop.Services
 {
@@ -73,7 +74,7 @@ namespace EconToolbox.Desktop.Services
             wb.SaveAs(filePath);
         }
 
-        public static void ExportEad(IEnumerable<ViewModels.EadViewModel.EadRow> rows, IEnumerable<string> damageColumns, bool useStage, string result, string filePath)
+        public static void ExportEad(IEnumerable<EadViewModel.EadRow> rows, IEnumerable<string> damageColumns, bool useStage, string result, string filePath)
         {
             using var wb = new XLWorkbook();
             var ws = wb.Worksheets.Add("EAD");
@@ -100,6 +101,155 @@ namespace EconToolbox.Desktop.Services
             var summary = wb.Worksheets.Add("Summary");
             summary.Cell(1,1).Value = "Result";
             summary.Cell(1,2).Value = result;
+            wb.SaveAs(filePath);
+        }
+
+        public static void ExportAll(EadViewModel ead, UpdatedCostViewModel updated, AnnualizerViewModel annualizer, WaterDemandViewModel waterDemand, UdvViewModel udv, string filePath)
+        {
+            using var wb = new XLWorkbook();
+
+            // EAD Sheet
+            var eadSheet = wb.Worksheets.Add("EAD");
+            int col = 1;
+            eadSheet.Cell(1, col++).Value = "Probability";
+            if (ead.UseStage)
+                eadSheet.Cell(1, col++).Value = "Stage";
+            int dcCount = ead.DamageColumns.Count;
+            foreach (var name in ead.DamageColumns)
+                eadSheet.Cell(1, col++).Value = name;
+            int rowIdx = 2;
+            foreach (var r in ead.Rows)
+            {
+                col = 1;
+                eadSheet.Cell(rowIdx, col++).Value = r.Probability;
+                if (ead.UseStage)
+                    eadSheet.Cell(rowIdx, col++).Value = r.Stage;
+                for (int i = 0; i < dcCount; i++)
+                    eadSheet.Cell(rowIdx, col++).Value = r.Damages.Count > i ? r.Damages[i] : 0;
+                rowIdx++;
+            }
+            eadSheet.Cell(rowIdx + 1, 1).Value = "Result";
+            eadSheet.Cell(rowIdx + 1, 2).Value = ead.Result;
+
+            // Annualizer Sheets
+            var annSummary = wb.Worksheets.Add("Annualizer");
+            var annData = new Dictionary<string, double>
+            {
+                {"First Cost", annualizer.FirstCost},
+                {"Rate", annualizer.Rate},
+                {"Annual O&M", annualizer.AnnualOm},
+                {"Annual Benefits", annualizer.AnnualBenefits},
+                {"IDC", annualizer.Idc},
+                {"Total Investment", annualizer.TotalInvestment},
+                {"CRF", annualizer.Crf},
+                {"Annual Cost", annualizer.AnnualCost},
+                {"BCR", annualizer.Bcr}
+            };
+            rowIdx = 1;
+            foreach (var kv in annData)
+            {
+                annSummary.Cell(rowIdx, 1).Value = kv.Key;
+                annSummary.Cell(rowIdx, 2).Value = kv.Value;
+                rowIdx++;
+            }
+            var annFc = wb.Worksheets.Add("FutureCosts");
+            annFc.Cell(1,1).Value = "Cost";
+            annFc.Cell(1,2).Value = "Year";
+            rowIdx = 2;
+            foreach (var f in annualizer.FutureCosts)
+            {
+                annFc.Cell(rowIdx,1).Value = f.Cost;
+                annFc.Cell(rowIdx,2).Value = f.Year;
+                rowIdx++;
+            }
+
+            // Water Demand Sheet
+            var wdSheet = wb.Worksheets.Add("WaterDemand");
+            wdSheet.Cell(1,1).Value = "Year";
+            wdSheet.Cell(1,2).Value = "Demand";
+            rowIdx = 2;
+            foreach (var d in waterDemand.Results)
+            {
+                wdSheet.Cell(rowIdx,1).Value = d.Year;
+                wdSheet.Cell(rowIdx,2).Value = d.Demand;
+                rowIdx++;
+            }
+
+            // Updated Cost Sheets
+            var ucItems = wb.Worksheets.Add("UpdatedCost");
+            ucItems.Cell(1,1).Value = "Category";
+            ucItems.Cell(1,2).Value = "Actual Cost";
+            ucItems.Cell(1,3).Value = "Update Factor";
+            ucItems.Cell(1,4).Value = "Updated Cost";
+            rowIdx = 2;
+            foreach (var item in updated.UpdatedCostItems)
+            {
+                ucItems.Cell(rowIdx,1).Value = item.Category;
+                ucItems.Cell(rowIdx,2).Value = item.ActualCost;
+                ucItems.Cell(rowIdx,3).Value = item.UpdateFactor;
+                ucItems.Cell(rowIdx,4).Value = item.UpdatedCost;
+                rowIdx++;
+            }
+            var ucRrr = wb.Worksheets.Add("RRR");
+            ucRrr.Cell(1,1).Value = "Item";
+            ucRrr.Cell(1,2).Value = "Future Cost";
+            ucRrr.Cell(1,3).Value = "Year";
+            ucRrr.Cell(1,4).Value = "PV Factor";
+            ucRrr.Cell(1,5).Value = "Present Value";
+            rowIdx = 2;
+            foreach (var item in updated.RrrCostItems)
+            {
+                ucRrr.Cell(rowIdx,1).Value = item.Item;
+                ucRrr.Cell(rowIdx,2).Value = item.FutureCost;
+                ucRrr.Cell(rowIdx,3).Value = item.Year;
+                ucRrr.Cell(rowIdx,4).Value = item.PvFactor;
+                ucRrr.Cell(rowIdx,5).Value = item.PresentValue;
+                rowIdx++;
+            }
+            var ucSummary = wb.Worksheets.Add("UpdatedCostSummary");
+            var ucData = new Dictionary<string, double>
+            {
+                {"Percent", updated.Percent},
+                {"Total Joint O&M", updated.TotalJointOm},
+                {"Total Updated Cost", updated.TotalUpdatedCost},
+                {"RRR Updated Cost", updated.RrrUpdatedCost},
+                {"RRR Annualized", updated.RrrAnnualized},
+                {"OM Scaled", updated.OmScaled},
+                {"RRR Scaled", updated.RrrScaled},
+                {"Cost Recommendation", updated.CostRecommendation},
+                {"Capital1", updated.Capital1},
+                {"Total1", updated.Total1},
+                {"Capital2", updated.Capital2},
+                {"Total2", updated.Total2}
+            };
+            rowIdx = 1;
+            foreach (var kv in ucData)
+            {
+                ucSummary.Cell(rowIdx,1).Value = kv.Key;
+                ucSummary.Cell(rowIdx,2).Value = kv.Value;
+                rowIdx++;
+            }
+
+            // Unit Day Value Sheet
+            var udvSheet = wb.Worksheets.Add("Udv");
+            var udvData = new Dictionary<string, object>
+            {
+                {"Recreation Type", udv.RecreationType},
+                {"Activity Type", udv.ActivityType},
+                {"Points", udv.Points},
+                {"Unit Day Value", udv.UnitDayValue},
+                {"User Days", udv.UserDays},
+                {"Visitation", udv.Visitation},
+                {"Result", udv.Result}
+            };
+            rowIdx = 1;
+            foreach (var kv in udvData)
+            {
+                udvSheet.Cell(rowIdx,1).Value = kv.Key;
+                udvSheet.Cell(rowIdx,2).Value = kv.Value;
+                rowIdx++;
+            }
+
             wb.SaveAs(filePath);
         }
     }

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -1,4 +1,5 @@
 using System.Windows.Input;
+using EconToolbox.Desktop.Services;
 
 namespace EconToolbox.Desktop.ViewModels
 { 
@@ -10,11 +11,11 @@ namespace EconToolbox.Desktop.ViewModels
         public UdvViewModel Udv { get; } = new();
         public WaterDemandViewModel WaterDemand { get; } = new();
 
-        private object? _selectedViewModel;
-        public object? SelectedViewModel
+        private int _selectedIndex;
+        public int SelectedIndex
         {
-            get => _selectedViewModel;
-            set { _selectedViewModel = value; OnPropertyChanged(); }
+            get => _selectedIndex;
+            set { _selectedIndex = value; OnPropertyChanged(); }
         }
 
         public ICommand CalculateCommand { get; }
@@ -28,18 +29,37 @@ namespace EconToolbox.Desktop.ViewModels
 
         private void Calculate()
         {
-            if (SelectedViewModel == null) return;
-            var prop = SelectedViewModel.GetType().GetProperty("ComputeCommand");
-            if (prop?.GetValue(SelectedViewModel) is ICommand cmd && cmd.CanExecute(null))
-                cmd.Execute(null);
+            switch (SelectedIndex)
+            {
+                case 0:
+                    if (Ead.ComputeCommand.CanExecute(null)) Ead.ComputeCommand.Execute(null);
+                    break;
+                case 1:
+                    if (UpdatedCost.ComputeCommand.CanExecute(null)) UpdatedCost.ComputeCommand.Execute(null);
+                    break;
+                case 2:
+                    if (Annualizer.ComputeCommand.CanExecute(null)) Annualizer.ComputeCommand.Execute(null);
+                    break;
+                case 3:
+                    if (WaterDemand.ComputeCommand.CanExecute(null)) WaterDemand.ComputeCommand.Execute(null);
+                    break;
+                case 4:
+                    if (Udv.ComputeCommand.CanExecute(null)) Udv.ComputeCommand.Execute(null);
+                    break;
+            }
         }
 
         private void Export()
         {
-            if (SelectedViewModel == null) return;
-            var prop = SelectedViewModel.GetType().GetProperty("ExportCommand");
-            if (prop?.GetValue(SelectedViewModel) is ICommand cmd && cmd.CanExecute(null))
-                cmd.Execute(null);
+            var dlg = new Microsoft.Win32.SaveFileDialog
+            {
+                Filter = "Excel Workbook (*.xlsx)|*.xlsx",
+                FileName = "econ_toolbox.xlsx"
+            };
+            if (dlg.ShowDialog() == true)
+            {
+                ExcelExporter.ExportAll(Ead, UpdatedCost, Annualizer, WaterDemand, Udv, dlg.FileName);
+            }
         }
     }
 }

--- a/ViewModels/UpdatedCostViewModel.cs
+++ b/ViewModels/UpdatedCostViewModel.cs
@@ -207,6 +207,7 @@ namespace EconToolbox.Desktop.ViewModels
         public ICommand ComputeUpdatedStorageCommand { get; }
         public ICommand ComputeRrrCommand { get; }
         public ICommand ComputeTotalCommand { get; }
+        public ICommand ComputeCommand { get; }
 
         public UpdatedCostViewModel()
         {
@@ -215,6 +216,14 @@ namespace EconToolbox.Desktop.ViewModels
             ComputeUpdatedStorageCommand = new RelayCommand(ComputeUpdatedStorage);
             ComputeRrrCommand = new RelayCommand(ComputeRrr);
             ComputeTotalCommand = new RelayCommand(ComputeTotal);
+            ComputeCommand = new RelayCommand(() =>
+            {
+                ComputeStorage();
+                ComputeJoint();
+                ComputeUpdatedStorage();
+                ComputeRrr();
+                ComputeTotal();
+            });
 
             UpdatedCostItems.Add(new UpdatedCostEntry { Category = "Lands and Damages" });
             UpdatedCostItems.Add(new UpdatedCostEntry { Category = "Relocations" });

--- a/ViewModels/WaterDemandViewModel.cs
+++ b/ViewModels/WaterDemandViewModel.cs
@@ -54,11 +54,13 @@ namespace EconToolbox.Desktop.ViewModels
 
         public ICommand ForecastCommand { get; }
         public ICommand ExportCommand { get; }
+        public ICommand ComputeCommand { get; }
 
         public WaterDemandViewModel()
         {
             ForecastCommand = new RelayCommand(Forecast);
             ExportCommand = new RelayCommand(Export);
+            ComputeCommand = ForecastCommand;
         }
 
         private void Forecast()

--- a/Views/EadView.xaml
+++ b/Views/EadView.xaml
@@ -8,20 +8,22 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
-        <StackPanel Orientation="Horizontal" Grid.Row="0" Margin="0,0,0,5">
+        <TextBlock Grid.Row="0" Text="Enter probabilities (descending) with corresponding damages. Use Add Damage Column for additional categories. Optional stage values must align with probabilities." TextWrapping="Wrap" Margin="0,0,0,5"/>
+        <StackPanel Orientation="Horizontal" Grid.Row="1" Margin="0,0,0,5">
             <Button Content="Add Damage Column" Command="{Binding AddDamageColumnCommand}" Margin="0,0,5,0"/>
             <Button Content="Remove Damage Column" Command="{Binding RemoveDamageColumnCommand}" Margin="0,0,5,0"/>
             <CheckBox Content="Include Stage" IsChecked="{Binding UseStage}" Margin="0,0,5,0"/>
         </StackPanel>
-        <DataGrid x:Name="EadDataGrid" ItemsSource="{Binding Rows}" Grid.Row="1" AutoGenerateColumns="False"
+        <DataGrid x:Name="EadDataGrid" ItemsSource="{Binding Rows}" Grid.Row="2" AutoGenerateColumns="False"
                   CanUserAddRows="True" CanUserDeleteRows="True" Height="120" Margin="0,0,0,5"/>
-        <Canvas Grid.Row="2" Height="150" Width="300" Margin="0,0,0,5">
+        <Canvas Grid.Row="3" Height="150" Width="300" Margin="0,0,0,5">
             <Polyline Points="{Binding StageDamagePoints}" Stroke="Blue" StrokeThickness="2"/>
         </Canvas>
-        <Canvas Grid.Row="3" Height="150" Width="300" Margin="0,0,0,5">
+        <Canvas Grid.Row="4" Height="150" Width="300" Margin="0,0,0,5">
             <Polyline Points="{Binding FrequencyDamagePoints}" Stroke="Red" StrokeThickness="2"/>
         </Canvas>
-        <TextBlock Grid.Row="4" Text="{Binding Result}"/>
+        <TextBlock Grid.Row="5" Text="{Binding Result}"/>
     </Grid>
 </UserControl>

--- a/Views/UdvView.xaml
+++ b/Views/UdvView.xaml
@@ -7,27 +7,29 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
-        <StackPanel Orientation="Horizontal" Grid.Row="0" Margin="0,0,0,5">
+        <TextBlock Grid.Row="0" Text="Select recreation and activity, enter points, user days, and visitation. Points must follow the table's ascending order." TextWrapping="Wrap" Margin="0,0,0,5"/>
+        <StackPanel Orientation="Horizontal" Grid.Row="1" Margin="0,0,0,5">
             <ComboBox ItemsSource="{Binding RecreationTypes}" SelectedItem="{Binding RecreationType}" Width="120" Margin="0,0,5,0"/>
             <ComboBox ItemsSource="{Binding ActivityTypes}" SelectedItem="{Binding ActivityType}" Width="180"/>
         </StackPanel>
-        <StackPanel Orientation="Horizontal" Grid.Row="1" Margin="0,0,0,5">
+        <StackPanel Orientation="Horizontal" Grid.Row="2" Margin="0,0,0,5">
             <TextBlock Text="Points" VerticalAlignment="Center" Margin="0,0,5,0"/>
             <TextBox Text="{Binding Points}" Width="60" Margin="0,0,10,0"/>
             <TextBlock Text="Unit Day Value" VerticalAlignment="Center" Margin="0,0,5,0"/>
             <TextBlock Text="{Binding UnitDayValue, StringFormat={}{0:F2}}" VerticalAlignment="Center"/>
         </StackPanel>
-        <StackPanel Orientation="Horizontal" Grid.Row="2" Margin="0,0,0,5">
+        <StackPanel Orientation="Horizontal" Grid.Row="3" Margin="0,0,0,5">
             <TextBlock Text="Annual User Days" VerticalAlignment="Center" Margin="0,0,5,0"/>
             <TextBox Text="{Binding UserDays}" Width="80" Margin="0,0,10,0"/>
             <TextBlock Text="Visitation" VerticalAlignment="Center" Margin="0,0,5,0"/>
             <TextBox Text="{Binding Visitation}" Width="60" Margin="0,0,10,0"/>
             <Button Content="Compute" Command="{Binding ComputeCommand}"/>
         </StackPanel>
-        <TextBlock Text="{Binding Result}" Grid.Row="3"/>
-        <Grid Grid.Row="4">
+        <TextBlock Text="{Binding Result}" Grid.Row="4"/>
+        <Grid Grid.Row="5">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="2*"/>
                 <ColumnDefinition Width="3*"/>

--- a/Views/UpdatedCostView.xaml
+++ b/Views/UpdatedCostView.xaml
@@ -4,7 +4,9 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d">
-    <TabControl>
+    <StackPanel>
+        <TextBlock Text="Complete each section and ensure year values are ascending. Use Calculate to process all sections." TextWrapping="Wrap" Margin="10,0,10,10"/>
+        <TabControl Margin="10,0,10,10">
         <TabItem Header="Storage Cost">
             <Grid Margin="10">
                 <Grid.RowDefinitions>
@@ -138,5 +140,6 @@
                 </StackPanel>
             </Grid>
         </TabItem>
-    </TabControl>
+        </TabControl>
+    </StackPanel>
 </UserControl>


### PR DESCRIPTION
## Summary
- Trigger tab-specific calculations through the global **Calculate** button
- Add top-of-tab instructions and input guidance for all tool sections
- Export results from every tab into a single workbook via the global **Export** button

## Testing
- ⚠️ `dotnet build` *(dotnet not installed in container)*


------
https://chatgpt.com/codex/tasks/task_e_68c31f903bec83309f3d0f1b4137c76c