### PR TITLE
Enhance water demand forecasting

### DIFF
--- a/Models/DemandEntry.cs
+++ b/Models/DemandEntry.cs
@@ -4,6 +4,8 @@ namespace EconToolbox.Desktop.Models
     {
         private int _year;
         private double _demand;
+        private double _industrialDemand;
+        private double _adjustedDemand;
 
         public int Year
         {
@@ -15,6 +17,18 @@ namespace EconToolbox.Desktop.Models
         {
             get => _demand;
             set { _demand = value; OnPropertyChanged(); }
+        }
+
+        public double IndustrialDemand
+        {
+            get => _industrialDemand;
+            set { _industrialDemand = value; OnPropertyChanged(); }
+        }
+
+        public double AdjustedDemand
+        {
+            get => _adjustedDemand;
+            set { _adjustedDemand = value; OnPropertyChanged(); }
         }
     }
 }

--- a/Services/ExcelExporter.cs
+++ b/Services/ExcelExporter.cs
@@ -27,11 +27,15 @@ namespace EconToolbox.Desktop.Services
             var ws = wb.Worksheets.Add("WaterDemand");
             ws.Cell(1,1).Value = "Year";
             ws.Cell(1,2).Value = "Demand";
+            ws.Cell(1,3).Value = "Industrial";
+            ws.Cell(1,4).Value = "Adjusted";
             int row = 2;
             foreach(var d in data)
             {
                 ws.Cell(row,1).Value = d.Year;
                 ws.Cell(row,2).Value = d.Demand;
+                ws.Cell(row,3).Value = d.IndustrialDemand;
+                ws.Cell(row,4).Value = d.AdjustedDemand;
                 row++;
             }
             wb.SaveAs(filePath);
@@ -167,11 +171,15 @@ namespace EconToolbox.Desktop.Services
             var wdSheet = wb.Worksheets.Add("WaterDemand");
             wdSheet.Cell(1,1).Value = "Year";
             wdSheet.Cell(1,2).Value = "Demand";
+            wdSheet.Cell(1,3).Value = "Industrial";
+            wdSheet.Cell(1,4).Value = "Adjusted";
             rowIdx = 2;
             foreach (var d in waterDemand.Results)
             {
                 wdSheet.Cell(rowIdx,1).Value = d.Year;
                 wdSheet.Cell(rowIdx,2).Value = d.Demand;
+                wdSheet.Cell(rowIdx,3).Value = d.IndustrialDemand;
+                wdSheet.Cell(rowIdx,4).Value = d.AdjustedDemand;
                 rowIdx++;
             }
 

--- a/Views/WaterDemandView.xaml
+++ b/Views/WaterDemandView.xaml
@@ -25,14 +25,29 @@
                         <DataGridTextColumn Header="Demand" Binding="{Binding Demand}"/>
                     </DataGrid.Columns>
                 </DataGrid>
-                <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="0,0,0,5">
+                <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="0,0,0,5" VerticalAlignment="Top">
                     <TextBlock Text="Forecast Years" VerticalAlignment="Center" Margin="0,0,5,0"/>
                     <TextBox Width="60" Text="{Binding ForecastYears}" Margin="0,0,10,0"/>
                     <CheckBox Content="Use Growth Rate" IsChecked="{Binding UseGrowthRate}" Margin="0,0,10,0"/>
+                    <TextBlock Text="Current Industrial %" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                    <TextBox Width="60" Text="{Binding CurrentIndustrialPercent}" Margin="0,0,10,0"/>
+                    <TextBlock Text="Future Industrial %" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                    <TextBox Width="60" Text="{Binding FutureIndustrialPercent}" Margin="0,0,10,0"/>
+                    <TextBlock Text="Improvements %" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                    <TextBox Width="60" Text="{Binding SystemImprovementsPercent}" Margin="0,0,10,0"/>
+                    <TextBlock Text="Losses %" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                    <TextBox Width="60" Text="{Binding SystemLossesPercent}" Margin="0,0,10,0"/>
                     <Button Content="Forecast" Command="{Binding ForecastCommand}" Margin="0,0,5,0"/>
                     <Button Content="Export" Command="{Binding ExportCommand}"/>
                 </StackPanel>
-                <DataGrid Grid.Row="2" ItemsSource="{Binding Results}" AutoGenerateColumns="True" FontWeight="Bold" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"/>
+                <DataGrid Grid.Row="2" ItemsSource="{Binding Results}" AutoGenerateColumns="False" FontWeight="Bold" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+                    <DataGrid.Columns>
+                        <DataGridTextColumn Header="Year" Binding="{Binding Year}"/>
+                        <DataGridTextColumn Header="Demand" Binding="{Binding Demand}"/>
+                        <DataGridTextColumn Header="Industrial" Binding="{Binding IndustrialDemand}"/>
+                        <DataGridTextColumn Header="Adjusted" Binding="{Binding AdjustedDemand}"/>
+                    </DataGrid.Columns>
+                </DataGrid>
             </Grid>
             <Canvas Grid.Column="1" Margin="10,0,0,0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
                 <Polyline Points="{Binding ChartPoints}" Stroke="Blue" StrokeThickness="2"/>


### PR DESCRIPTION
## Summary
- Expand water demand forecast to capture industrial share, system improvements, and losses.
- Export detailed water demand results including industrial and adjusted demand.
- Remove castle icon resources and revert application icon configuration.

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c32f4fd00483308027b1afa634cec2