### PR TITLE
feat: preload water demand data and refresh styling

### DIFF
--- a/App.xaml
+++ b/App.xaml
@@ -3,5 +3,37 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              StartupUri="MainWindow.xaml">
     <Application.Resources>
+        <!-- Global color palette -->
+        <Color x:Key="PrimaryColor">#2D6A8E</Color>
+        <Color x:Key="AccentColor">#1ABC9C</Color>
+        <Color x:Key="BackgroundColor">#F4F7FB</Color>
+
+        <SolidColorBrush x:Key="PrimaryBrush" Color="{StaticResource PrimaryColor}"/>
+        <SolidColorBrush x:Key="AccentBrush" Color="{StaticResource AccentColor}"/>
+        <SolidColorBrush x:Key="BackgroundBrush" Color="{StaticResource BackgroundColor}"/>
+
+        <!-- Modernized control styles -->
+        <Style TargetType="Button">
+            <Setter Property="Background" Value="{StaticResource PrimaryBrush}"/>
+            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Padding" Value="10,5"/>
+            <Setter Property="Margin" Value="4"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+        </Style>
+
+        <Style TargetType="TextBox">
+            <Setter Property="Margin" Value="4"/>
+            <Setter Property="Padding" Value="4"/>
+            <Setter Property="BorderBrush" Value="{StaticResource AccentBrush}"/>
+            <Setter Property="BorderThickness" Value="1"/>
+        </Style>
+
+        <Style TargetType="DataGrid">
+            <Setter Property="RowBackground" Value="White"/>
+            <Setter Property="AlternatingRowBackground" Value="#E9EFF5"/>
+            <Setter Property="GridLinesVisibility" Value="None"/>
+            <Setter Property="BorderBrush" Value="Transparent"/>
+        </Style>
     </Application.Resources>
 </Application>

--- a/EconToolbox.Desktop.csproj
+++ b/EconToolbox.Desktop.csproj
@@ -8,4 +8,9 @@
   <ItemGroup>
     <PackageReference Include="ClosedXML" Version="0.102.4" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="Practical Forecast Exercise - Tables 6-28-18.xlsx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -3,7 +3,8 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:vm="clr-namespace:EconToolbox.Desktop.ViewModels"
         xmlns:views="clr-namespace:EconToolbox.Desktop.Views"
-        Title="Economic Toolbox" Height="700" Width="1000" Background="WhiteSmoke">
+        Title="Economic Toolbox" Height="700" Width="1000" 
+        Background="{StaticResource BackgroundBrush}" FontFamily="Segoe UI">
     <Window.DataContext>
         <vm:MainViewModel/>
     </Window.DataContext>
@@ -12,7 +13,7 @@
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
-        <TabControl Margin="10" SelectedIndex="{Binding SelectedIndex}" Grid.Row="0" FontSize="14">
+        <TabControl Margin="10" SelectedIndex="{Binding SelectedIndex}" Grid.Row="0" FontSize="14" Background="White">
             <TabItem Header="EAD" DataContext="{Binding Ead}">
                 <views:EadView/>
             </TabItem>

--- a/Views/WaterDemandView.xaml
+++ b/Views/WaterDemandView.xaml
@@ -1,6 +1,7 @@
 <UserControl x:Class="EconToolbox.Desktop.Views.WaterDemandView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             Background="{StaticResource BackgroundBrush}">
     <Grid Margin="10">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
@@ -19,12 +20,14 @@
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="*"/>
                 </Grid.RowDefinitions>
-                <DataGrid Grid.Row="0" ItemsSource="{Binding HistoricalData}" AutoGenerateColumns="False" Margin="0,0,0,5" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+                <Border Grid.Row="0" Background="White" CornerRadius="4" Padding="5" Margin="0,0,0,5">
+                    <DataGrid ItemsSource="{Binding HistoricalData}" AutoGenerateColumns="False" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
                     <DataGrid.Columns>
                         <DataGridTextColumn Header="Year" Binding="{Binding Year}"/>
                         <DataGridTextColumn Header="Demand" Binding="{Binding Demand}"/>
                     </DataGrid.Columns>
-                </DataGrid>
+                    </DataGrid>
+                </Border>
                 <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="0,0,0,5" VerticalAlignment="Top">
                     <TextBlock Text="Forecast Years" VerticalAlignment="Center" Margin="0,0,5,0"/>
                     <TextBox Width="60" Text="{Binding ForecastYears}" Margin="0,0,10,0"/>
@@ -40,18 +43,22 @@
                     <Button Content="Forecast" Command="{Binding ForecastCommand}" Margin="0,0,5,0"/>
                     <Button Content="Export" Command="{Binding ExportCommand}"/>
                 </StackPanel>
-                <DataGrid Grid.Row="2" ItemsSource="{Binding Results}" AutoGenerateColumns="False" FontWeight="Bold" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
-                    <DataGrid.Columns>
-                        <DataGridTextColumn Header="Year" Binding="{Binding Year}"/>
-                        <DataGridTextColumn Header="Demand" Binding="{Binding Demand}"/>
-                        <DataGridTextColumn Header="Industrial" Binding="{Binding IndustrialDemand}"/>
-                        <DataGridTextColumn Header="Adjusted" Binding="{Binding AdjustedDemand}"/>
-                    </DataGrid.Columns>
-                </DataGrid>
+                <Border Grid.Row="2" Background="White" CornerRadius="4" Padding="5">
+                    <DataGrid ItemsSource="{Binding Results}" AutoGenerateColumns="False" FontWeight="Bold" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Header="Year" Binding="{Binding Year}"/>
+                            <DataGridTextColumn Header="Demand" Binding="{Binding Demand}"/>
+                            <DataGridTextColumn Header="Industrial" Binding="{Binding IndustrialDemand}"/>
+                            <DataGridTextColumn Header="Adjusted" Binding="{Binding AdjustedDemand}"/>
+                        </DataGrid.Columns>
+                    </DataGrid>
+                </Border>
             </Grid>
-            <Canvas Grid.Column="1" Margin="10,0,0,0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
-                <Polyline Points="{Binding ChartPoints}" Stroke="Blue" StrokeThickness="2"/>
-            </Canvas>
+            <Border Grid.Column="1" Margin="10,0,0,0" Background="White" CornerRadius="4" Padding="5">
+                <Canvas HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+                    <Polyline Points="{Binding ChartPoints}" Stroke="{StaticResource AccentBrush}" StrokeThickness="2"/>
+                </Canvas>
+            </Border>
         </Grid>
         <TextBlock Grid.Row="2" Text="{Binding Explanation}" FontWeight="Bold" TextWrapping="Wrap" Margin="0,10,0,0"/>
     </Grid>


### PR DESCRIPTION
## Summary
- preload Water Demand tab with historical data from the included Practical Forecast Exercise workbook
- add lightweight XML-based workbook parser
- modernize app visuals with a new color palette and styled controls

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c33793bbc48330bddfec7a5f76e62b