### PR TITLE
Fix ClosedXML package version and unused variable warning

### DIFF
--- a/EconToolbox.Desktop.csproj
+++ b/EconToolbox.Desktop.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ClosedXML" Version="0.102.4" />
+    <PackageReference Include="ClosedXML" Version="0.104.0" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Practical Forecast Exercise - Tables 6-28-18.xlsx">

--- a/ViewModels/AnnualizerViewModel.cs
+++ b/ViewModels/AnnualizerViewModel.cs
@@ -194,7 +194,7 @@ namespace EconToolbox.Desktop.ViewModels
                     $"BCR: {Bcr:F2}"
                 };
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 Idc = TotalInvestment = Crf = AnnualCost = Bcr = double.NaN;
                 Results = new ObservableCollection<string> { "Error computing results" };


### PR DESCRIPTION
## Summary
- Use ClosedXML 0.104.0 to match restored package
- Remove unused exception variable in `AnnualizerViewModel`

## Testing
- ⚠️ `dotnet build EconToolbox.Desktop.csproj /property:GenerateFullPaths=true /p:Configuration=Debug /p:Platform="AnyCPU" /consoleloggerparameters:NoSummary` *(dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c430e28e6c833088cdeeca6965474e