### PR TITLE
Add sectoral water demand percentages

### DIFF
--- a/Models/DemandEntry.cs
+++ b/Models/DemandEntry.cs
@@ -4,7 +4,10 @@ namespace EconToolbox.Desktop.Models
     {
         private int _year;
         private double _demand;
+        private double _residentialDemand;
+        private double _commercialDemand;
         private double _industrialDemand;
+        private double _agriculturalDemand;
         private double _adjustedDemand;
         private double _growthRate;
 
@@ -20,10 +23,28 @@ namespace EconToolbox.Desktop.Models
             set { _demand = value; OnPropertyChanged(); }
         }
 
+        public double ResidentialDemand
+        {
+            get => _residentialDemand;
+            set { _residentialDemand = value; OnPropertyChanged(); }
+        }
+
+        public double CommercialDemand
+        {
+            get => _commercialDemand;
+            set { _commercialDemand = value; OnPropertyChanged(); }
+        }
+
         public double IndustrialDemand
         {
             get => _industrialDemand;
             set { _industrialDemand = value; OnPropertyChanged(); }
+        }
+
+        public double AgriculturalDemand
+        {
+            get => _agriculturalDemand;
+            set { _agriculturalDemand = value; OnPropertyChanged(); }
         }
 
         public double AdjustedDemand

--- a/Services/ExcelExporter.cs
+++ b/Services/ExcelExporter.cs
@@ -32,18 +32,27 @@ namespace EconToolbox.Desktop.Services
             var ws = wb.Worksheets.Add("WaterDemand");
             ws.Cell(1,1).Value = "Year";
             ws.Cell(1,2).Value = "Demand";
-            ws.Cell(1,3).Value = "Industrial";
-            ws.Cell(1,4).Value = "Adjusted";
+            ws.Cell(1,3).Value = "Residential";
+            ws.Cell(1,4).Value = "Commercial";
+            ws.Cell(1,5).Value = "Industrial";
+            ws.Cell(1,6).Value = "Agricultural";
+            ws.Cell(1,7).Value = "Adjusted";
             ws.Cell(1,2).GetComment().AddText("Demand = Prior Demand × (1 + Growth Rate)");
-            ws.Cell(1,3).GetComment().AddText("Industrial = Demand × Industrial %");
-            ws.Cell(1,4).GetComment().AddText("Adjusted = Demand × (1 - Improvements %) × (1 - Losses %)");
+            ws.Cell(1,3).GetComment().AddText("Residential = Demand × Residential %");
+            ws.Cell(1,4).GetComment().AddText("Commercial = Demand × Commercial %");
+            ws.Cell(1,5).GetComment().AddText("Industrial = Demand × Industrial %");
+            ws.Cell(1,6).GetComment().AddText("Agricultural = Demand × Agricultural %");
+            ws.Cell(1,7).GetComment().AddText("Adjusted = Demand × (1 - Improvements %) × (1 - Losses %)");
             int row = 2;
             foreach(var d in data)
             {
                 ws.Cell(row,1).Value = d.Year;
                 ws.Cell(row,2).Value = d.Demand;
-                ws.Cell(row,3).Value = d.IndustrialDemand;
-                ws.Cell(row,4).Value = d.AdjustedDemand;
+                ws.Cell(row,3).Value = d.ResidentialDemand;
+                ws.Cell(row,4).Value = d.CommercialDemand;
+                ws.Cell(row,5).Value = d.IndustrialDemand;
+                ws.Cell(row,6).Value = d.AgriculturalDemand;
+                ws.Cell(row,7).Value = d.AdjustedDemand;
                 row++;
             }
             wb.SaveAs(filePath);

--- a/ViewModels/WaterDemandViewModel.cs
+++ b/ViewModels/WaterDemandViewModel.cs
@@ -28,6 +28,12 @@ namespace EconToolbox.Desktop.ViewModels
         private string _explanation = string.Empty;
         private double _currentIndustrialPercent;
         private double _futureIndustrialPercent;
+        private double _currentResidentialPercent;
+        private double _futureResidentialPercent;
+        private double _currentCommercialPercent;
+        private double _futureCommercialPercent;
+        private double _currentAgriculturalPercent;
+        private double _futureAgriculturalPercent;
         private double _systemImprovementsPercent;
         private double _systemLossesPercent;
         private double _standardGrowthRate;
@@ -83,6 +89,42 @@ namespace EconToolbox.Desktop.ViewModels
         {
             get => _futureIndustrialPercent;
             set { _futureIndustrialPercent = value; OnPropertyChanged(); }
+        }
+
+        public double CurrentResidentialPercent
+        {
+            get => _currentResidentialPercent;
+            set { _currentResidentialPercent = value; OnPropertyChanged(); }
+        }
+
+        public double FutureResidentialPercent
+        {
+            get => _futureResidentialPercent;
+            set { _futureResidentialPercent = value; OnPropertyChanged(); }
+        }
+
+        public double CurrentCommercialPercent
+        {
+            get => _currentCommercialPercent;
+            set { _currentCommercialPercent = value; OnPropertyChanged(); }
+        }
+
+        public double FutureCommercialPercent
+        {
+            get => _futureCommercialPercent;
+            set { _futureCommercialPercent = value; OnPropertyChanged(); }
+        }
+
+        public double CurrentAgriculturalPercent
+        {
+            get => _currentAgriculturalPercent;
+            set { _currentAgriculturalPercent = value; OnPropertyChanged(); }
+        }
+
+        public double FutureAgriculturalPercent
+        {
+            get => _futureAgriculturalPercent;
+            set { _futureAgriculturalPercent = value; OnPropertyChanged(); }
         }
 
         public double SystemImprovementsPercent
@@ -189,8 +231,20 @@ namespace EconToolbox.Desktop.ViewModels
                     double industrialPercent = ForecastYears <= 0
                         ? CurrentIndustrialPercent
                         : CurrentIndustrialPercent + (FutureIndustrialPercent - CurrentIndustrialPercent) * t / (double)ForecastYears;
+                    double residentialPercent = ForecastYears <= 0
+                        ? CurrentResidentialPercent
+                        : CurrentResidentialPercent + (FutureResidentialPercent - CurrentResidentialPercent) * t / (double)ForecastYears;
+                    double commercialPercent = ForecastYears <= 0
+                        ? CurrentCommercialPercent
+                        : CurrentCommercialPercent + (FutureCommercialPercent - CurrentCommercialPercent) * t / (double)ForecastYears;
+                    double agriculturalPercent = ForecastYears <= 0
+                        ? CurrentAgriculturalPercent
+                        : CurrentAgriculturalPercent + (FutureAgriculturalPercent - CurrentAgriculturalPercent) * t / (double)ForecastYears;
 
                     double industrialDemand = demand * industrialPercent / 100.0;
+                    double residentialDemand = demand * residentialPercent / 100.0;
+                    double commercialDemand = demand * commercialPercent / 100.0;
+                    double agriculturalDemand = demand * agriculturalPercent / 100.0;
                     double adjusted = demand * (1 + SystemLossesPercent / 100.0) * (1 - SystemImprovementsPercent / 100.0);
                     double growthRate = t == 0 ? 0 : (demand / Results[t - 1].Demand - 1) * 100.0;
 
@@ -198,7 +252,10 @@ namespace EconToolbox.Desktop.ViewModels
                     {
                         Year = year,
                         Demand = demand,
+                        ResidentialDemand = residentialDemand,
+                        CommercialDemand = commercialDemand,
                         IndustrialDemand = industrialDemand,
+                        AgriculturalDemand = agriculturalDemand,
                         AdjustedDemand = adjusted,
                         GrowthRate = growthRate
                     });
@@ -210,7 +267,10 @@ namespace EconToolbox.Desktop.ViewModels
                     "Population = BasePopulation × (1 + PopulationGrowthRate)^t, " +
                     "Per Capita = BasePerCapitaDemand × (1 + PerCapitaDemandChangeRate)^t, " +
                     "Total Demand = Population × Per Capita. " +
-                    $"Industrial share interpolated from {CurrentIndustrialPercent:F1}% to {FutureIndustrialPercent:F1}% " +
+                    $"Shares interpolated: Res {CurrentResidentialPercent:F1}%→{FutureResidentialPercent:F1}%, " +
+                    $"Com {CurrentCommercialPercent:F1}%→{FutureCommercialPercent:F1}%, " +
+                    $"Ind {CurrentIndustrialPercent:F1}%→{FutureIndustrialPercent:F1}%, " +
+                    $"Ag {CurrentAgriculturalPercent:F1}%→{FutureAgriculturalPercent:F1}% " +
                     $"with {SystemImprovementsPercent:F1}% improvements and {SystemLossesPercent:F1}% losses.";
             }
             catch
@@ -251,18 +311,27 @@ namespace EconToolbox.Desktop.ViewModels
                 double rate = Results[i].GrowthRate / 100.0;
                 Results[i].Demand = baseDemand * (1 + rate);
 
-                double industrialPercent;
-                if (Results[i].Year <= lastHistYear)
-                {
-                    industrialPercent = CurrentIndustrialPercent;
-                }
-                else
-                {
-                    double t = ForecastYears <= 1 ? 1 : (i - forecastStartIndex) / (double)(ForecastYears - 1);
-                    industrialPercent = CurrentIndustrialPercent + (FutureIndustrialPercent - CurrentIndustrialPercent) * t;
-                }
+                double t = Results[i].Year <= lastHistYear
+                    ? 0
+                    : (ForecastYears <= 1 ? 1 : (i - forecastStartIndex) / (double)(ForecastYears - 1));
+
+                double industrialPercent = Results[i].Year <= lastHistYear
+                    ? CurrentIndustrialPercent
+                    : CurrentIndustrialPercent + (FutureIndustrialPercent - CurrentIndustrialPercent) * t;
+                double residentialPercent = Results[i].Year <= lastHistYear
+                    ? CurrentResidentialPercent
+                    : CurrentResidentialPercent + (FutureResidentialPercent - CurrentResidentialPercent) * t;
+                double commercialPercent = Results[i].Year <= lastHistYear
+                    ? CurrentCommercialPercent
+                    : CurrentCommercialPercent + (FutureCommercialPercent - CurrentCommercialPercent) * t;
+                double agriculturalPercent = Results[i].Year <= lastHistYear
+                    ? CurrentAgriculturalPercent
+                    : CurrentAgriculturalPercent + (FutureAgriculturalPercent - CurrentAgriculturalPercent) * t;
 
                 Results[i].IndustrialDemand = Results[i].Demand * industrialPercent / 100.0;
+                Results[i].ResidentialDemand = Results[i].Demand * residentialPercent / 100.0;
+                Results[i].CommercialDemand = Results[i].Demand * commercialPercent / 100.0;
+                Results[i].AgriculturalDemand = Results[i].Demand * agriculturalPercent / 100.0;
                 Results[i].AdjustedDemand = Results[i].Demand * (1 + SystemLossesPercent / 100.0) * (1 - SystemImprovementsPercent / 100.0);
             }
         }

--- a/Views/WaterDemandView.xaml
+++ b/Views/WaterDemandView.xaml
@@ -43,6 +43,12 @@
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
                     </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto"/>
@@ -94,15 +100,39 @@
                     <TextBox Grid.Row="9" Grid.Column="1" Text="{Binding FutureIndustrialPercent}"/>
                     <TextBlock Text="%" Grid.Row="9" Grid.Column="2" VerticalAlignment="Center"/>
 
-                    <TextBlock Text="Improvements %" Grid.Row="10" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                    <TextBox Grid.Row="10" Grid.Column="1" Text="{Binding SystemImprovementsPercent}"/>
+                    <TextBlock Text="Current Residential %" Grid.Row="10" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                    <TextBox Grid.Row="10" Grid.Column="1" Text="{Binding CurrentResidentialPercent}"/>
                     <TextBlock Text="%" Grid.Row="10" Grid.Column="2" VerticalAlignment="Center"/>
 
-                    <TextBlock Text="Losses %" Grid.Row="11" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                    <TextBox Grid.Row="11" Grid.Column="1" Text="{Binding SystemLossesPercent}"/>
+                    <TextBlock Text="Future Residential %" Grid.Row="11" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                    <TextBox Grid.Row="11" Grid.Column="1" Text="{Binding FutureResidentialPercent}"/>
                     <TextBlock Text="%" Grid.Row="11" Grid.Column="2" VerticalAlignment="Center"/>
 
-                    <StackPanel Grid.Row="12" Grid.ColumnSpan="3" Orientation="Horizontal" HorizontalAlignment="Left">
+                    <TextBlock Text="Current Commercial %" Grid.Row="12" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                    <TextBox Grid.Row="12" Grid.Column="1" Text="{Binding CurrentCommercialPercent}"/>
+                    <TextBlock Text="%" Grid.Row="12" Grid.Column="2" VerticalAlignment="Center"/>
+
+                    <TextBlock Text="Future Commercial %" Grid.Row="13" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                    <TextBox Grid.Row="13" Grid.Column="1" Text="{Binding FutureCommercialPercent}"/>
+                    <TextBlock Text="%" Grid.Row="13" Grid.Column="2" VerticalAlignment="Center"/>
+
+                    <TextBlock Text="Current Agricultural %" Grid.Row="14" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                    <TextBox Grid.Row="14" Grid.Column="1" Text="{Binding CurrentAgriculturalPercent}"/>
+                    <TextBlock Text="%" Grid.Row="14" Grid.Column="2" VerticalAlignment="Center"/>
+
+                    <TextBlock Text="Future Agricultural %" Grid.Row="15" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                    <TextBox Grid.Row="15" Grid.Column="1" Text="{Binding FutureAgriculturalPercent}"/>
+                    <TextBlock Text="%" Grid.Row="15" Grid.Column="2" VerticalAlignment="Center"/>
+
+                    <TextBlock Text="Improvements %" Grid.Row="16" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                    <TextBox Grid.Row="16" Grid.Column="1" Text="{Binding SystemImprovementsPercent}"/>
+                    <TextBlock Text="%" Grid.Row="16" Grid.Column="2" VerticalAlignment="Center"/>
+
+                    <TextBlock Text="Losses %" Grid.Row="17" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                    <TextBox Grid.Row="17" Grid.Column="1" Text="{Binding SystemLossesPercent}"/>
+                    <TextBlock Text="%" Grid.Row="17" Grid.Column="2" VerticalAlignment="Center"/>
+
+                    <StackPanel Grid.Row="18" Grid.ColumnSpan="3" Orientation="Horizontal" HorizontalAlignment="Left">
                         <Button Content="Forecast" Width="80" Command="{Binding ForecastCommand}" Margin="0,0,5,0"/>
                         <Button Content="Export" Width="80" Command="{Binding ExportCommand}"/>
                     </StackPanel>
@@ -125,10 +155,31 @@
                                 </Style>
                             </DataGridTextColumn.ElementStyle>
                         </DataGridTextColumn>
+                        <DataGridTextColumn Header="Residential" Binding="{Binding ResidentialDemand, StringFormat={}{0:N2}}">
+                            <DataGridTextColumn.ElementStyle>
+                                <Style TargetType="TextBlock">
+                                    <Setter Property="ToolTip" Value="Residential = Demand × Residential %"/>
+                                </Style>
+                            </DataGridTextColumn.ElementStyle>
+                        </DataGridTextColumn>
+                        <DataGridTextColumn Header="Commercial" Binding="{Binding CommercialDemand, StringFormat={}{0:N2}}">
+                            <DataGridTextColumn.ElementStyle>
+                                <Style TargetType="TextBlock">
+                                    <Setter Property="ToolTip" Value="Commercial = Demand × Commercial %"/>
+                                </Style>
+                            </DataGridTextColumn.ElementStyle>
+                        </DataGridTextColumn>
                         <DataGridTextColumn Header="Industrial" Binding="{Binding IndustrialDemand, StringFormat={}{0:N2}}">
                             <DataGridTextColumn.ElementStyle>
                                 <Style TargetType="TextBlock">
                                     <Setter Property="ToolTip" Value="Industrial = Demand × Industrial %"/>
+                                </Style>
+                            </DataGridTextColumn.ElementStyle>
+                        </DataGridTextColumn>
+                        <DataGridTextColumn Header="Agricultural" Binding="{Binding AgriculturalDemand, StringFormat={}{0:N2}}">
+                            <DataGridTextColumn.ElementStyle>
+                                <Style TargetType="TextBlock">
+                                    <Setter Property="ToolTip" Value="Agricultural = Demand × Agricultural %"/>
                                 </Style>
                             </DataGridTextColumn.ElementStyle>
                         </DataGridTextColumn>


### PR DESCRIPTION
## Summary
- add residential, commercial, and agricultural percentages to water-demand forecasts
- compute sector demands with interpolated shares and export to Excel
- expand UI table to edit sector percentages and show each sector's demand

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c49983cba48330b455a2ba2dd2a2a2