### PR TITLE
Fix FontWeight usage in MainWindow

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -95,12 +95,12 @@
                             <DataGridTextColumn Header="PV Factor" Binding="{Binding PvFactor}" IsReadOnly="True"/>
                         </DataGrid.Columns>
                     </DataGrid>
-                    <StackPanel Grid.Row="9" Grid.ColumnSpan="2" FontWeight="Bold">
-                        <TextBlock Text="{Binding Idc, StringFormat=IDC: {0:C2}}" ToolTip="Interest during construction (IDC) based on first cost, rate and schedule."/>
-                        <TextBlock Text="{Binding TotalInvestment, StringFormat=Total Investment: {0:C2}}" ToolTip="Total Investment = First Cost + IDC + PV of Future Costs"/>
-                        <TextBlock Text="{Binding Crf, StringFormat=CRF: {0:F4}}" ToolTip="CRF = r(1+r)^n / ((1+r)^n - 1)"/>
-                        <TextBlock Text="{Binding AnnualCost, StringFormat=Annual Cost: {0:C2}}" ToolTip="Annual Cost = Total Investment × CRF + Annual O&amp;M"/>
-                        <TextBlock Text="{Binding Bcr, StringFormat=BCR: {0:F2}}" ToolTip="BCR = Annual Benefits ÷ Annual Cost"/>
+                    <StackPanel Grid.Row="9" Grid.ColumnSpan="2">
+                        <TextBlock FontWeight="Bold" Text="{Binding Idc, StringFormat=IDC: {0:C2}}" ToolTip="Interest during construction (IDC) based on first cost, rate and schedule."/>
+                        <TextBlock FontWeight="Bold" Text="{Binding TotalInvestment, StringFormat=Total Investment: {0:C2}}" ToolTip="Total Investment = First Cost + IDC + PV of Future Costs"/>
+                        <TextBlock FontWeight="Bold" Text="{Binding Crf, StringFormat=CRF: {0:F4}}" ToolTip="CRF = r(1+r)^n / ((1+r)^n - 1)"/>
+                        <TextBlock FontWeight="Bold" Text="{Binding AnnualCost, StringFormat=Annual Cost: {0:C2}}" ToolTip="Annual Cost = Total Investment × CRF + Annual O&amp;M"/>
+                        <TextBlock FontWeight="Bold" Text="{Binding Bcr, StringFormat=BCR: {0:F2}}" ToolTip="BCR = Annual Benefits ÷ Annual Cost"/>
                     </StackPanel>
                 </Grid>
                 </StackPanel>


### PR DESCRIPTION
## Summary
- remove invalid FontWeight on StackPanel and apply FontWeight to individual TextBlocks

## Testing
- `dotnet build EconToolbox.Desktop.csproj /property:GenerateFullPaths=true /consoleloggerparameters:NoSummary /p:Configuration=Debug /p:Platform="AnyCPU"` *(fails: dotnet not installed)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c3596e59f88330b0ad8ed24a99e442