### PR TITLE
Handle generic ExcelExporter values with XLCellValue

### DIFF
--- a/Services/ExcelExporter.cs
+++ b/Services/ExcelExporter.cs
@@ -254,7 +254,9 @@ namespace EconToolbox.Desktop.Services
             foreach (var kv in udvData)
             {
                 udvSheet.Cell(rowIdx,1).SetValue(kv.Key);
-                udvSheet.Cell(rowIdx,2).SetValue(kv.Value);
+                // ClosedXML's SetValue does not accept a plain object, so convert
+                // each value explicitly to an XLCellValue before assignment.
+                udvSheet.Cell(rowIdx,2).Value = XLCellValue.FromObject(kv.Value);
                 rowIdx++;
             }
 


### PR DESCRIPTION
## Summary
- convert UDV export values to `XLCellValue` so ClosedXML can write mixed types

## Testing
- `dotnet build EconToolbox.Desktop.csproj /property:GenerateFullPaths=true /consoleloggerparameters:NoSummary /p:Configuration=Debug /p:Platform="AnyCPU"` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden repository)*

------
https://chatgpt.com/codex/tasks/task_e_68c3360b45c88330a6e7b8f1d06f9306