### PR TITLE
Auto-fill EAD damage values for auto-populated probabilities

### DIFF
--- a/Models/EadModel.cs
+++ b/Models/EadModel.cs
@@ -26,13 +26,16 @@ namespace EconToolbox.Desktop.Models
                     throw new ArgumentException("Probabilities must be between 0 and 1");
             }
 
-            // Insert 100% probability if missing
-            if (pairs[0].p < 1.0)
-                pairs.Insert(0, (1.0, pairs[0].d));
+            // Track the maximum damage to auto-fill the 0% probability row
+            double maxDamage = pairs.Max(t => t.d);
 
-            // Append 0% probability with zero damage if missing
+            // Insert 100% probability with $0 damage if missing
+            if (pairs[0].p < 1.0)
+                pairs.Insert(0, (1.0, 0.0));
+
+            // Append 0% probability with the highest damage if missing
             if (pairs[^1].p > 0.0)
-                pairs.Add((0.0, 0.0));
+                pairs.Add((0.0, maxDamage));
 
             // Compute EAD using the trapezoidal rule
             double sum = 0.0;

--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ EAD integrates a probability–damage curve assuming probabilities are ordered f
 
 where \(d_k\) are damages and \(p_k\) the associated exceedance probabilities.
 
+If 100% or 0% probability points are omitted, the tool automatically inserts
+a 100% probability with $0 damage and a 0% probability with the maximum damage
+value from the column.
+
 ### Updated Cost of Storage
 
 Updated cost for reallocated storage is computed as:


### PR DESCRIPTION
## Summary
- Ensure EAD calculations auto-fill damage values when 100% or 0% probabilities are inserted
- Document automatic filling of extreme probability rows in README

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c47d674b0c8330a10117131816cdc9