### PR TITLE
Add StandardGrowthRate property to Scenario model

### DIFF
--- a/Models/Scenario.cs
+++ b/Models/Scenario.cs
@@ -15,6 +15,7 @@ namespace EconToolbox.Desktop.Models
         public double BasePerCapitaDemand { get; set; }
         public double PopulationGrowthRate { get; set; }
         public double PerCapitaDemandChangeRate { get; set; }
+        public double StandardGrowthRate { get; set; }
 
         public double CurrentIndustrialPercent { get; set; }
         public double FutureIndustrialPercent { get; set; }


### PR DESCRIPTION
## Summary
- add missing `StandardGrowthRate` property to `Scenario` model to support view model binding

## Testing
- `dotnet build EconToolbox.Desktop.csproj` *(fails: dotnet not installed; attempted apt-get but repositories are unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68c49caaa0988330802193a63794fe91