### PR TITLE
Use months for IDC schedule in annualizer

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -65,7 +65,7 @@
                     <DataGrid ItemsSource="{Binding IdcEntries}" Grid.Row="7" Grid.Column="1" AutoGenerateColumns="False" Margin="0,0,0,5" VerticalAlignment="Stretch">
                         <DataGrid.Columns>
                             <DataGridTextColumn Header="Cost" Binding="{Binding Cost}"/>
-                            <DataGridTextColumn Header="Year" Binding="{Binding Year}"/>
+                            <DataGridTextColumn Header="Month" Binding="{Binding Year}"/>
                             <DataGridComboBoxColumn Header="Timing" SelectedItemBinding="{Binding Timing}">
                                 <DataGridComboBoxColumn.ItemsSource>
                                     <x:Array Type="sys:String" xmlns:sys="clr-namespace:System;assembly=mscorlib">

--- a/ViewModels/AnnualizerViewModel.cs
+++ b/ViewModels/AnnualizerViewModel.cs
@@ -154,7 +154,7 @@ namespace EconToolbox.Desktop.ViewModels
         private void UpdatePvFactors()
         {
             double r = Rate / 100.0;
-            foreach (var entry in FutureCosts.Concat(IdcEntries))
+            foreach (var entry in FutureCosts)
             {
                 double offset = entry.Timing switch
                 {
@@ -163,6 +163,18 @@ namespace EconToolbox.Desktop.ViewModels
                     _ => 1.0
                 };
                 entry.PvFactor = Math.Pow(1.0 + r, -(entry.Year + offset));
+            }
+
+            foreach (var entry in IdcEntries)
+            {
+                double offsetMonths = entry.Timing switch
+                {
+                    "beginning" => 0.0,
+                    "midpoint" => 0.5,
+                    _ => 1.0
+                };
+                double months = entry.Year + offsetMonths;
+                entry.PvFactor = Math.Pow(1.0 + r, -(months / 12.0));
             }
         }
 


### PR DESCRIPTION
## Summary
- Switch IDC schedule column header from Year to Month to reflect construction period units
- Calculate IDC PV factors based on months instead of years

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c456abc7a08330b6985d97e165e9f4