### PR TITLE
Align water demand forecasting inputs

### DIFF
--- a/Views/WaterDemandView.xaml
+++ b/Views/WaterDemandView.xaml
@@ -41,28 +41,35 @@
                     </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
                     </Grid.ColumnDefinitions>
+                    <Grid.Resources>
+                        <Style TargetType="TextBox">
+                            <Setter Property="Width" Value="120"/>
+                            <Setter Property="HorizontalAlignment" Value="Left"/>
+                            <Setter Property="Margin" Value="0,0,10,0"/>
+                        </Style>
+                    </Grid.Resources>
 
                     <TextBlock Text="Forecast Years" Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                    <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding ForecastYears}" Margin="0,0,10,0" HorizontalAlignment="Left"/>
+                    <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding ForecastYears}"/>
 
                     <CheckBox Content="Use Growth Rate" Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" IsChecked="{Binding UseGrowthRate}" VerticalAlignment="Center" HorizontalAlignment="Left"/>
 
                     <TextBlock Text="Standard Growth Rate" Grid.Row="2" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                    <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding StandardGrowthRate}" HorizontalAlignment="Left"/>
+                    <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding StandardGrowthRate}"/>
 
                     <TextBlock Text="Current Industrial %" Grid.Row="3" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                    <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding CurrentIndustrialPercent}" Margin="0,0,10,0" HorizontalAlignment="Left"/>
+                    <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding CurrentIndustrialPercent}"/>
 
                     <TextBlock Text="Future Industrial %" Grid.Row="4" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                    <TextBox Grid.Row="4" Grid.Column="1" Text="{Binding FutureIndustrialPercent}" HorizontalAlignment="Left"/>
+                    <TextBox Grid.Row="4" Grid.Column="1" Text="{Binding FutureIndustrialPercent}"/>
 
                     <TextBlock Text="Improvements %" Grid.Row="5" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                    <TextBox Grid.Row="5" Grid.Column="1" Text="{Binding SystemImprovementsPercent}" Margin="0,0,10,0" HorizontalAlignment="Left"/>
+                    <TextBox Grid.Row="5" Grid.Column="1" Text="{Binding SystemImprovementsPercent}"/>
 
                     <TextBlock Text="Losses %" Grid.Row="6" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                    <TextBox Grid.Row="6" Grid.Column="1" Text="{Binding SystemLossesPercent}" HorizontalAlignment="Left"/>
+                    <TextBox Grid.Row="6" Grid.Column="1" Text="{Binding SystemLossesPercent}"/>
 
                     <StackPanel Grid.Row="7" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Left">
                         <Button Content="Forecast" Width="80" Command="{Binding ForecastCommand}" Margin="0,0,5,0"/>


### PR DESCRIPTION
## Summary
- ensure water demand forecasting inputs use a consistent style
- align input text boxes vertically and size them uniformly

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c488dd0b1083309a4fc76331629c6b