### PR TITLE
Add water demand growth rate inputs and forecast formula

### DIFF
--- a/Views/WaterDemandView.xaml
+++ b/Views/WaterDemandView.xaml
@@ -41,6 +41,8 @@
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
                     </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto"/>
@@ -76,23 +78,31 @@
                     <TextBox Grid.Row="5" Grid.Column="1" Text="{Binding BasePerCapitaDemand}"/>
                     <TextBlock Text="gallons/person/day" Grid.Row="5" Grid.Column="2" VerticalAlignment="Center"/>
 
-                    <TextBlock Text="Current Industrial %" Grid.Row="6" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                    <TextBox Grid.Row="6" Grid.Column="1" Text="{Binding CurrentIndustrialPercent}"/>
+                    <TextBlock Text="Population Growth %" Grid.Row="6" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                    <TextBox Grid.Row="6" Grid.Column="1" Text="{Binding PopulationGrowthRate}"/>
                     <TextBlock Text="%" Grid.Row="6" Grid.Column="2" VerticalAlignment="Center"/>
 
-                    <TextBlock Text="Future Industrial %" Grid.Row="7" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                    <TextBox Grid.Row="7" Grid.Column="1" Text="{Binding FutureIndustrialPercent}"/>
+                    <TextBlock Text="Per Capita Change %" Grid.Row="7" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                    <TextBox Grid.Row="7" Grid.Column="1" Text="{Binding PerCapitaDemandChangeRate}"/>
                     <TextBlock Text="%" Grid.Row="7" Grid.Column="2" VerticalAlignment="Center"/>
 
-                    <TextBlock Text="Improvements %" Grid.Row="8" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                    <TextBox Grid.Row="8" Grid.Column="1" Text="{Binding SystemImprovementsPercent}"/>
+                    <TextBlock Text="Current Industrial %" Grid.Row="8" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                    <TextBox Grid.Row="8" Grid.Column="1" Text="{Binding CurrentIndustrialPercent}"/>
                     <TextBlock Text="%" Grid.Row="8" Grid.Column="2" VerticalAlignment="Center"/>
 
-                    <TextBlock Text="Losses %" Grid.Row="9" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                    <TextBox Grid.Row="9" Grid.Column="1" Text="{Binding SystemLossesPercent}"/>
+                    <TextBlock Text="Future Industrial %" Grid.Row="9" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                    <TextBox Grid.Row="9" Grid.Column="1" Text="{Binding FutureIndustrialPercent}"/>
                     <TextBlock Text="%" Grid.Row="9" Grid.Column="2" VerticalAlignment="Center"/>
 
-                    <StackPanel Grid.Row="10" Grid.ColumnSpan="3" Orientation="Horizontal" HorizontalAlignment="Left">
+                    <TextBlock Text="Improvements %" Grid.Row="10" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                    <TextBox Grid.Row="10" Grid.Column="1" Text="{Binding SystemImprovementsPercent}"/>
+                    <TextBlock Text="%" Grid.Row="10" Grid.Column="2" VerticalAlignment="Center"/>
+
+                    <TextBlock Text="Losses %" Grid.Row="11" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                    <TextBox Grid.Row="11" Grid.Column="1" Text="{Binding SystemLossesPercent}"/>
+                    <TextBlock Text="%" Grid.Row="11" Grid.Column="2" VerticalAlignment="Center"/>
+
+                    <StackPanel Grid.Row="12" Grid.ColumnSpan="3" Orientation="Horizontal" HorizontalAlignment="Left">
                         <Button Content="Forecast" Width="80" Command="{Binding ForecastCommand}" Margin="0,0,5,0"/>
                         <Button Content="Export" Width="80" Command="{Binding ExportCommand}"/>
                     </StackPanel>


### PR DESCRIPTION
## Summary
- add population and per-capita growth rate properties with UI inputs
- compute forecast using combined population and per-capita growth formula
- update explanation to describe new demand calculation

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c490236c08833083317fb6ca580fb7