### PR TITLE
Improve result displays and cost annualization inputs

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -36,7 +36,6 @@
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="*"/>
                     </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto"/>
@@ -61,23 +60,42 @@
                              ToolTip="Expected annual benefits."/>
                     <TextBlock Text="Construction Months" Grid.Row="6" Margin="0,0,5,5"/>
                     <TextBox Text="{Binding ConstructionMonths}" Grid.Row="6" Grid.Column="1" Margin="0,0,0,5"/>
-                    <TextBlock Text="IDC Costs" Grid.Row="7" Margin="0,0,5,5"/>
-                    <TextBox Text="{Binding IdcCosts}" Grid.Row="7" Grid.Column="1" Margin="0,0,0,5"/>
-                    <TextBlock Text="IDC Timings" Grid.Row="8" Margin="0,0,5,5"/>
-                    <TextBox Text="{Binding IdcTimings}" Grid.Row="8" Grid.Column="1" Margin="0,0,0,5"/>
-                    <TextBlock Text="Future Costs" Grid.Row="9" Margin="0,0,5,5"/>
-                    <DataGrid ItemsSource="{Binding FutureCosts}" Grid.Row="9" Grid.Column="1" AutoGenerateColumns="False" Height="100" Margin="0,0,0,5">
+                    <TextBlock Text="IDC Schedule" Grid.Row="7" Margin="0,0,5,5"/>
+                    <DataGrid ItemsSource="{Binding IdcEntries}" Grid.Row="7" Grid.Column="1" AutoGenerateColumns="False" Height="100" Margin="0,0,0,5">
                         <DataGrid.Columns>
                             <DataGridTextColumn Header="Cost" Binding="{Binding Cost}"/>
                             <DataGridTextColumn Header="Year" Binding="{Binding Year}"/>
+                            <DataGridComboBoxColumn Header="Timing" SelectedItemBinding="{Binding Timing}">
+                                <DataGridComboBoxColumn.ItemsSource>
+                                    <x:Array Type="sys:String" xmlns:sys="clr-namespace:System;assembly=mscorlib">
+                                        <sys:String>beginning</sys:String>
+                                        <sys:String>midpoint</sys:String>
+                                        <sys:String>end</sys:String>
+                                    </x:Array>
+                                </DataGridComboBoxColumn.ItemsSource>
+                            </DataGridComboBoxColumn>
+                            <DataGridTextColumn Header="PV Factor" Binding="{Binding PvFactor}" IsReadOnly="True"/>
                         </DataGrid.Columns>
                     </DataGrid>
-                    <TextBlock Text="{Binding Idc, StringFormat=IDC: {0:F2}}" Grid.Row="10" Grid.ColumnSpan="2"/>
-                    <TextBlock Text="{Binding TotalInvestment, StringFormat=Total Investment: {0:F2}}" Grid.Row="11" Grid.ColumnSpan="2"/>
-                    <TextBlock Text="{Binding Crf, StringFormat=CRF: {0:F4}}" Grid.Row="12" Grid.ColumnSpan="2"/>
-                    <TextBlock Text="{Binding AnnualCost, StringFormat=Annual Cost: {0:F2}}" Grid.Row="13" Grid.ColumnSpan="2"/>
-                    <TextBlock Text="{Binding Bcr, StringFormat=BCR: {0:F2}}" Grid.Row="14" Grid.ColumnSpan="2"/>
-                    </Grid>
+                    <TextBlock Text="Future Costs" Grid.Row="8" Margin="0,0,5,5"/>
+                    <DataGrid ItemsSource="{Binding FutureCosts}" Grid.Row="8" Grid.Column="1" AutoGenerateColumns="False" Height="100" Margin="0,0,0,5">
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Header="Cost" Binding="{Binding Cost}"/>
+                            <DataGridTextColumn Header="Year" Binding="{Binding Year}"/>
+                            <DataGridComboBoxColumn Header="Timing" SelectedItemBinding="{Binding Timing}">
+                                <DataGridComboBoxColumn.ItemsSource>
+                                    <x:Array Type="sys:String" xmlns:sys="clr-namespace:System;assembly=mscorlib">
+                                        <sys:String>beginning</sys:String>
+                                        <sys:String>midpoint</sys:String>
+                                        <sys:String>end</sys:String>
+                                    </x:Array>
+                                </DataGridComboBoxColumn.ItemsSource>
+                            </DataGridComboBoxColumn>
+                            <DataGridTextColumn Header="PV Factor" Binding="{Binding PvFactor}" IsReadOnly="True"/>
+                        </DataGrid.Columns>
+                    </DataGrid>
+                    <ItemsControl Grid.Row="9" Grid.ColumnSpan="2" ItemsSource="{Binding Results}"/>
+                </Grid>
                 </StackPanel>
             </TabItem>
             <TabItem Header="Water Demand" DataContext="{Binding WaterDemand}">

--- a/Models/FutureCostEntry.cs
+++ b/Models/FutureCostEntry.cs
@@ -4,6 +4,8 @@ namespace EconToolbox.Desktop.Models
     {
         private double _cost;
         private int _year;
+        private double _pvFactor;
+        private string _timing = "end";
 
         public double Cost
         {
@@ -15,6 +17,24 @@ namespace EconToolbox.Desktop.Models
         {
             get => _year;
             set { _year = value; OnPropertyChanged(); }
+        }
+
+        /// <summary>
+        /// Present value factor calculated from rate, year and payment timing.
+        /// </summary>
+        public double PvFactor
+        {
+            get => _pvFactor;
+            set { _pvFactor = value; OnPropertyChanged(); }
+        }
+
+        /// <summary>
+        /// Payment timing within the period: beginning, midpoint or end.
+        /// </summary>
+        public string Timing
+        {
+            get => _timing;
+            set { _timing = value; OnPropertyChanged(); }
         }
     }
 }

--- a/Services/ExcelExporter.cs
+++ b/Services/ExcelExporter.cs
@@ -129,7 +129,7 @@ namespace EconToolbox.Desktop.Services
                 rowIdx++;
             }
             eadSheet.Cell(rowIdx + 1, 1).Value = "Result";
-            eadSheet.Cell(rowIdx + 1, 2).Value = ead.Result;
+            eadSheet.Cell(rowIdx + 1, 2).Value = string.Join(" | ", ead.Results);
 
             // Annualizer Sheets
             var annSummary = wb.Worksheets.Add("Annualizer");

--- a/ViewModels/EadViewModel.cs
+++ b/ViewModels/EadViewModel.cs
@@ -27,11 +27,11 @@ namespace EconToolbox.Desktop.ViewModels
             set { _useStage = value; OnPropertyChanged(); }
         }
 
-        private string _result = string.Empty;
-        public string Result
+        private ObservableCollection<string> _results = new();
+        public ObservableCollection<string> Results
         {
-            get => _result;
-            set { _result = value; OnPropertyChanged(); }
+            get => _results;
+            set { _results = value; OnPropertyChanged(); }
         }
 
         private PointCollection _stageDamagePoints = new();
@@ -104,7 +104,7 @@ namespace EconToolbox.Desktop.ViewModels
             {
                 if (Rows.Count == 0 || DamageColumns.Count == 0)
                 {
-                    Result = "No data";
+                    Results = new ObservableCollection<string> { "No data" };
                     StageDamagePoints = new PointCollection();
                     FrequencyDamagePoints = new PointCollection();
                     return;
@@ -118,12 +118,12 @@ namespace EconToolbox.Desktop.ViewModels
                     double ead = EadModel.Compute(probabilities, damages);
                     results.Add($"{DamageColumns[i]}: {ead:F2}");
                 }
-                Result = string.Join(" | ", results);
+                Results = new ObservableCollection<string>(results);
                 UpdateCharts();
             }
             catch (Exception ex)
             {
-                Result = $"Error: {ex.Message}";
+                Results = new ObservableCollection<string> { $"Error: {ex.Message}" };
                 StageDamagePoints = new PointCollection();
                 FrequencyDamagePoints = new PointCollection();
             }
@@ -189,7 +189,8 @@ namespace EconToolbox.Desktop.ViewModels
             };
             if (dlg.ShowDialog() == true)
             {
-                Services.ExcelExporter.ExportEad(Rows, DamageColumns, UseStage, Result, dlg.FileName);
+                string combined = string.Join(" | ", Results);
+                Services.ExcelExporter.ExportEad(Rows, DamageColumns, UseStage, combined, dlg.FileName);
             }
         }
 

--- a/Views/EadView.xaml
+++ b/Views/EadView.xaml
@@ -5,7 +5,7 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
@@ -17,13 +17,13 @@
             <CheckBox Content="Include Stage" IsChecked="{Binding UseStage}" Margin="0,0,5,0"/>
         </StackPanel>
         <DataGrid x:Name="EadDataGrid" ItemsSource="{Binding Rows}" Grid.Row="2" AutoGenerateColumns="False"
-                  CanUserAddRows="True" CanUserDeleteRows="True" Height="120" Margin="0,0,0,5"/>
+                  CanUserAddRows="True" CanUserDeleteRows="True" Margin="0,0,0,5"/>
         <Canvas Grid.Row="3" Height="150" Width="300" Margin="0,0,0,5">
             <Polyline Points="{Binding StageDamagePoints}" Stroke="Blue" StrokeThickness="2"/>
         </Canvas>
         <Canvas Grid.Row="4" Height="150" Width="300" Margin="0,0,0,5">
             <Polyline Points="{Binding FrequencyDamagePoints}" Stroke="Red" StrokeThickness="2"/>
         </Canvas>
-        <TextBlock Grid.Row="5" Text="{Binding Result}"/>
+        <ItemsControl Grid.Row="5" ItemsSource="{Binding Results}"/>
     </Grid>
 </UserControl>


### PR DESCRIPTION
## Summary
- Add result panels with line-separated entries for EAD and cost annualization tabs
- Auto-compute present value factors and add timing options for future cost and IDC schedules
- Enlarge EAD input table to fill available space

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c323fe71b08330869a48b0516c2002