### PR TITLE
fix: correct picture handling in Excel exporter

### DIFF
--- a/Services/ExcelExporter.cs
+++ b/Services/ExcelExporter.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using ClosedXML.Excel;
+using ClosedXML.Excel.Drawings;
 using EconToolbox.Desktop.Models;
 using System.Linq;
 using EconToolbox.Desktop.ViewModels;
@@ -335,7 +336,7 @@ namespace EconToolbox.Desktop.Services
             byte[] img = CreateEadChartImage(stagePoints, frequencyPoints);
             using var stream = new MemoryStream(img);
             var pic = ws.AddPicture(stream, XLPictureFormat.Png, "EADChart");
-            pic.MoveTo(ws.Cell(row, column).Address);
+            pic.MoveTo(ws.Cell(row, column));
         }
 
         private static byte[] CreateEadChartImage(PointCollection stagePoints, PointCollection frequencyPoints)


### PR DESCRIPTION
## Summary
- add missing ClosedXML drawings reference
- correct `MoveTo` usage when positioning chart images

## Testing
- `dotnet build EconToolbox.Desktop.csproj /property:GenerateFullPaths=true /p:Configuration=Debug /p:Platform="AnyCPU" /consoleloggerparameters:NoSummary` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c48693daec8330b83be0407fd07819