### PR TITLE
Improve scenario clarity and add scrollable views

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -3,7 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:vm="clr-namespace:EconToolbox.Desktop.ViewModels"
         xmlns:views="clr-namespace:EconToolbox.Desktop.Views"
-        Title="Economic Toolbox" Height="700" Width="1000" 
+        Title="Economic Toolbox" Height="700" Width="1000" ResizeMode="CanResize"
         Background="{StaticResource BackgroundBrush}" FontFamily="Segoe UI">
     <Window.DataContext>
         <vm:MainViewModel/>
@@ -13,7 +13,8 @@
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
-        <TabControl Margin="10" SelectedIndex="{Binding SelectedIndex}" Grid.Row="0" FontSize="14" Background="White">
+        <ScrollViewer Grid.Row="0" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
+            <TabControl Margin="10" SelectedIndex="{Binding SelectedIndex}" FontSize="14" Background="White">
             <TabItem Header="EAD" DataContext="{Binding Ead}">
                 <views:EadView/>
             </TabItem>
@@ -62,7 +63,7 @@
                     <TextBlock Text="Construction Months" Grid.Row="6" Margin="0,0,5,5"/>
                     <TextBox Text="{Binding ConstructionMonths}" Grid.Row="6" Grid.Column="1" Margin="0,0,0,5"/>
                     <TextBlock Text="IDC Schedule" Grid.Row="7" Margin="0,0,5,5"/>
-                    <DataGrid ItemsSource="{Binding IdcEntries}" Grid.Row="7" Grid.Column="1" AutoGenerateColumns="False" Margin="0,0,0,5" VerticalAlignment="Stretch">
+                    <DataGrid ItemsSource="{Binding IdcEntries}" Grid.Row="7" Grid.Column="1" AutoGenerateColumns="False" Margin="0,0,0,5" VerticalAlignment="Stretch" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto">
                         <DataGrid.Columns>
                             <DataGridTextColumn Header="Cost" Binding="{Binding Cost}"/>
                             <DataGridTextColumn Header="Month" Binding="{Binding Year}"/>
@@ -79,7 +80,7 @@
                         </DataGrid.Columns>
                     </DataGrid>
                     <TextBlock Text="Future Costs" Grid.Row="8" Margin="0,0,5,5"/>
-                    <DataGrid ItemsSource="{Binding FutureCosts}" Grid.Row="8" Grid.Column="1" AutoGenerateColumns="False" Margin="0,0,0,5" VerticalAlignment="Stretch">
+                    <DataGrid ItemsSource="{Binding FutureCosts}" Grid.Row="8" Grid.Column="1" AutoGenerateColumns="False" Margin="0,0,0,5" VerticalAlignment="Stretch" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto">
                         <DataGrid.Columns>
                             <DataGridTextColumn Header="Cost" Binding="{Binding Cost}"/>
                             <DataGridTextColumn Header="Year" Binding="{Binding Year}"/>
@@ -111,7 +112,8 @@
         <TabItem Header="Unit Day Value" DataContext="{Binding Udv}">
             <views:UdvView/>
         </TabItem>
-        </TabControl>
+            </TabControl>
+        </ScrollViewer>
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Grid.Row="1" Margin="10,0,10,10">
             <Button x:Name="CalculateButton" Content="Calculate" Width="100" Command="{Binding CalculateCommand}" Margin="0,0,5,0"/>
             <Button Content="Export" Width="{Binding ElementName=CalculateButton, Path=ActualWidth}" Command="{Binding ExportCommand}"/>

--- a/Models/Scenario.cs
+++ b/Models/Scenario.cs
@@ -9,6 +9,7 @@ namespace EconToolbox.Desktop.Models
     public class Scenario : ObservableObject
     {
         public string Name { get; set; } = string.Empty;
+        public string Description { get; set; } = string.Empty;
 
         public int BaseYear { get; set; }
         public double BasePopulation { get; set; }

--- a/ViewModels/WaterDemandViewModel.cs
+++ b/ViewModels/WaterDemandViewModel.cs
@@ -187,9 +187,24 @@ namespace EconToolbox.Desktop.ViewModels
 
         public WaterDemandViewModel()
         {
-            Scenarios.Add(new Scenario { Name = "Baseline", LineBrush = Brushes.Blue });
-            Scenarios.Add(new Scenario { Name = "Optimistic", LineBrush = Brushes.Green });
-            Scenarios.Add(new Scenario { Name = "Pessimistic", LineBrush = Brushes.Red });
+            Scenarios.Add(new Scenario
+            {
+                Name = "Baseline",
+                LineBrush = Brushes.Blue,
+                Description = "Most likely projection based on expected population and demand changes"
+            });
+            Scenarios.Add(new Scenario
+            {
+                Name = "Optimistic",
+                LineBrush = Brushes.Green,
+                Description = "Higher growth assumptions resulting in greater future demand"
+            });
+            Scenarios.Add(new Scenario
+            {
+                Name = "Pessimistic",
+                LineBrush = Brushes.Red,
+                Description = "Lower growth assumptions producing reduced future demand"
+            });
             SelectedScenario = Scenarios.FirstOrDefault();
 
             ForecastCommand = new RelayCommand(Forecast);

--- a/Views/EadView.xaml
+++ b/Views/EadView.xaml
@@ -1,7 +1,8 @@
 <UserControl x:Class="EconToolbox.Desktop.Views.EadView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    <Grid Margin="10">
+    <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
+        <Grid Margin="10">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
@@ -22,7 +23,7 @@
 
             <Border Grid.Column="0" Background="White" CornerRadius="4" Padding="5">
                 <DataGrid x:Name="EadDataGrid" ItemsSource="{Binding Rows}" AutoGenerateColumns="False"
-                          CanUserAddRows="True" CanUserDeleteRows="True"/>
+                          CanUserAddRows="True" CanUserDeleteRows="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto"/>
             </Border>
 
             <Border Grid.Column="1" Margin="10,0,0,0" Background="White" CornerRadius="4" Padding="5">
@@ -33,5 +34,6 @@
             </Border>
         </Grid>
         <ItemsControl ItemsSource="{Binding Results}" Grid.Row="3" Margin="0,5,0,0"/>
-    </Grid>
+        </Grid>
+    </ScrollViewer>
 </UserControl>

--- a/Views/UdvView.xaml
+++ b/Views/UdvView.xaml
@@ -1,7 +1,8 @@
 <UserControl x:Class="EconToolbox.Desktop.Views.UdvView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    <Grid Margin="10">
+    <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
+        <Grid Margin="10">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
@@ -29,7 +30,7 @@
             <Button Content="Compute" Command="{Binding ComputeCommand}"/>
         </StackPanel>
         <TextBlock Text="{Binding Result}" Grid.Row="4"/>
-        <DataGrid Grid.Row="5" ItemsSource="{Binding Table}" AutoGenerateColumns="False" CanUserAddRows="False">
+        <DataGrid Grid.Row="5" ItemsSource="{Binding Table}" AutoGenerateColumns="False" CanUserAddRows="False" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto">
             <DataGrid.Columns>
                 <DataGridTextColumn Header="Points" Binding="{Binding Points}"/>
                 <DataGridTextColumn Header="General Recreation" Binding="{Binding GeneralRecreation}"/>
@@ -38,5 +39,6 @@
                 <DataGridTextColumn Header="Specialized Recreation" Binding="{Binding SpecializedRecreation}"/>
             </DataGrid.Columns>
         </DataGrid>
-    </Grid>
+        </Grid>
+    </ScrollViewer>
 </UserControl>

--- a/Views/UpdatedCostView.xaml
+++ b/Views/UpdatedCostView.xaml
@@ -4,7 +4,8 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d">
-    <StackPanel>
+    <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
+        <StackPanel>
         <TextBlock Text="Complete each section and ensure year values are ascending. Use Calculate to process all sections." TextWrapping="Wrap" Margin="10,0,10,10"/>
         <TabControl Margin="10,0,10,10">
         <TabItem Header="Storage Cost">
@@ -54,7 +55,7 @@
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="*"/>
                 </Grid.RowDefinitions>
-                <DataGrid ItemsSource="{Binding UpdatedCostItems}" AutoGenerateColumns="False" Grid.Row="0" Height="150" Margin="0,0,0,5">
+                <DataGrid ItemsSource="{Binding UpdatedCostItems}" AutoGenerateColumns="False" Grid.Row="0" Height="150" Margin="0,0,0,5" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto">
                     <DataGrid.Columns>
                         <DataGridTextColumn Header="Category" Binding="{Binding Category}"/>
                         <DataGridTextColumn Header="Actual Cost" Binding="{Binding ActualCost}"/>
@@ -89,7 +90,7 @@
                 <TextBox Text="{Binding RrrCwcci}" Grid.Row="2" Grid.Column="1" Margin="0,0,0,5"/>
                 <TextBlock Text="Base Year" Grid.Row="3" Margin="0,0,5,5"/>
                 <TextBox Text="{Binding RrrBaseYear}" Grid.Row="3" Grid.Column="1" Margin="0,0,0,5"/>
-                <DataGrid ItemsSource="{Binding RrrCostItems}" AutoGenerateColumns="False" Grid.Row="4" Grid.ColumnSpan="2" Height="150" Margin="0,0,0,5">
+                <DataGrid ItemsSource="{Binding RrrCostItems}" AutoGenerateColumns="False" Grid.Row="4" Grid.ColumnSpan="2" Height="150" Margin="0,0,0,5" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto">
                     <DataGrid.Columns>
                         <DataGridTextColumn Header="Item" Binding="{Binding Item}"/>
                         <DataGridTextColumn Header="Future Cost" Binding="{Binding FutureCost}"/>
@@ -156,5 +157,6 @@
             </Grid>
         </TabItem>
         </TabControl>
-    </StackPanel>
+        </StackPanel>
+    </ScrollViewer>
 </UserControl>

--- a/Views/WaterDemandView.xaml
+++ b/Views/WaterDemandView.xaml
@@ -1,217 +1,231 @@
 <UserControl x:Class="EconToolbox.Desktop.Views.WaterDemandView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Name="Root"
              Background="{StaticResource BackgroundBrush}">
-    <Grid Margin="10">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="*"/>
-            <RowDefinition Height="Auto"/>
-        </Grid.RowDefinitions>
-        <StackPanel Grid.Row="0" Margin="0,0,0,5">
-            <TextBlock Text="Provide historical demand data, choose a forecast length and method, then compute results." TextWrapping="Wrap"/>
-            <ComboBox ItemsSource="{Binding Scenarios}" SelectedItem="{Binding SelectedScenario}" DisplayMemberPath="Name" Width="150" Margin="0,5,0,0"/>
-        </StackPanel>
-        <Grid Grid.Row="1">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="3*"/>
-                <ColumnDefinition Width="2*"/>
-            </Grid.ColumnDefinitions>
-            <Grid Grid.Column="0">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="2*"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="*"/>
-                </Grid.RowDefinitions>
-                <Border Grid.Row="0" Background="White" CornerRadius="4" Padding="5" Margin="0,0,0,5">
-                    <DataGrid ItemsSource="{Binding HistoricalData}" AutoGenerateColumns="False" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
-                    <DataGrid.Columns>
-                        <DataGridTextColumn Header="Year" Binding="{Binding Year}"/>
-                        <DataGridTextColumn Header="Demand per Capita" Binding="{Binding Demand}"/>
-                    </DataGrid.Columns>
-                    </DataGrid>
-                </Border>
-                <Grid Grid.Row="1" Margin="0,0,0,5" VerticalAlignment="Top" HorizontalAlignment="Left">
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                    </Grid.RowDefinitions>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="Auto"/>
-                    </Grid.ColumnDefinitions>
-                    <Grid.Resources>
-                        <Style TargetType="TextBox">
-                            <Setter Property="Width" Value="120"/>
-                            <Setter Property="HorizontalAlignment" Value="Left"/>
-                            <Setter Property="Margin" Value="0,0,10,0"/>
-                        </Style>
-                    </Grid.Resources>
+    <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
+        <Grid Margin="10">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+            <TextBlock Grid.Row="0" Text="Provide historical demand data, choose a forecast length and method, then compute results." TextWrapping="Wrap"/>
+            <TabControl Grid.Row="1" ItemsSource="{Binding Scenarios}" SelectedItem="{Binding SelectedScenario}">
+                <TabControl.ItemTemplate>
+                    <DataTemplate>
+                        <TextBlock Text="{Binding Name}" ToolTip="{Binding Description}"/>
+                    </DataTemplate>
+                </TabControl.ItemTemplate>
+                <TabControl.ContentTemplate>
+                    <DataTemplate>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="3*"/>
+                                <ColumnDefinition Width="2*"/>
+                            </Grid.ColumnDefinitions>
+                            <Grid Grid.Column="0">
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="2*"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="*"/>
+                                </Grid.RowDefinitions>
+                                <Border Grid.Row="0" Background="White" CornerRadius="4" Padding="5" Margin="0,0,0,5">
+                                    <DataGrid ItemsSource="{Binding DataContext.HistoricalData, ElementName=Root}" AutoGenerateColumns="False" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" ScrollViewer.VerticalScrollBarVisibility="Auto" ScrollViewer.HorizontalScrollBarVisibility="Auto">
+                                        <DataGrid.Columns>
+                                            <DataGridTextColumn Header="Year" Binding="{Binding Year}"/>
+                                            <DataGridTextColumn Header="Demand per Capita" Binding="{Binding Demand}"/>
+                                        </DataGrid.Columns>
+                                    </DataGrid>
+                                </Border>
+                                <Grid Grid.Row="1" Margin="0,0,0,5" VerticalAlignment="Top" HorizontalAlignment="Left">
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                    </Grid.RowDefinitions>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                    </Grid.ColumnDefinitions>
+                                    <Grid.Resources>
+                                        <Style TargetType="TextBox">
+                                            <Setter Property="Width" Value="120"/>
+                                            <Setter Property="HorizontalAlignment" Value="Left"/>
+                                            <Setter Property="Margin" Value="0,0,10,0"/>
+                                        </Style>
+                                    </Grid.Resources>
 
-                    <TextBlock Text="Forecast Years" Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                    <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding ForecastYears}"/>
-                    <TextBlock Text="years" Grid.Row="0" Grid.Column="2" VerticalAlignment="Center"/>
+                                    <TextBlock Text="Forecast Years" Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                                    <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding DataContext.ForecastYears, ElementName=Root}"/>
+                                    <TextBlock Text="years" Grid.Row="0" Grid.Column="2" VerticalAlignment="Center"/>
 
-                    <CheckBox Content="Use Growth Rate" Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="3" IsChecked="{Binding UseGrowthRate}" VerticalAlignment="Center" HorizontalAlignment="Left"/>
+                                    <CheckBox Content="Use Growth Rate" Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="3" IsChecked="{Binding DataContext.UseGrowthRate, ElementName=Root}" VerticalAlignment="Center" HorizontalAlignment="Left"/>
 
-                    <TextBlock Text="Standard Growth Rate" Grid.Row="2" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                    <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding StandardGrowthRate}"/>
-                    <TextBlock Text="%" Grid.Row="2" Grid.Column="2" VerticalAlignment="Center"/>
+                                    <TextBlock Text="Standard Growth Rate" Grid.Row="2" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                                    <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding StandardGrowthRate}"/>
+                                    <TextBlock Text="%" Grid.Row="2" Grid.Column="2" VerticalAlignment="Center"/>
 
-                    <TextBlock Text="Base Year" Grid.Row="3" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                    <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding BaseYear}"/>
+                                    <TextBlock Text="Base Year" Grid.Row="3" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                                    <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding BaseYear}"/>
 
-                    <TextBlock Text="Base Population" Grid.Row="4" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                    <TextBox Grid.Row="4" Grid.Column="1" Text="{Binding BasePopulation}"/>
-                    <TextBlock Text="people" Grid.Row="4" Grid.Column="2" VerticalAlignment="Center"/>
+                                    <TextBlock Text="Base Population" Grid.Row="4" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                                    <TextBox Grid.Row="4" Grid.Column="1" Text="{Binding BasePopulation}"/>
+                                    <TextBlock Text="people" Grid.Row="4" Grid.Column="2" VerticalAlignment="Center"/>
 
-                    <TextBlock Text="Base Per Capita" Grid.Row="5" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                    <TextBox Grid.Row="5" Grid.Column="1" Text="{Binding BasePerCapitaDemand}"/>
-                    <TextBlock Text="gallons/person/day" Grid.Row="5" Grid.Column="2" VerticalAlignment="Center"/>
+                                    <TextBlock Text="Base Per Capita" Grid.Row="5" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                                    <TextBox Grid.Row="5" Grid.Column="1" Text="{Binding BasePerCapitaDemand}"/>
+                                    <TextBlock Text="gallons/person/day" Grid.Row="5" Grid.Column="2" VerticalAlignment="Center"/>
 
-                    <TextBlock Text="Population Growth %" Grid.Row="6" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                    <TextBox Grid.Row="6" Grid.Column="1" Text="{Binding PopulationGrowthRate}"/>
-                    <TextBlock Text="%" Grid.Row="6" Grid.Column="2" VerticalAlignment="Center"/>
+                                    <TextBlock Text="Population Growth %" Grid.Row="6" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                                    <TextBox Grid.Row="6" Grid.Column="1" Text="{Binding PopulationGrowthRate}"/>
+                                    <TextBlock Text="%" Grid.Row="6" Grid.Column="2" VerticalAlignment="Center"/>
 
-                    <TextBlock Text="Per Capita Change %" Grid.Row="7" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                    <TextBox Grid.Row="7" Grid.Column="1" Text="{Binding PerCapitaDemandChangeRate}"/>
-                    <TextBlock Text="%" Grid.Row="7" Grid.Column="2" VerticalAlignment="Center"/>
+                                    <TextBlock Text="Per Capita Change %" Grid.Row="7" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                                    <TextBox Grid.Row="7" Grid.Column="1" Text="{Binding PerCapitaDemandChangeRate}"/>
+                                    <TextBlock Text="%" Grid.Row="7" Grid.Column="2" VerticalAlignment="Center"/>
 
-                    <TextBlock Text="Current Industrial %" Grid.Row="8" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                    <TextBox Grid.Row="8" Grid.Column="1" Text="{Binding CurrentIndustrialPercent}"/>
-                    <TextBlock Text="%" Grid.Row="8" Grid.Column="2" VerticalAlignment="Center"/>
+                                    <TextBlock Text="Current Industrial %" Grid.Row="8" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                                    <TextBox Grid.Row="8" Grid.Column="1" Text="{Binding CurrentIndustrialPercent}"/>
+                                    <TextBlock Text="%" Grid.Row="8" Grid.Column="2" VerticalAlignment="Center"/>
 
-                    <TextBlock Text="Future Industrial %" Grid.Row="9" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                    <TextBox Grid.Row="9" Grid.Column="1" Text="{Binding FutureIndustrialPercent}"/>
-                    <TextBlock Text="%" Grid.Row="9" Grid.Column="2" VerticalAlignment="Center"/>
+                                    <TextBlock Text="Future Industrial %" Grid.Row="9" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                                    <TextBox Grid.Row="9" Grid.Column="1" Text="{Binding FutureIndustrialPercent}"/>
+                                    <TextBlock Text="%" Grid.Row="9" Grid.Column="2" VerticalAlignment="Center"/>
 
-                    <TextBlock Text="Current Residential %" Grid.Row="10" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                    <TextBox Grid.Row="10" Grid.Column="1" Text="{Binding CurrentResidentialPercent}"/>
-                    <TextBlock Text="%" Grid.Row="10" Grid.Column="2" VerticalAlignment="Center"/>
+                                    <TextBlock Text="Current Residential %" Grid.Row="10" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                                    <TextBox Grid.Row="10" Grid.Column="1" Text="{Binding CurrentResidentialPercent}"/>
+                                    <TextBlock Text="%" Grid.Row="10" Grid.Column="2" VerticalAlignment="Center"/>
 
-                    <TextBlock Text="Future Residential %" Grid.Row="11" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                    <TextBox Grid.Row="11" Grid.Column="1" Text="{Binding FutureResidentialPercent}"/>
-                    <TextBlock Text="%" Grid.Row="11" Grid.Column="2" VerticalAlignment="Center"/>
+                                    <TextBlock Text="Future Residential %" Grid.Row="11" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                                    <TextBox Grid.Row="11" Grid.Column="1" Text="{Binding FutureResidentialPercent}"/>
+                                    <TextBlock Text="%" Grid.Row="11" Grid.Column="2" VerticalAlignment="Center"/>
 
-                    <TextBlock Text="Current Commercial %" Grid.Row="12" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                    <TextBox Grid.Row="12" Grid.Column="1" Text="{Binding CurrentCommercialPercent}"/>
-                    <TextBlock Text="%" Grid.Row="12" Grid.Column="2" VerticalAlignment="Center"/>
+                                    <TextBlock Text="Current Commercial %" Grid.Row="12" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                                    <TextBox Grid.Row="12" Grid.Column="1" Text="{Binding CurrentCommercialPercent}"/>
+                                    <TextBlock Text="%" Grid.Row="12" Grid.Column="2" VerticalAlignment="Center"/>
 
-                    <TextBlock Text="Future Commercial %" Grid.Row="13" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                    <TextBox Grid.Row="13" Grid.Column="1" Text="{Binding FutureCommercialPercent}"/>
-                    <TextBlock Text="%" Grid.Row="13" Grid.Column="2" VerticalAlignment="Center"/>
+                                    <TextBlock Text="Future Commercial %" Grid.Row="13" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                                    <TextBox Grid.Row="13" Grid.Column="1" Text="{Binding FutureCommercialPercent}"/>
+                                    <TextBlock Text="%" Grid.Row="13" Grid.Column="2" VerticalAlignment="Center"/>
 
-                    <TextBlock Text="Current Agricultural %" Grid.Row="14" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                    <TextBox Grid.Row="14" Grid.Column="1" Text="{Binding CurrentAgriculturalPercent}"/>
-                    <TextBlock Text="%" Grid.Row="14" Grid.Column="2" VerticalAlignment="Center"/>
+                                    <TextBlock Text="Current Agricultural %" Grid.Row="14" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                                    <TextBox Grid.Row="14" Grid.Column="1" Text="{Binding CurrentAgriculturalPercent}"/>
+                                    <TextBlock Text="%" Grid.Row="14" Grid.Column="2" VerticalAlignment="Center"/>
 
-                    <TextBlock Text="Future Agricultural %" Grid.Row="15" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                    <TextBox Grid.Row="15" Grid.Column="1" Text="{Binding FutureAgriculturalPercent}"/>
-                    <TextBlock Text="%" Grid.Row="15" Grid.Column="2" VerticalAlignment="Center"/>
+                                    <TextBlock Text="Future Agricultural %" Grid.Row="15" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                                    <TextBox Grid.Row="15" Grid.Column="1" Text="{Binding FutureAgriculturalPercent}"/>
+                                    <TextBlock Text="%" Grid.Row="15" Grid.Column="2" VerticalAlignment="Center"/>
 
-                    <TextBlock Text="Improvements %" Grid.Row="16" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                    <TextBox Grid.Row="16" Grid.Column="1" Text="{Binding SystemImprovementsPercent}"/>
-                    <TextBlock Text="%" Grid.Row="16" Grid.Column="2" VerticalAlignment="Center"/>
+                                    <TextBlock Text="Improvements %" Grid.Row="16" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                                    <TextBox Grid.Row="16" Grid.Column="1" Text="{Binding SystemImprovementsPercent}"/>
+                                    <TextBlock Text="%" Grid.Row="16" Grid.Column="2" VerticalAlignment="Center"/>
 
-                    <TextBlock Text="Losses %" Grid.Row="17" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                    <TextBox Grid.Row="17" Grid.Column="1" Text="{Binding SystemLossesPercent}"/>
-                    <TextBlock Text="%" Grid.Row="17" Grid.Column="2" VerticalAlignment="Center"/>
+                                    <TextBlock Text="Losses %" Grid.Row="17" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                                    <TextBox Grid.Row="17" Grid.Column="1" Text="{Binding SystemLossesPercent}"/>
+                                    <TextBlock Text="%" Grid.Row="17" Grid.Column="2" VerticalAlignment="Center"/>
 
-                    <StackPanel Grid.Row="18" Grid.ColumnSpan="3" Orientation="Horizontal" HorizontalAlignment="Left">
-                        <Button Content="Forecast" Width="80" Command="{Binding ForecastCommand}" Margin="0,0,5,0"/>
-                        <Button Content="Export" Width="80" Command="{Binding ExportCommand}"/>
-                    </StackPanel>
-                </Grid>
-                <Border Grid.Row="2" Background="White" CornerRadius="4" Padding="5">
-                    <DataGrid ItemsSource="{Binding Results}" AutoGenerateColumns="False" FontWeight="Bold" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
-                        <DataGrid.Columns>
-                        <DataGridTextColumn Header="Year" Binding="{Binding Year}"/>
-                        <DataGridTextColumn Header="Growth Rate" Binding="{Binding GrowthRate, Mode=TwoWay, StringFormat={}{0:N2}}">
-                            <DataGridTextColumn.ElementStyle>
-                                <Style TargetType="TextBlock">
-                                    <Setter Property="ToolTip" Value="Growth Rate = (Current Demand - Previous Demand) / Previous Demand"/>
-                                </Style>
-                            </DataGridTextColumn.ElementStyle>
-                        </DataGridTextColumn>
-                        <DataGridTextColumn Header="Demand" Binding="{Binding Demand, StringFormat={}{0:N2}}">
-                            <DataGridTextColumn.ElementStyle>
-                                <Style TargetType="TextBlock">
-                                    <Setter Property="ToolTip" Value="Demand = Prior Demand × (1 + Growth Rate)"/>
-                                </Style>
-                            </DataGridTextColumn.ElementStyle>
-                        </DataGridTextColumn>
-                        <DataGridTextColumn Header="Residential" Binding="{Binding ResidentialDemand, StringFormat={}{0:N2}}">
-                            <DataGridTextColumn.ElementStyle>
-                                <Style TargetType="TextBlock">
-                                    <Setter Property="ToolTip" Value="Residential = Demand × Residential %"/>
-                                </Style>
-                            </DataGridTextColumn.ElementStyle>
-                        </DataGridTextColumn>
-                        <DataGridTextColumn Header="Commercial" Binding="{Binding CommercialDemand, StringFormat={}{0:N2}}">
-                            <DataGridTextColumn.ElementStyle>
-                                <Style TargetType="TextBlock">
-                                    <Setter Property="ToolTip" Value="Commercial = Demand × Commercial %"/>
-                                </Style>
-                            </DataGridTextColumn.ElementStyle>
-                        </DataGridTextColumn>
-                        <DataGridTextColumn Header="Industrial" Binding="{Binding IndustrialDemand, StringFormat={}{0:N2}}">
-                            <DataGridTextColumn.ElementStyle>
-                                <Style TargetType="TextBlock">
-                                    <Setter Property="ToolTip" Value="Industrial = Demand × Industrial %"/>
-                                </Style>
-                            </DataGridTextColumn.ElementStyle>
-                        </DataGridTextColumn>
-                        <DataGridTextColumn Header="Agricultural" Binding="{Binding AgriculturalDemand, StringFormat={}{0:N2}}">
-                            <DataGridTextColumn.ElementStyle>
-                                <Style TargetType="TextBlock">
-                                    <Setter Property="ToolTip" Value="Agricultural = Demand × Agricultural %"/>
-                                </Style>
-                            </DataGridTextColumn.ElementStyle>
-                        </DataGridTextColumn>
-                        <DataGridTextColumn Header="Adjusted" Binding="{Binding AdjustedDemand, StringFormat={}{0:N2}}">
-                            <DataGridTextColumn.ElementStyle>
-                                <Style TargetType="TextBlock">
-                                    <Setter Property="ToolTip" Value="Adjusted = Demand × (1 - Improvements %) × (1 - Losses %)"/>
-                                </Style>
-                            </DataGridTextColumn.ElementStyle>
-                        </DataGridTextColumn>
-                    </DataGrid.Columns>
-                    </DataGrid>
-                </Border>
-            </Grid>
-            <Border Grid.Column="1" Margin="10,0,0,0" Background="White" CornerRadius="4" Padding="5">
-                <ItemsControl ItemsSource="{Binding Scenarios}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
-                    <ItemsControl.ItemsPanel>
-                        <ItemsPanelTemplate>
-                            <Canvas/>
-                        </ItemsPanelTemplate>
-                    </ItemsControl.ItemsPanel>
-                    <ItemsControl.ItemTemplate>
-                        <DataTemplate>
-                            <Polyline Points="{Binding ChartPoints}" Stroke="{Binding LineBrush}" StrokeThickness="2"/>
-                        </DataTemplate>
-                    </ItemsControl.ItemTemplate>
-                </ItemsControl>
-            </Border>
+                                    <StackPanel Grid.Row="18" Grid.ColumnSpan="3" Orientation="Horizontal" HorizontalAlignment="Left">
+                                        <Button Content="Forecast" Width="80" Command="{Binding DataContext.ForecastCommand, ElementName=Root}" Margin="0,0,5,0"/>
+                                        <Button Content="Export" Width="80" Command="{Binding DataContext.ExportCommand, ElementName=Root}"/>
+                                    </StackPanel>
+                                </Grid>
+                                <Border Grid.Row="2" Background="White" CornerRadius="4" Padding="5">
+                                    <DataGrid ItemsSource="{Binding Results}" AutoGenerateColumns="False" FontWeight="Bold" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" ScrollViewer.VerticalScrollBarVisibility="Auto" ScrollViewer.HorizontalScrollBarVisibility="Auto">
+                                        <DataGrid.Columns>
+                                            <DataGridTextColumn Header="Year" Binding="{Binding Year}"/>
+                                            <DataGridTextColumn Header="Growth Rate" Binding="{Binding GrowthRate, Mode=TwoWay, StringFormat={}{0:N2}}">
+                                                <DataGridTextColumn.ElementStyle>
+                                                    <Style TargetType="TextBlock">
+                                                        <Setter Property="ToolTip" Value="Growth Rate = (Current Demand - Previous Demand) / Previous Demand"/>
+                                                    </Style>
+                                                </DataGridTextColumn.ElementStyle>
+                                            </DataGridTextColumn>
+                                            <DataGridTextColumn Header="Demand" Binding="{Binding Demand, StringFormat={}{0:N2}}">
+                                                <DataGridTextColumn.ElementStyle>
+                                                    <Style TargetType="TextBlock">
+                                                        <Setter Property="ToolTip" Value="Demand = Prior Demand × (1 + Growth Rate)"/>
+                                                    </Style>
+                                                </DataGridTextColumn.ElementStyle>
+                                            </DataGridTextColumn>
+                                            <DataGridTextColumn Header="Residential" Binding="{Binding ResidentialDemand, StringFormat={}{0:N2}}">
+                                                <DataGridTextColumn.ElementStyle>
+                                                    <Style TargetType="TextBlock">
+                                                        <Setter Property="ToolTip" Value="Residential = Demand × Residential %"/>
+                                                    </Style>
+                                                </DataGridTextColumn.ElementStyle>
+                                            </DataGridTextColumn>
+                                            <DataGridTextColumn Header="Commercial" Binding="{Binding CommercialDemand, StringFormat={}{0:N2}}">
+                                                <DataGridTextColumn.ElementStyle>
+                                                    <Style TargetType="TextBlock">
+                                                        <Setter Property="ToolTip" Value="Commercial = Demand × Commercial %"/>
+                                                    </Style>
+                                                </DataGridTextColumn.ElementStyle>
+                                            </DataGridTextColumn>
+                                            <DataGridTextColumn Header="Industrial" Binding="{Binding IndustrialDemand, StringFormat={}{0:N2}}">
+                                                <DataGridTextColumn.ElementStyle>
+                                                    <Style TargetType="TextBlock">
+                                                        <Setter Property="ToolTip" Value="Industrial = Demand × Industrial %"/>
+                                                    </Style>
+                                                </DataGridTextColumn.ElementStyle>
+                                            </DataGridTextColumn>
+                                            <DataGridTextColumn Header="Agricultural" Binding="{Binding AgriculturalDemand, StringFormat={}{0:N2}}">
+                                                <DataGridTextColumn.ElementStyle>
+                                                    <Style TargetType="TextBlock">
+                                                        <Setter Property="ToolTip" Value="Agricultural = Demand × Agricultural %"/>
+                                                    </Style>
+                                                </DataGridTextColumn.ElementStyle>
+                                            </DataGridTextColumn>
+                                            <DataGridTextColumn Header="Adjusted" Binding="{Binding AdjustedDemand, StringFormat={}{0:N2}}">
+                                                <DataGridTextColumn.ElementStyle>
+                                                    <Style TargetType="TextBlock">
+                                                        <Setter Property="ToolTip" Value="Adjusted = Demand × (1 - Improvements %) × (1 - Losses %)"/>
+                                                    </Style>
+                                                </DataGridTextColumn.ElementStyle>
+                                            </DataGridTextColumn>
+                                        </DataGrid.Columns>
+                                    </DataGrid>
+                                </Border>
+                            </Grid>
+                            <Border Grid.Column="1" Margin="10,0,0,0" Background="White" CornerRadius="4" Padding="5">
+                                <ItemsControl ItemsSource="{Binding DataContext.Scenarios, ElementName=Root}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+                                    <ItemsControl.ItemsPanel>
+                                        <ItemsPanelTemplate>
+                                            <Canvas/>
+                                        </ItemsPanelTemplate>
+                                    </ItemsControl.ItemsPanel>
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate>
+                                            <Polyline Points="{Binding ChartPoints}" Stroke="{Binding LineBrush}" StrokeThickness="2"/>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
+                            </Border>
+                        </Grid>
+                    </DataTemplate>
+                </TabControl.ContentTemplate>
+            </TabControl>
+            <TextBlock Grid.Row="2" Text="{Binding SelectedScenario.Description}" FontWeight="SemiBold" TextWrapping="Wrap" Margin="0,10,0,0"/>
+            <TextBlock Grid.Row="3" Text="{Binding Explanation}" FontWeight="Bold" TextWrapping="Wrap" Margin="0,10,0,0"/>
         </Grid>
-        <TextBlock Grid.Row="2" Text="{Binding Explanation}" FontWeight="Bold" TextWrapping="Wrap" Margin="0,10,0,0"/>
-    </Grid>
+    </ScrollViewer>
 </UserControl>
+


### PR DESCRIPTION
## Summary
- Explain Baseline, Optimistic, and Pessimistic scenarios with descriptions
- Replace scenario selector with tabs and add scrolling to Water Demand view
- Enable scrolling/resizing across all tabs and data grids

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c49f00b39483309a10974f126c50d4