### PR TITLE
Refine water demand layout and enhance output formulas

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -95,7 +95,13 @@
                             <DataGridTextColumn Header="PV Factor" Binding="{Binding PvFactor}" IsReadOnly="True"/>
                         </DataGrid.Columns>
                     </DataGrid>
-                    <ItemsControl Grid.Row="9" Grid.ColumnSpan="2" ItemsSource="{Binding Results}" FontWeight="Bold"/>
+                    <StackPanel Grid.Row="9" Grid.ColumnSpan="2" FontWeight="Bold">
+                        <TextBlock Text="{Binding Idc, StringFormat=IDC: {0:C2}}" ToolTip="Interest during construction (IDC) based on first cost, rate and schedule."/>
+                        <TextBlock Text="{Binding TotalInvestment, StringFormat=Total Investment: {0:C2}}" ToolTip="Total Investment = First Cost + IDC + PV of Future Costs"/>
+                        <TextBlock Text="{Binding Crf, StringFormat=CRF: {0:F4}}" ToolTip="CRF = r(1+r)^n / ((1+r)^n - 1)"/>
+                        <TextBlock Text="{Binding AnnualCost, StringFormat=Annual Cost: {0:C2}}" ToolTip="Annual Cost = Total Investment × CRF + Annual O&M"/>
+                        <TextBlock Text="{Binding Bcr, StringFormat=BCR: {0:F2}}" ToolTip="BCR = Annual Benefits ÷ Annual Cost"/>
+                    </StackPanel>
                 </Grid>
                 </StackPanel>
             </TabItem>
@@ -107,8 +113,8 @@
         </TabItem>
         </TabControl>
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Grid.Row="1" Margin="10,0,10,10">
-            <Button Content="Calculate" Command="{Binding CalculateCommand}" Margin="0,0,5,0"/>
-            <Button Content="Export" Command="{Binding ExportCommand}"/>
+            <Button x:Name="CalculateButton" Content="Calculate" Width="100" Command="{Binding CalculateCommand}" Margin="0,0,5,0"/>
+            <Button Content="Export" Width="100" Command="{Binding ExportCommand}"/>
         </StackPanel>
     </Grid>
 </Window>

--- a/Services/ExcelExporter.cs
+++ b/Services/ExcelExporter.cs
@@ -29,6 +29,9 @@ namespace EconToolbox.Desktop.Services
             ws.Cell(1,2).Value = "Demand";
             ws.Cell(1,3).Value = "Industrial";
             ws.Cell(1,4).Value = "Adjusted";
+            ws.Cell(1,2).Comment.AddText("Demand = Prior Demand × (1 + Growth Rate)");
+            ws.Cell(1,3).Comment.AddText("Industrial = Demand × Industrial %");
+            ws.Cell(1,4).Comment.AddText("Adjusted = Demand × (1 - Improvements %) × (1 - Losses %)");
             int row = 2;
             foreach(var d in data)
             {
@@ -61,7 +64,20 @@ namespace EconToolbox.Desktop.Services
             foreach(var kv in data)
             {
                 summary.Cell(row,1).Value = kv.Key;
-                summary.Cell(row,2).Value = kv.Value;
+                var cell = summary.Cell(row,2);
+                cell.Value = kv.Value;
+                if (kv.Key.Contains("Cost") || kv.Key.Contains("Benefits") || kv.Key.Contains("Investment") || kv.Key == "IDC")
+                    cell.Style.NumberFormat.Format = "$#,##0.00";
+                if (kv.Key == "IDC")
+                    cell.Comment.AddText("Calculated from first cost, discount rate and IDC schedule");
+                else if (kv.Key == "Total Investment")
+                    cell.Comment.AddText("First Cost + IDC + PV of Future Costs");
+                else if (kv.Key == "CRF")
+                    cell.Comment.AddText("r(1+r)^n / ((1+r)^n - 1)");
+                else if (kv.Key == "Annual Cost")
+                    cell.Comment.AddText("Total Investment * CRF + Annual O&M");
+                else if (kv.Key == "BCR")
+                    cell.Comment.AddText("Annual Benefits / Annual Cost");
                 row++;
             }
 
@@ -153,7 +169,20 @@ namespace EconToolbox.Desktop.Services
             foreach (var kv in annData)
             {
                 annSummary.Cell(rowIdx, 1).Value = kv.Key;
-                annSummary.Cell(rowIdx, 2).Value = kv.Value;
+                var cell = annSummary.Cell(rowIdx, 2);
+                cell.Value = kv.Value;
+                if (kv.Key.Contains("Cost") || kv.Key.Contains("Benefits") || kv.Key.Contains("Investment") || kv.Key == "IDC")
+                    cell.Style.NumberFormat.Format = "$#,##0.00";
+                if (kv.Key == "IDC")
+                    cell.Comment.AddText("Calculated from first cost, discount rate and IDC schedule");
+                else if (kv.Key == "Total Investment")
+                    cell.Comment.AddText("First Cost + IDC + PV of Future Costs");
+                else if (kv.Key == "CRF")
+                    cell.Comment.AddText("r(1+r)^n / ((1+r)^n - 1)");
+                else if (kv.Key == "Annual Cost")
+                    cell.Comment.AddText("Total Investment * CRF + Annual O&M");
+                else if (kv.Key == "BCR")
+                    cell.Comment.AddText("Annual Benefits / Annual Cost");
                 rowIdx++;
             }
             var annFc = wb.Worksheets.Add("FutureCosts");
@@ -173,6 +202,9 @@ namespace EconToolbox.Desktop.Services
             wdSheet.Cell(1,2).Value = "Demand";
             wdSheet.Cell(1,3).Value = "Industrial";
             wdSheet.Cell(1,4).Value = "Adjusted";
+            wdSheet.Cell(1,2).Comment.AddText("Demand = Prior Demand × (1 + Growth Rate)");
+            wdSheet.Cell(1,3).Comment.AddText("Industrial = Demand × Industrial %");
+            wdSheet.Cell(1,4).Comment.AddText("Adjusted = Demand × (1 - Improvements %) × (1 - Losses %)");
             rowIdx = 2;
             foreach (var d in waterDemand.Results)
             {
@@ -234,7 +266,34 @@ namespace EconToolbox.Desktop.Services
             foreach (var kv in ucData)
             {
                 ucSummary.Cell(rowIdx,1).Value = kv.Key;
-                ucSummary.Cell(rowIdx,2).Value = kv.Value;
+                var cell = ucSummary.Cell(rowIdx,2);
+                cell.Value = kv.Value;
+                if (kv.Key.Contains("Cost") || kv.Key.Contains("Annualized") || kv.Key.Contains("Scaled") || kv.Key.Contains("Capital") || kv.Key.Contains("OM"))
+                    cell.Style.NumberFormat.Format = "$#,##0.00";
+                if (kv.Key == "Percent")
+                    cell.Comment.AddText("Percent = Storage Recommendation / Total Usable Storage");
+                else if (kv.Key == "Total Joint O&M")
+                    cell.Comment.AddText("Total Joint O&M = Joint Operations Cost + Joint Maintenance Cost");
+                else if (kv.Key == "Total Updated Cost")
+                    cell.Comment.AddText("Total Updated Cost = Σ(Actual Cost × Update Factor)");
+                else if (kv.Key == "RRR Updated Cost")
+                    cell.Comment.AddText("RRR Updated Cost = Present Value × CWCCI");
+                else if (kv.Key == "RRR Annualized")
+                    cell.Comment.AddText("RRR Annualized = RRR Updated Cost × CRF");
+                else if (kv.Key == "OM Scaled")
+                    cell.Comment.AddText("OM Scaled = Total Joint O&M × Percent");
+                else if (kv.Key == "RRR Scaled")
+                    cell.Comment.AddText("RRR Scaled = RRR Annualized × Percent");
+                else if (kv.Key == "Cost Recommendation")
+                    cell.Comment.AddText("Cost Recommendation = Total Updated Cost × Percent");
+                else if (kv.Key == "Capital1")
+                    cell.Comment.AddText("Capital1 = Total Updated Cost × Percent × CRF1");
+                else if (kv.Key == "Total1")
+                    cell.Comment.AddText("Total1 = Capital1 + OM Scaled + RRR Scaled");
+                else if (kv.Key == "Capital2")
+                    cell.Comment.AddText("Capital2 = Total Updated Cost × Percent × CRF2");
+                else if (kv.Key == "Total2")
+                    cell.Comment.AddText("Total2 = Capital2 + OM Scaled");
                 rowIdx++;
             }
 

--- a/ViewModels/AnnualizerViewModel.cs
+++ b/ViewModels/AnnualizerViewModel.cs
@@ -137,14 +137,17 @@ namespace EconToolbox.Desktop.ViewModels
                 foreach (FutureCostEntry entry in e.NewItems)
                     entry.PropertyChanged += EntryOnPropertyChanged;
             UpdatePvFactors();
+            Compute();
         }
 
         private void EntryOnPropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
             if (e.PropertyName == nameof(FutureCostEntry.Year) ||
-                e.PropertyName == nameof(FutureCostEntry.Timing))
+                e.PropertyName == nameof(FutureCostEntry.Timing) ||
+                e.PropertyName == nameof(FutureCostEntry.Cost))
             {
                 UpdatePvFactors();
+                Compute();
             }
         }
 

--- a/Views/UpdatedCostView.xaml
+++ b/Views/UpdatedCostView.xaml
@@ -24,7 +24,7 @@
                 <TextBlock Text="Storage Recommendation" Grid.Row="1" Margin="0,0,5,5"/>
                 <TextBox Text="{Binding StorageRecommendation}" Grid.Row="1" Grid.Column="1" Margin="0,0,0,5"/>
                 <Button Content="Compute" Command="{Binding ComputeStorageCommand}" Grid.Row="2" Grid.ColumnSpan="2" Margin="0,5,0,5"/>
-                <TextBlock Text="{Binding Percent, StringFormat=P: {0:F5}}" Grid.Row="3" Grid.ColumnSpan="2"/>
+                <TextBlock Text="{Binding Percent, StringFormat=P: {0:F5}}" Grid.Row="3" Grid.ColumnSpan="2" ToolTip="Percent = Storage Recommendation / Total Usable Storage"/>
             </Grid>
         </TabItem>
         <TabItem Header="Joint Costs O&amp;M">
@@ -44,7 +44,7 @@
                 <TextBlock Text="Joint Maintenance Cost" Grid.Row="1" Margin="0,0,5,5"/>
                 <TextBox Text="{Binding JointMaintenanceCost}" Grid.Row="1" Grid.Column="1" Margin="0,0,0,5"/>
                 <Button Content="Compute" Command="{Binding ComputeJointCommand}" Grid.Row="2" Grid.ColumnSpan="2" Margin="0,5,0,5"/>
-                <TextBlock Text="{Binding TotalJointOm, StringFormat=Total Joint O&amp;M: {0:C2}}" Grid.Row="3" Grid.ColumnSpan="2"/>
+                <TextBlock Text="{Binding TotalJointOm, StringFormat=Total Joint O&amp;M: {0:C2}}" Grid.Row="3" Grid.ColumnSpan="2" ToolTip="Total Joint O&M = Joint Operations Cost + Joint Maintenance Cost"/>
             </Grid>
         </TabItem>
         <TabItem Header="Updated Storage Cost">
@@ -63,7 +63,7 @@
                     </DataGrid.Columns>
                 </DataGrid>
                 <Button Content="Compute" Command="{Binding ComputeUpdatedStorageCommand}" Grid.Row="1" Margin="0,5,0,5"/>
-                <TextBlock Text="{Binding TotalUpdatedCost, StringFormat=Total Updated Cost: {0:C2}}" Grid.Row="2"/>
+                <TextBlock Text="{Binding TotalUpdatedCost, StringFormat=Total Updated Cost: {0:C2}}" Grid.Row="2" ToolTip="Total Updated Cost = Σ(Actual Cost × Update Factor)"/>
             </Grid>
         </TabItem>
         <TabItem Header="RR&amp;R and Mitigation">
@@ -100,8 +100,8 @@
                 </DataGrid>
                 <Button Content="Compute" Command="{Binding ComputeRrrCommand}" Grid.Row="5" Grid.ColumnSpan="2" Margin="0,5,0,5"/>
                 <StackPanel Grid.Row="6" Grid.ColumnSpan="2">
-                    <TextBlock Text="{Binding RrrUpdatedCost, StringFormat=Updated Cost: {0:C2}}"/>
-                    <TextBlock Text="{Binding RrrAnnualized, StringFormat=Annualized: {0:C2}}"/>
+                    <TextBlock Text="{Binding RrrUpdatedCost, StringFormat=Updated Cost: {0:C2}}" ToolTip="Updated Cost = Present Value × CWCCI"/>
+                    <TextBlock Text="{Binding RrrAnnualized, StringFormat=Annualized: {0:C2}}" ToolTip="Annualized = Updated Cost × CRF"/>
                 </StackPanel>
             </Grid>
         </TabItem>
@@ -129,14 +129,14 @@
                 <TextBox Text="{Binding AnalysisPeriod2}" Grid.Row="3" Grid.Column="1" Margin="0,0,0,5"/>
                 <Button Content="Compute" Command="{Binding ComputeTotalCommand}" Grid.Row="4" Grid.ColumnSpan="2" Margin="0,5,0,5"/>
                 <StackPanel Grid.Row="5" Grid.ColumnSpan="2">
-                    <TextBlock Text="{Binding Percent, StringFormat=P: {0:F5}}"/>
-                    <TextBlock Text="{Binding CostRecommendation, StringFormat=Cost of Storage Recommendation: {0:C2}}"/>
-                    <TextBlock Text="{Binding Capital1, StringFormat=Annualized Storage Cost 1: {0:C2}}"/>
-                    <TextBlock Text="{Binding OmScaled, StringFormat=Joint O&amp;M: {0:C2}}"/>
-                    <TextBlock Text="{Binding RrrScaled, StringFormat=Annualized RR&amp;R/Mitigation: {0:C2}}"/>
-                    <TextBlock Text="{Binding Total1, StringFormat=Total Annual Cost 1: {0:C2}}"/>
-                    <TextBlock Text="{Binding Capital2, StringFormat=Annualized Storage Cost 2: {0:C2}}"/>
-                    <TextBlock Text="{Binding Total2, StringFormat=Total Annual Cost 2: {0:C2}}"/>
+                    <TextBlock Text="{Binding Percent, StringFormat=P: {0:F5}}" ToolTip="Percent = Storage Recommendation / Total Usable Storage"/>
+                    <TextBlock Text="{Binding CostRecommendation, StringFormat=Cost of Storage Recommendation: {0:C2}}" ToolTip="Cost Recommendation = Total Updated Cost × Percent"/>
+                    <TextBlock Text="{Binding Capital1, StringFormat=Annualized Storage Cost 1: {0:C2}}" ToolTip="Annualized Storage Cost 1 = Total Updated Cost × Percent × CRF1"/>
+                    <TextBlock Text="{Binding OmScaled, StringFormat=Joint O&amp;M: {0:C2}}" ToolTip="Joint O&M = Total Joint O&M × Percent"/>
+                    <TextBlock Text="{Binding RrrScaled, StringFormat=Annualized RR&amp;R/Mitigation: {0:C2}}" ToolTip="Annualized RR&R/Mitigation = RRR Annualized × Percent"/>
+                    <TextBlock Text="{Binding Total1, StringFormat=Total Annual Cost 1: {0:C2}}" ToolTip="Total Annual Cost 1 = Capital1 + Joint O&M + Annualized RR&R/Mitigation"/>
+                    <TextBlock Text="{Binding Capital2, StringFormat=Annualized Storage Cost 2: {0:C2}}" ToolTip="Annualized Storage Cost 2 = Total Updated Cost × Percent × CRF2"/>
+                    <TextBlock Text="{Binding Total2, StringFormat=Total Annual Cost 2: {0:C2}}" ToolTip="Total Annual Cost 2 = Capital2 + Joint O&M"/>
                 </StackPanel>
             </Grid>
         </TabItem>

--- a/Views/WaterDemandView.xaml
+++ b/Views/WaterDemandView.xaml
@@ -28,41 +28,75 @@
                     </DataGrid.Columns>
                     </DataGrid>
                 </Border>
-                <StackPanel Grid.Row="1" Orientation="Vertical" Margin="0,0,0,5" VerticalAlignment="Top">
-                    <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
-                        <TextBlock Text="Forecast Years" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                        <TextBox Width="60" Text="{Binding ForecastYears}" Margin="0,0,10,0"/>
-                        <CheckBox Content="Use Growth Rate" IsChecked="{Binding UseGrowthRate}"/>
+                <Grid Grid.Row="1" Margin="0,0,0,5" VerticalAlignment="Top">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="80"/>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="80"/>
+                    </Grid.ColumnDefinitions>
+
+                    <TextBlock Text="Forecast Years" Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                    <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding ForecastYears}" Margin="0,0,10,0" Width="80"/>
+                    <CheckBox Content="Use Growth Rate" Grid.Row="0" Grid.Column="2" Grid.ColumnSpan="2" IsChecked="{Binding UseGrowthRate}" VerticalAlignment="Center"/>
+
+                    <TextBlock Text="Standard Growth Rate" Grid.Row="1" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                    <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding StandardGrowthRate}" Width="80"/>
+
+                    <TextBlock Text="Current Industrial %" Grid.Row="2" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                    <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding CurrentIndustrialPercent}" Margin="0,0,10,0" Width="80"/>
+                    <TextBlock Text="Future Industrial %" Grid.Row="2" Grid.Column="2" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                    <TextBox Grid.Row="2" Grid.Column="3" Text="{Binding FutureIndustrialPercent}" Width="80"/>
+
+                    <TextBlock Text="Improvements %" Grid.Row="3" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                    <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding SystemImprovementsPercent}" Margin="0,0,10,0" Width="80"/>
+                    <TextBlock Text="Losses %" Grid.Row="3" Grid.Column="2" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                    <TextBox Grid.Row="3" Grid.Column="3" Text="{Binding SystemLossesPercent}" Width="80"/>
+
+                    <StackPanel Grid.Row="4" Grid.ColumnSpan="4" Orientation="Horizontal" HorizontalAlignment="Left">
+                        <Button Content="Forecast" Width="80" Command="{Binding ForecastCommand}" Margin="0,0,5,0"/>
+                        <Button Content="Export" Width="80" Command="{Binding ExportCommand}"/>
                     </StackPanel>
-                    <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
-                        <TextBlock Text="Standard Growth Rate" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                        <TextBox Width="60" Text="{Binding StandardGrowthRate}"/>
-                    </StackPanel>
-                    <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
-                        <TextBlock Text="Current Industrial %" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                        <TextBox Width="60" Text="{Binding CurrentIndustrialPercent}" Margin="0,0,10,0"/>
-                        <TextBlock Text="Future Industrial %" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                        <TextBox Width="60" Text="{Binding FutureIndustrialPercent}"/>
-                    </StackPanel>
-                    <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
-                        <TextBlock Text="Improvements %" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                        <TextBox Width="60" Text="{Binding SystemImprovementsPercent}" Margin="0,0,10,0"/>
-                        <TextBlock Text="Losses %" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                        <TextBox Width="60" Text="{Binding SystemLossesPercent}"/>
-                    </StackPanel>
-                    <StackPanel Orientation="Horizontal">
-                        <Button Content="Forecast" Command="{Binding ForecastCommand}" Margin="0,0,5,0"/>
-                        <Button Content="Export" Command="{Binding ExportCommand}"/>
-                    </StackPanel>
-                </StackPanel>
+                </Grid>
                 <Border Grid.Row="2" Background="White" CornerRadius="4" Padding="5">
                     <DataGrid ItemsSource="{Binding Results}" AutoGenerateColumns="False" FontWeight="Bold" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
                         <DataGrid.Columns>
                         <DataGridTextColumn Header="Year" Binding="{Binding Year}"/>
-                        <DataGridTextColumn Header="Growth Rate" Binding="{Binding GrowthRate, Mode=TwoWay}"/>
-                        <DataGridTextColumn Header="Demand" Binding="{Binding Demand}"/>
-                        <DataGridTextColumn Header="Industrial" Binding="{Binding IndustrialDemand}"/>
-                        <DataGridTextColumn Header="Adjusted" Binding="{Binding AdjustedDemand}"/>
+                        <DataGridTextColumn Header="Growth Rate" Binding="{Binding GrowthRate, Mode=TwoWay, StringFormat={}{0:N2}}">
+                            <DataGridTextColumn.ElementStyle>
+                                <Style TargetType="TextBlock">
+                                    <Setter Property="ToolTip" Value="Growth Rate = (Current Demand - Previous Demand) / Previous Demand"/>
+                                </Style>
+                            </DataGridTextColumn.ElementStyle>
+                        </DataGridTextColumn>
+                        <DataGridTextColumn Header="Demand" Binding="{Binding Demand, StringFormat={}{0:N2}}">
+                            <DataGridTextColumn.ElementStyle>
+                                <Style TargetType="TextBlock">
+                                    <Setter Property="ToolTip" Value="Demand = Prior Demand × (1 + Growth Rate)"/>
+                                </Style>
+                            </DataGridTextColumn.ElementStyle>
+                        </DataGridTextColumn>
+                        <DataGridTextColumn Header="Industrial" Binding="{Binding IndustrialDemand, StringFormat={}{0:N2}}">
+                            <DataGridTextColumn.ElementStyle>
+                                <Style TargetType="TextBlock">
+                                    <Setter Property="ToolTip" Value="Industrial = Demand × Industrial %"/>
+                                </Style>
+                            </DataGridTextColumn.ElementStyle>
+                        </DataGridTextColumn>
+                        <DataGridTextColumn Header="Adjusted" Binding="{Binding AdjustedDemand, StringFormat={}{0:N2}}">
+                            <DataGridTextColumn.ElementStyle>
+                                <Style TargetType="TextBlock">
+                                    <Setter Property="ToolTip" Value="Adjusted = Demand × (1 - Improvements %) × (1 - Losses %)"/>
+                                </Style>
+                            </DataGridTextColumn.ElementStyle>
+                        </DataGridTextColumn>
                     </DataGrid.Columns>
                     </DataGrid>
                 </Border>


### PR DESCRIPTION
## Summary
- Align water demand forecast inputs with uniform grid and button sizes
- Auto-recalculate cost annualization when IDC or future costs change
- Add formatted outputs with formula tooltips and export comments across tabs

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c34ce3623c833094b6524716a32868