### PR TITLE
Fix ampersand encoding in XAML

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -99,7 +99,7 @@
                         <TextBlock Text="{Binding Idc, StringFormat=IDC: {0:C2}}" ToolTip="Interest during construction (IDC) based on first cost, rate and schedule."/>
                         <TextBlock Text="{Binding TotalInvestment, StringFormat=Total Investment: {0:C2}}" ToolTip="Total Investment = First Cost + IDC + PV of Future Costs"/>
                         <TextBlock Text="{Binding Crf, StringFormat=CRF: {0:F4}}" ToolTip="CRF = r(1+r)^n / ((1+r)^n - 1)"/>
-                        <TextBlock Text="{Binding AnnualCost, StringFormat=Annual Cost: {0:C2}}" ToolTip="Annual Cost = Total Investment × CRF + Annual O&M"/>
+                        <TextBlock Text="{Binding AnnualCost, StringFormat=Annual Cost: {0:C2}}" ToolTip="Annual Cost = Total Investment × CRF + Annual O&amp;M"/>
                         <TextBlock Text="{Binding Bcr, StringFormat=BCR: {0:F2}}" ToolTip="BCR = Annual Benefits ÷ Annual Cost"/>
                     </StackPanel>
                 </Grid>

--- a/Views/UpdatedCostView.xaml
+++ b/Views/UpdatedCostView.xaml
@@ -44,7 +44,7 @@
                 <TextBlock Text="Joint Maintenance Cost" Grid.Row="1" Margin="0,0,5,5"/>
                 <TextBox Text="{Binding JointMaintenanceCost}" Grid.Row="1" Grid.Column="1" Margin="0,0,0,5"/>
                 <Button Content="Compute" Command="{Binding ComputeJointCommand}" Grid.Row="2" Grid.ColumnSpan="2" Margin="0,5,0,5"/>
-                <TextBlock Text="{Binding TotalJointOm, StringFormat=Total Joint O&amp;M: {0:C2}}" Grid.Row="3" Grid.ColumnSpan="2" ToolTip="Total Joint O&M = Joint Operations Cost + Joint Maintenance Cost"/>
+                <TextBlock Text="{Binding TotalJointOm, StringFormat=Total Joint O&amp;M: {0:C2}}" Grid.Row="3" Grid.ColumnSpan="2" ToolTip="Total Joint O&amp;M = Joint Operations Cost + Joint Maintenance Cost"/>
             </Grid>
         </TabItem>
         <TabItem Header="Updated Storage Cost">
@@ -132,11 +132,11 @@
                     <TextBlock Text="{Binding Percent, StringFormat=P: {0:F5}}" ToolTip="Percent = Storage Recommendation / Total Usable Storage"/>
                     <TextBlock Text="{Binding CostRecommendation, StringFormat=Cost of Storage Recommendation: {0:C2}}" ToolTip="Cost Recommendation = Total Updated Cost × Percent"/>
                     <TextBlock Text="{Binding Capital1, StringFormat=Annualized Storage Cost 1: {0:C2}}" ToolTip="Annualized Storage Cost 1 = Total Updated Cost × Percent × CRF1"/>
-                    <TextBlock Text="{Binding OmScaled, StringFormat=Joint O&amp;M: {0:C2}}" ToolTip="Joint O&M = Total Joint O&M × Percent"/>
-                    <TextBlock Text="{Binding RrrScaled, StringFormat=Annualized RR&amp;R/Mitigation: {0:C2}}" ToolTip="Annualized RR&R/Mitigation = RRR Annualized × Percent"/>
-                    <TextBlock Text="{Binding Total1, StringFormat=Total Annual Cost 1: {0:C2}}" ToolTip="Total Annual Cost 1 = Capital1 + Joint O&M + Annualized RR&R/Mitigation"/>
+                    <TextBlock Text="{Binding OmScaled, StringFormat=Joint O&amp;M: {0:C2}}" ToolTip="Joint O&amp;M = Total Joint O&amp;M × Percent"/>
+                    <TextBlock Text="{Binding RrrScaled, StringFormat=Annualized RR&amp;R/Mitigation: {0:C2}}" ToolTip="Annualized RR&amp;R/Mitigation = RRR Annualized × Percent"/>
+                    <TextBlock Text="{Binding Total1, StringFormat=Total Annual Cost 1: {0:C2}}" ToolTip="Total Annual Cost 1 = Capital1 + Joint O&amp;M + Annualized RR&amp;R/Mitigation"/>
                     <TextBlock Text="{Binding Capital2, StringFormat=Annualized Storage Cost 2: {0:C2}}" ToolTip="Annualized Storage Cost 2 = Total Updated Cost × Percent × CRF2"/>
-                    <TextBlock Text="{Binding Total2, StringFormat=Total Annual Cost 2: {0:C2}}" ToolTip="Total Annual Cost 2 = Capital2 + Joint O&M"/>
+                    <TextBlock Text="{Binding Total2, StringFormat=Total Annual Cost 2: {0:C2}}" ToolTip="Total Annual Cost 2 = Capital2 + Joint O&amp;M"/>
                 </StackPanel>
             </Grid>
         </TabItem>


### PR DESCRIPTION
## Summary
- escape `&` characters in MainWindow tooltip
- escape `&` characters throughout UpdatedCostView tooltips

## Testing
- `dotnet build EconToolbox.Desktop.csproj /property:GenerateFullPaths=true /consoleloggerparameters:NoSummary /p:Configuration=Debug /p:Platform="AnyCPU"` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68c35234986883308add349eb4cc6df5