### PR TITLE
Refine UI layouts and editable EAD headers

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -114,7 +114,7 @@
         </TabControl>
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Grid.Row="1" Margin="10,0,10,10">
             <Button x:Name="CalculateButton" Content="Calculate" Width="100" Command="{Binding CalculateCommand}" Margin="0,0,5,0"/>
-            <Button Content="Export" Width="100" Command="{Binding ExportCommand}"/>
+            <Button Content="Export" Width="{Binding ElementName=CalculateButton, Path=ActualWidth}" Command="{Binding ExportCommand}"/>
         </StackPanel>
     </Grid>
 </Window>

--- a/ViewModels/EadViewModel.cs
+++ b/ViewModels/EadViewModel.cs
@@ -62,7 +62,15 @@ namespace EconToolbox.Desktop.ViewModels
             _removeDamageColumnCommand = new RelayCommand(RemoveDamageColumn, () => DamageColumns.Count > 1);
             ComputeCommand = new RelayCommand(Compute);
             ExportCommand = new RelayCommand(Export);
+            DamageColumns.CollectionChanged += DamageColumns_CollectionChanged;
             AddDamageColumn(); // start with one damage column
+        }
+
+        private void DamageColumns_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        {
+            _removeDamageColumnCommand.RaiseCanExecuteChanged();
+            if (e.Action == NotifyCollectionChangedAction.Replace)
+                Compute();
         }
 
         private void Rows_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)

--- a/ViewModels/WaterDemandViewModel.cs
+++ b/ViewModels/WaterDemandViewModel.cs
@@ -104,7 +104,6 @@ namespace EconToolbox.Desktop.ViewModels
 
         public WaterDemandViewModel()
         {
-            LoadHistoricalFromWorkbook();
             ForecastCommand = new RelayCommand(Forecast);
             ExportCommand = new RelayCommand(Export);
             ComputeCommand = ForecastCommand;

--- a/Views/EadView.xaml.cs
+++ b/Views/EadView.xaml.cs
@@ -60,9 +60,16 @@ namespace EconToolbox.Desktop.Views
             }
             for (int i = 0; i < vm.DamageColumns.Count; i++)
             {
+                var headerBox = new TextBox { MinWidth = 80 };
+                BindingOperations.SetBinding(headerBox, TextBox.TextProperty, new Binding($"DamageColumns[{i}]")
+                {
+                    Source = vm,
+                    Mode = BindingMode.TwoWay,
+                    UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged
+                });
                 EadDataGrid.Columns.Add(new DataGridTextColumn
                 {
-                    Header = vm.DamageColumns[i],
+                    Header = headerBox,
                     Binding = new Binding($"Damages[{i}]")
                 });
             }

--- a/Views/UdvView.xaml
+++ b/Views/UdvView.xaml
@@ -29,23 +29,14 @@
             <Button Content="Compute" Command="{Binding ComputeCommand}"/>
         </StackPanel>
         <TextBlock Text="{Binding Result}" Grid.Row="4"/>
-        <Grid Grid.Row="5">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="2*"/>
-                <ColumnDefinition Width="3*"/>
-            </Grid.ColumnDefinitions>
-            <DataGrid ItemsSource="{Binding Table}" AutoGenerateColumns="False" CanUserAddRows="False" Grid.Column="0" Margin="0,0,5,0">
-                <DataGrid.Columns>
-                    <DataGridTextColumn Header="Points" Binding="{Binding Points}"/>
-                    <DataGridTextColumn Header="General Recreation" Binding="{Binding GeneralRecreation}"/>
-                    <DataGridTextColumn Header="General Fishing &amp; Hunting" Binding="{Binding GeneralFishingHunting}"/>
-                    <DataGridTextColumn Header="Specialized Fishing &amp; Hunting" Binding="{Binding SpecializedFishingHunting}"/>
-                    <DataGridTextColumn Header="Specialized Recreation" Binding="{Binding SpecializedRecreation}"/>
-                </DataGrid.Columns>
-            </DataGrid>
-            <Canvas Grid.Column="1" Width="200" Height="120" Background="WhiteSmoke" Margin="5,0,0,0">
-                <Polyline Points="{Binding ChartPoints}" Stroke="Blue" StrokeThickness="2"/>
-            </Canvas>
-        </Grid>
+        <DataGrid Grid.Row="5" ItemsSource="{Binding Table}" AutoGenerateColumns="False" CanUserAddRows="False">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="Points" Binding="{Binding Points}"/>
+                <DataGridTextColumn Header="General Recreation" Binding="{Binding GeneralRecreation}"/>
+                <DataGridTextColumn Header="General Fishing &amp; Hunting" Binding="{Binding GeneralFishingHunting}"/>
+                <DataGridTextColumn Header="Specialized Fishing &amp; Hunting" Binding="{Binding SpecializedFishingHunting}"/>
+                <DataGridTextColumn Header="Specialized Recreation" Binding="{Binding SpecializedRecreation}"/>
+            </DataGrid.Columns>
+        </DataGrid>
     </Grid>
 </UserControl>

--- a/Views/UpdatedCostView.xaml
+++ b/Views/UpdatedCostView.xaml
@@ -128,16 +128,31 @@
                 <TextBlock Text="Analysis Period 2" Grid.Row="3" Margin="0,0,5,5"/>
                 <TextBox Text="{Binding AnalysisPeriod2}" Grid.Row="3" Grid.Column="1" Margin="0,0,0,5"/>
                 <Button Content="Compute" Command="{Binding ComputeTotalCommand}" Grid.Row="4" Grid.ColumnSpan="2" Margin="0,5,0,5"/>
-                <StackPanel Grid.Row="5" Grid.ColumnSpan="2">
-                    <TextBlock Text="{Binding Percent, StringFormat=P: {0:F5}}" ToolTip="Percent = Storage Recommendation / Total Usable Storage"/>
-                    <TextBlock Text="{Binding CostRecommendation, StringFormat=Cost of Storage Recommendation: {0:C2}}" ToolTip="Cost Recommendation = Total Updated Cost × Percent"/>
-                    <TextBlock Text="{Binding Capital1, StringFormat=Annualized Storage Cost 1: {0:C2}}" ToolTip="Annualized Storage Cost 1 = Total Updated Cost × Percent × CRF1"/>
-                    <TextBlock Text="{Binding OmScaled, StringFormat=Joint O&amp;M: {0:C2}}" ToolTip="Joint O&amp;M = Total Joint O&amp;M × Percent"/>
-                    <TextBlock Text="{Binding RrrScaled, StringFormat=Annualized RR&amp;R/Mitigation: {0:C2}}" ToolTip="Annualized RR&amp;R/Mitigation = RRR Annualized × Percent"/>
-                    <TextBlock Text="{Binding Total1, StringFormat=Total Annual Cost 1: {0:C2}}" ToolTip="Total Annual Cost 1 = Capital1 + Joint O&amp;M + Annualized RR&amp;R/Mitigation"/>
-                    <TextBlock Text="{Binding Capital2, StringFormat=Annualized Storage Cost 2: {0:C2}}" ToolTip="Annualized Storage Cost 2 = Total Updated Cost × Percent × CRF2"/>
-                    <TextBlock Text="{Binding Total2, StringFormat=Total Annual Cost 2: {0:C2}}" ToolTip="Total Annual Cost 2 = Capital2 + Joint O&amp;M"/>
-                </StackPanel>
+                <Grid Grid.Row="5" Grid.ColumnSpan="2">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <GroupBox Header="Cost 1" Grid.Column="0" Margin="0,0,5,0">
+                        <StackPanel>
+                            <TextBlock Text="{Binding Percent, StringFormat=P: {0:F5}}" ToolTip="Percent = Storage Recommendation / Total Usable Storage"/>
+                            <TextBlock Text="{Binding CostRecommendation, StringFormat=Cost of Storage Recommendation: {0:C2}}" ToolTip="Cost Recommendation = Total Updated Cost × Percent"/>
+                            <TextBlock Text="{Binding Capital1, StringFormat=Annualized Storage Cost 1: {0:C2}}" ToolTip="Annualized Storage Cost 1 = Total Updated Cost × Percent × CRF1"/>
+                            <TextBlock Text="{Binding OmScaled, StringFormat=Joint O&amp;M: {0:C2}}" ToolTip="Joint O&amp;M = Total Joint O&amp;M × Percent"/>
+                            <TextBlock Text="{Binding RrrScaled, StringFormat=Annualized RR&amp;R/Mitigation: {0:C2}}" ToolTip="Annualized RR&amp;R/Mitigation = RRR Annualized × Percent"/>
+                            <TextBlock Text="{Binding Total1, StringFormat=Total Annual Cost 1: {0:C2}}" ToolTip="Total Annual Cost 1 = Capital1 + Joint O&amp;M + Annualized RR&amp;R/Mitigation"/>
+                        </StackPanel>
+                    </GroupBox>
+                    <GroupBox Header="Cost 2" Grid.Column="1" Margin="5,0,0,0">
+                        <StackPanel>
+                            <TextBlock Text="{Binding Percent, StringFormat=P: {0:F5}}" ToolTip="Percent = Storage Recommendation / Total Usable Storage"/>
+                            <TextBlock Text="{Binding CostRecommendation, StringFormat=Cost of Storage Recommendation: {0:C2}}" ToolTip="Cost Recommendation = Total Updated Cost × Percent"/>
+                            <TextBlock Text="{Binding Capital2, StringFormat=Annualized Storage Cost 2: {0:C2}}" ToolTip="Annualized Storage Cost 2 = Total Updated Cost × Percent × CRF2"/>
+                            <TextBlock Text="{Binding OmScaled, StringFormat=Joint O&amp;M: {0:C2}}" ToolTip="Joint O&amp;M = Total Joint O&amp;M × Percent"/>
+                            <TextBlock Text="{Binding Total2, StringFormat=Total Annual Cost 2: {0:C2}}" ToolTip="Total Annual Cost 2 = Capital2 + Joint O&amp;M"/>
+                        </StackPanel>
+                    </GroupBox>
+                </Grid>
             </Grid>
         </TabItem>
         </TabControl>

--- a/Views/WaterDemandView.xaml
+++ b/Views/WaterDemandView.xaml
@@ -41,28 +41,28 @@
                     </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="80"/>
+                        <ColumnDefinition Width="*"/>
                     </Grid.ColumnDefinitions>
 
                     <TextBlock Text="Forecast Years" Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                    <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding ForecastYears}" Margin="0,0,10,0" Width="80" HorizontalAlignment="Left"/>
+                    <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding ForecastYears}" Margin="0,0,10,0" HorizontalAlignment="Left"/>
 
                     <CheckBox Content="Use Growth Rate" Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" IsChecked="{Binding UseGrowthRate}" VerticalAlignment="Center" HorizontalAlignment="Left"/>
 
                     <TextBlock Text="Standard Growth Rate" Grid.Row="2" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                    <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding StandardGrowthRate}" Width="80" HorizontalAlignment="Left"/>
+                    <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding StandardGrowthRate}" HorizontalAlignment="Left"/>
 
                     <TextBlock Text="Current Industrial %" Grid.Row="3" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                    <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding CurrentIndustrialPercent}" Margin="0,0,10,0" Width="80" HorizontalAlignment="Left"/>
+                    <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding CurrentIndustrialPercent}" Margin="0,0,10,0" HorizontalAlignment="Left"/>
 
                     <TextBlock Text="Future Industrial %" Grid.Row="4" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                    <TextBox Grid.Row="4" Grid.Column="1" Text="{Binding FutureIndustrialPercent}" Width="80" HorizontalAlignment="Left"/>
+                    <TextBox Grid.Row="4" Grid.Column="1" Text="{Binding FutureIndustrialPercent}" HorizontalAlignment="Left"/>
 
                     <TextBlock Text="Improvements %" Grid.Row="5" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                    <TextBox Grid.Row="5" Grid.Column="1" Text="{Binding SystemImprovementsPercent}" Margin="0,0,10,0" Width="80" HorizontalAlignment="Left"/>
+                    <TextBox Grid.Row="5" Grid.Column="1" Text="{Binding SystemImprovementsPercent}" Margin="0,0,10,0" HorizontalAlignment="Left"/>
 
                     <TextBlock Text="Losses %" Grid.Row="6" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                    <TextBox Grid.Row="6" Grid.Column="1" Text="{Binding SystemLossesPercent}" Width="80" HorizontalAlignment="Left"/>
+                    <TextBox Grid.Row="6" Grid.Column="1" Text="{Binding SystemLossesPercent}" HorizontalAlignment="Left"/>
 
                     <StackPanel Grid.Row="7" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Left">
                         <Button Content="Forecast" Width="80" Command="{Binding ForecastCommand}" Margin="0,0,5,0"/>


### PR DESCRIPTION
## Summary
- Remove Unit Day Value graph and let its points table span the entire view.
- Clear Water Demand historical data, align its forecast inputs, and keep bottom Export button width in sync with Calculate.
- Allow editable EAD damage column headers and recompute results when those headings change.
- Display Total Annual Cost outputs in side-by-side columns for Cost 1 and Cost 2.

## Testing
- `dotnet build` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c42f3a101c8330a1e685e9f67bf0cd