### PR TITLE
Align forecast inputs in demand view

### DIFF
--- a/Views/WaterDemandView.xaml
+++ b/Views/WaterDemandView.xaml
@@ -28,8 +28,11 @@
                     </DataGrid.Columns>
                     </DataGrid>
                 </Border>
-                <Grid Grid.Row="1" Margin="0,0,0,5" VerticalAlignment="Top">
+                <Grid Grid.Row="1" Margin="0,0,0,5" VerticalAlignment="Top" HorizontalAlignment="Left">
                     <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
@@ -37,30 +40,31 @@
                         <RowDefinition Height="Auto"/>
                     </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*"/>
-                        <ColumnDefinition Width="80"/>
-                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
                         <ColumnDefinition Width="80"/>
                     </Grid.ColumnDefinitions>
 
                     <TextBlock Text="Forecast Years" Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                    <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding ForecastYears}" Margin="0,0,10,0" Width="80"/>
-                    <CheckBox Content="Use Growth Rate" Grid.Row="0" Grid.Column="2" Grid.ColumnSpan="2" IsChecked="{Binding UseGrowthRate}" VerticalAlignment="Center"/>
+                    <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding ForecastYears}" Margin="0,0,10,0" Width="80" HorizontalAlignment="Left"/>
 
-                    <TextBlock Text="Standard Growth Rate" Grid.Row="1" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                    <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding StandardGrowthRate}" Width="80"/>
+                    <CheckBox Content="Use Growth Rate" Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" IsChecked="{Binding UseGrowthRate}" VerticalAlignment="Center" HorizontalAlignment="Left"/>
 
-                    <TextBlock Text="Current Industrial %" Grid.Row="2" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                    <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding CurrentIndustrialPercent}" Margin="0,0,10,0" Width="80"/>
-                    <TextBlock Text="Future Industrial %" Grid.Row="2" Grid.Column="2" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                    <TextBox Grid.Row="2" Grid.Column="3" Text="{Binding FutureIndustrialPercent}" Width="80"/>
+                    <TextBlock Text="Standard Growth Rate" Grid.Row="2" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                    <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding StandardGrowthRate}" Width="80" HorizontalAlignment="Left"/>
 
-                    <TextBlock Text="Improvements %" Grid.Row="3" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                    <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding SystemImprovementsPercent}" Margin="0,0,10,0" Width="80"/>
-                    <TextBlock Text="Losses %" Grid.Row="3" Grid.Column="2" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                    <TextBox Grid.Row="3" Grid.Column="3" Text="{Binding SystemLossesPercent}" Width="80"/>
+                    <TextBlock Text="Current Industrial %" Grid.Row="3" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                    <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding CurrentIndustrialPercent}" Margin="0,0,10,0" Width="80" HorizontalAlignment="Left"/>
 
-                    <StackPanel Grid.Row="4" Grid.ColumnSpan="4" Orientation="Horizontal" HorizontalAlignment="Left">
+                    <TextBlock Text="Future Industrial %" Grid.Row="4" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                    <TextBox Grid.Row="4" Grid.Column="1" Text="{Binding FutureIndustrialPercent}" Width="80" HorizontalAlignment="Left"/>
+
+                    <TextBlock Text="Improvements %" Grid.Row="5" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                    <TextBox Grid.Row="5" Grid.Column="1" Text="{Binding SystemImprovementsPercent}" Margin="0,0,10,0" Width="80" HorizontalAlignment="Left"/>
+
+                    <TextBlock Text="Losses %" Grid.Row="6" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                    <TextBox Grid.Row="6" Grid.Column="1" Text="{Binding SystemLossesPercent}" Width="80" HorizontalAlignment="Left"/>
+
+                    <StackPanel Grid.Row="7" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Left">
                         <Button Content="Forecast" Width="80" Command="{Binding ForecastCommand}" Margin="0,0,5,0"/>
                         <Button Content="Export" Width="80" Command="{Binding ExportCommand}"/>
                     </StackPanel>


### PR DESCRIPTION
## Summary
- Left-justify demand forecast inputs
- Place each forecast input on its own line for clearer layout

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c35714f4788330a35d8c38b1700ea9