### PR TITLE
Enhance UX guidance and visuals across economic tools

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -10,10 +10,39 @@
     </Window.DataContext>
     <Grid>
         <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
-        <ScrollViewer Grid.Row="0" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
+        <Border Grid.Row="0" Background="{StaticResource PrimaryBrush}" Padding="20" CornerRadius="0,0,12,12">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+                <StackPanel Orientation="Vertical" Grid.Column="1" Margin="20,0,0,0">
+                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                        <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="28" Foreground="White" Margin="0,0,10,0"/>
+                        <TextBlock Text="Economic Toolbox" FontSize="28" FontWeight="Bold" Foreground="White"/>
+                    </StackPanel>
+                    <TextBlock TextWrapping="Wrap" Foreground="White" Margin="0,10,0,0">
+                        <Run Text="Review each tab to build a complete project narrative."/>
+                        <LineBreak/>
+                        <Run Text="Enter inputs carefully, press Calculate when available, and use Export to capture your work."/>
+                        <LineBreak/>
+                        <Run Text="Context-sensitive tips below explain what each result means and how your assumptions drive it."/>
+                    </TextBlock>
+                </StackPanel>
+                <Canvas Width="120" Height="80" HorizontalAlignment="Left" VerticalAlignment="Center">
+                    <Path Data="M10,70 L30,45 L55,55 L85,20" Stroke="White" StrokeThickness="4" StrokeEndLineCap="Round" StrokeStartLineCap="Round"/>
+                    <Ellipse Width="10" Height="10" Fill="{StaticResource AccentBrush}" Canvas.Left="6" Canvas.Top="65"/>
+                    <Ellipse Width="10" Height="10" Fill="{StaticResource AccentBrush}" Canvas.Left="26" Canvas.Top="40"/>
+                    <Ellipse Width="10" Height="10" Fill="{StaticResource AccentBrush}" Canvas.Left="51" Canvas.Top="50"/>
+                    <Ellipse Width="12" Height="12" Fill="White" Canvas.Left="79" Canvas.Top="14"/>
+                </Canvas>
+            </Grid>
+        </Border>
+        <ScrollViewer Grid.Row="1" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
             <TabControl Margin="10" SelectedIndex="{Binding SelectedIndex}" FontSize="14" Background="White">
             <TabItem Header="EAD" DataContext="{Binding Ead}">
                 <views:EadView/>
@@ -23,8 +52,24 @@
             </TabItem>
             <TabItem Header="Cost Annualization" DataContext="{Binding Annualizer}">
                 <StackPanel Margin="10">
-                    <TextBlock Text="Enter cost data and parameters. Future cost years must be in ascending order." TextWrapping="Wrap" Margin="0,0,0,10"/>
-                    <Grid>
+                    <Border Background="#E8F4FB" BorderBrush="{StaticResource PrimaryBrush}" BorderThickness="1" CornerRadius="8" Padding="15" Margin="0,0,0,10">
+                        <StackPanel>
+                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="20" Foreground="{StaticResource PrimaryBrush}" Margin="0,0,8,0"/>
+                                <TextBlock Text="Cost Annualization Workflow" FontWeight="Bold" FontSize="16" Foreground="{StaticResource PrimaryBrush}"/>
+                            </StackPanel>
+                            <TextBlock TextWrapping="Wrap" Margin="0,8,0,0">
+                                <Run Text="1. Document upfront investments, financing assumptions, and the analysis period."/>
+                                <LineBreak/>
+                                <Run Text="2. Capture the construction cash flow in the IDC schedule and list all future costs in the year they occur."/>
+                                <LineBreak/>
+                                <Run Text="3. Provide annual O&amp;M and annual benefits so the tool can translate capital outlays into comparable annual metrics."/>
+                                <LineBreak/>
+                                <Run Text="Use the Calculate button at the bottom of the window whenever you update inputs."/>
+                            </TextBlock>
+                        </StackPanel>
+                    </Border>
+                    <Grid Margin="0,10,0,0">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
@@ -97,11 +142,76 @@
                         </DataGrid.Columns>
                     </DataGrid>
                     <StackPanel Grid.Row="9" Grid.ColumnSpan="2">
-                        <TextBlock FontWeight="Bold" Text="{Binding Idc, StringFormat=IDC: {0:C2}}" ToolTip="Interest during construction (IDC) based on first cost, rate and schedule."/>
-                        <TextBlock FontWeight="Bold" Text="{Binding TotalInvestment, StringFormat=Total Investment: {0:C2}}" ToolTip="Total Investment = First Cost + IDC + PV of Future Costs"/>
-                        <TextBlock FontWeight="Bold" Text="{Binding Crf, StringFormat=CRF: {0:F4}}" ToolTip="CRF = r(1+r)^n / ((1+r)^n - 1)"/>
-                        <TextBlock FontWeight="Bold" Text="{Binding AnnualCost, StringFormat=Annual Cost: {0:C2}}" ToolTip="Annual Cost = Total Investment × CRF + Annual O&amp;M"/>
-                        <TextBlock FontWeight="Bold" Text="{Binding Bcr, StringFormat=BCR: {0:F2}}" ToolTip="BCR = Annual Benefits ÷ Annual Cost"/>
+                        <Border Background="White" CornerRadius="6" Padding="10" BorderBrush="#D0E4F2" BorderThickness="1" Margin="0,0,0,8">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="18" Foreground="{StaticResource PrimaryBrush}" Margin="0,0,8,0" VerticalAlignment="Center"/>
+                                <TextBlock Grid.Column="1" FontWeight="Bold" Text="{Binding Idc, StringFormat=IDC: {0:C2}}" VerticalAlignment="Center"/>
+                                <TextBlock Grid.Column="2" TextWrapping="Wrap" Margin="12,0,0,0" Foreground="#31556F">
+                                    Interest during construction accumulates from the IDC schedule using your month, timing, and rate inputs. Higher rates or longer construction windows increase this value.
+                                </TextBlock>
+                            </Grid>
+                        </Border>
+                        <Border Background="White" CornerRadius="6" Padding="10" BorderBrush="#D0E4F2" BorderThickness="1" Margin="0,0,0,8">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="18" Foreground="{StaticResource PrimaryBrush}" Margin="0,0,8,0" VerticalAlignment="Center"/>
+                                <TextBlock Grid.Column="1" FontWeight="Bold" Text="{Binding TotalInvestment, StringFormat=Total Investment: {0:C2}}" VerticalAlignment="Center"/>
+                                <TextBlock Grid.Column="2" TextWrapping="Wrap" Margin="12,0,0,0" Foreground="#31556F">
+                                    Total investment combines First Cost, IDC, and the present value of Future Costs. Adding more future expenses or higher IDC immediately raises this figure.
+                                </TextBlock>
+                            </Grid>
+                        </Border>
+                        <Border Background="White" CornerRadius="6" Padding="10" BorderBrush="#D0E4F2" BorderThickness="1" Margin="0,0,0,8">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="18" Foreground="{StaticResource PrimaryBrush}" Margin="0,0,8,0" VerticalAlignment="Center"/>
+                                <TextBlock Grid.Column="1" FontWeight="Bold" Text="{Binding Crf, StringFormat=CRF: {0:F4}}" VerticalAlignment="Center"/>
+                                <TextBlock Grid.Column="2" TextWrapping="Wrap" Margin="12,0,0,0" Foreground="#31556F">
+                                    The capital recovery factor converts present investment into an equivalent annual cost. It is entirely driven by your discount rate and analysis period selections.
+                                </TextBlock>
+                            </Grid>
+                        </Border>
+                        <Border Background="White" CornerRadius="6" Padding="10" BorderBrush="#D0E4F2" BorderThickness="1" Margin="0,0,0,8">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="18" Foreground="{StaticResource PrimaryBrush}" Margin="0,0,8,0" VerticalAlignment="Center"/>
+                                <TextBlock Grid.Column="1" FontWeight="Bold" Text="{Binding AnnualCost, StringFormat=Annual Cost: {0:C2}}" VerticalAlignment="Center"/>
+                                <TextBlock Grid.Column="2" TextWrapping="Wrap" Margin="12,0,0,0" Foreground="#31556F">
+                                    Annual cost reflects how the total investment and your O&amp;M inputs translate into yearly expenses. Increasing either component will raise this annualized value.
+                                </TextBlock>
+                            </Grid>
+                        </Border>
+                        <Border Background="White" CornerRadius="6" Padding="10" BorderBrush="#D0E4F2" BorderThickness="1">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="18" Foreground="{StaticResource PrimaryBrush}" Margin="0,0,8,0" VerticalAlignment="Center"/>
+                                <TextBlock Grid.Column="1" FontWeight="Bold" Text="{Binding Bcr, StringFormat=BCR: {0:F2}}" VerticalAlignment="Center"/>
+                                <TextBlock Grid.Column="2" TextWrapping="Wrap" Margin="12,0,0,0" Foreground="#31556F">
+                                    Benefit-cost ratio compares annual benefits against annual costs. Greater benefits or lower annual costs will push the BCR upward, signaling a stronger economic case.
+                                </TextBlock>
+                            </Grid>
+                        </Border>
                     </StackPanel>
                 </Grid>
                 </StackPanel>
@@ -114,9 +224,19 @@
         </TabItem>
             </TabControl>
         </ScrollViewer>
-        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Grid.Row="1" Margin="10,0,10,10">
-            <Button x:Name="CalculateButton" Content="Calculate" Width="100" Command="{Binding CalculateCommand}" Margin="0,0,5,0"/>
-            <Button Content="Export" Width="{Binding ElementName=CalculateButton, Path=ActualWidth}" Command="{Binding ExportCommand}"/>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Grid.Row="2" Margin="10,0,10,10">
+            <Button x:Name="CalculateButton" Command="{Binding CalculateCommand}" Margin="0,0,5,0">
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                    <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Margin="0,0,6,0" FontSize="16"/>
+                    <TextBlock Text="Calculate"/>
+                </StackPanel>
+            </Button>
+            <Button Width="{Binding ElementName=CalculateButton, Path=ActualWidth}" Command="{Binding ExportCommand}">
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                    <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Margin="0,0,6,0" FontSize="16"/>
+                    <TextBlock Text="Export"/>
+                </StackPanel>
+            </Button>
         </StackPanel>
     </Grid>
 </Window>

--- a/Views/EadView.xaml
+++ b/Views/EadView.xaml
@@ -8,13 +8,50 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
-        <TextBlock Grid.Row="0" Text="Enter probabilities with corresponding damages. Inputs are automatically sorted and missing 0% and 100% probabilities are added using the trapezoidal method. Use Add Damage Column for additional categories. Optional stage values must align with probabilities." TextWrapping="Wrap" Margin="0,0,0,5"/>
-        <StackPanel Orientation="Horizontal" Grid.Row="1" Margin="0,0,0,5">
-            <Button Content="Add Damage Column" Command="{Binding AddDamageColumnCommand}" Margin="0,0,5,0"/>
-            <Button Content="Remove Damage Column" Command="{Binding RemoveDamageColumnCommand}" Margin="0,0,5,0"/>
-            <CheckBox Content="Include Stage" IsChecked="{Binding UseStage}" Margin="0,0,5,0"/>
-        </StackPanel>
+        <Border Grid.Row="0" Background="#FFF2FBFF" BorderBrush="{StaticResource PrimaryBrush}" BorderThickness="1" CornerRadius="8" Padding="12" Margin="0,0,0,5">
+            <StackPanel>
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                    <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="20" Foreground="{StaticResource PrimaryBrush}" Margin="0,0,8,0"/>
+                    <TextBlock Text="Expected Annual Damage Instructions" FontWeight="Bold" FontSize="16" Foreground="{StaticResource PrimaryBrush}"/>
+                </StackPanel>
+                <TextBlock TextWrapping="Wrap" Margin="0,6,0,0">
+                    <Run Text="List probability-damage pairs for each category. The tool auto-completes the curve by inserting 0% and 100% points using the trapezoidal method."/>
+                    <LineBreak/>
+                    <Run Text="Toggle Include Stage if you have stage data aligned with the same probabilities."/>
+                    <LineBreak/>
+                    <Run Text="After editing the grid, click Calculate EAD so charts and statistics capture your latest entries."/>
+                </TextBlock>
+            </StackPanel>
+        </Border>
+        <WrapPanel Grid.Row="1" Margin="0,0,0,5" ItemHeight="36" ItemWidth="220" MinWidth="200">
+            <Button Command="{Binding AddDamageColumnCommand}">
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Margin="0,0,6,0"/>
+                    <TextBlock Text="Add Damage Column"/>
+                </StackPanel>
+            </Button>
+            <Button Command="{Binding RemoveDamageColumnCommand}">
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Margin="0,0,6,0"/>
+                    <TextBlock Text="Remove Damage Column"/>
+                </StackPanel>
+            </Button>
+            <CheckBox Content="Include Stage" IsChecked="{Binding UseStage}" VerticalAlignment="Center" Margin="4"/>
+            <Button Command="{Binding ComputeCommand}">
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Margin="0,0,6,0"/>
+                    <TextBlock Text="Calculate EAD"/>
+                </StackPanel>
+            </Button>
+            <Button Command="{Binding ExportCommand}">
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Margin="0,0,6,0"/>
+                    <TextBlock Text="Export Summary"/>
+                </StackPanel>
+            </Button>
+        </WrapPanel>
         <Grid Grid.Row="2">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>
@@ -27,13 +64,41 @@
             </Border>
 
             <Border Grid.Column="1" Margin="10,0,0,0" Background="White" CornerRadius="4" Padding="5">
-                <Canvas>
-                    <Polyline Points="{Binding FrequencyDamagePoints}" Stroke="{StaticResource AccentBrush}" StrokeThickness="2"/>
-                    <Polyline Points="{Binding StageDamagePoints}" Stroke="{StaticResource PrimaryBrush}" StrokeThickness="2"/>
-                </Canvas>
+                <StackPanel>
+                    <TextBlock FontWeight="SemiBold" Text="Visualize Your Curve" Margin="0,0,0,5"/>
+                    <Canvas Height="160">
+                        <Polyline Points="{Binding FrequencyDamagePoints}" Stroke="{StaticResource AccentBrush}" StrokeThickness="2"/>
+                        <Polyline Points="{Binding StageDamagePoints}" Stroke="{StaticResource PrimaryBrush}" StrokeThickness="2"/>
+                    </Canvas>
+                    <TextBlock TextWrapping="Wrap" FontSize="12" Foreground="#31556F">
+                        The teal line plots damages against exceedance probability, while the navy line (when stage is supplied) shows the paired stage-damage curve. Smoother, monotonic inputs yield clearer charts.
+                    </TextBlock>
+                </StackPanel>
             </Border>
         </Grid>
-        <ItemsControl ItemsSource="{Binding Results}" Grid.Row="3" Margin="0,5,0,0"/>
+        <ItemsControl ItemsSource="{Binding Results}" Grid.Row="3" Margin="0,5,0,5">
+            <ItemsControl.ItemTemplate>
+                <DataTemplate>
+                    <Border Background="White" BorderBrush="#D0E4F2" BorderThickness="1" CornerRadius="6" Padding="8" Margin="0,0,0,5">
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="16" Foreground="{StaticResource PrimaryBrush}" Margin="0,0,8,0"/>
+                            <TextBlock Text="{Binding}" TextWrapping="Wrap"/>
+                        </StackPanel>
+                    </Border>
+                </DataTemplate>
+            </ItemsControl.ItemTemplate>
+        </ItemsControl>
+        <Border Grid.Row="4" Background="#FFF8FD" BorderBrush="#E0CAE7" BorderThickness="1" CornerRadius="8" Padding="12">
+            <StackPanel>
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                    <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="18" Foreground="#8A4BAF" Margin="0,0,8,0"/>
+                    <TextBlock Text="Result Interpretation" FontWeight="Bold" Foreground="#8A4BAF"/>
+                </StackPanel>
+                <TextBlock TextWrapping="Wrap" Margin="0,6,0,0">
+                    Each Expected Annual Damage value averages the damage column across the entire probability curve you supplied. Higher damages at frequent events raise the EAD most dramatically. The plotted curves update with every calculation, helping you confirm the shape of the probability and stage relationships before exporting your Excel summary.
+                </TextBlock>
+            </StackPanel>
+        </Border>
         </Grid>
     </ScrollViewer>
 </UserControl>

--- a/Views/UdvView.xaml
+++ b/Views/UdvView.xaml
@@ -11,34 +11,69 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
-        <TextBlock Grid.Row="0" Text="Select recreation and activity, enter points, user days, and visitation. Points must follow the table's ascending order." TextWrapping="Wrap" Margin="0,0,0,5"/>
+        <Border Grid.Row="0" Background="#FFF4F7" BorderBrush="#E8A6B8" BorderThickness="1" CornerRadius="10" Padding="12" Margin="0,0,0,8">
+            <StackPanel>
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                    <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="18" Foreground="#C23E64" Margin="0,0,8,0"/>
+                    <TextBlock Text="Unit Day Value Overview" FontWeight="Bold" Foreground="#C23E64"/>
+                </StackPanel>
+                <TextBlock TextWrapping="Wrap" Margin="0,6,0,0">
+                    Choose the recreation and activity classification, then supply point scores, user days, and visitation. Points must align with the table order to return the correct value tier.
+                </TextBlock>
+            </StackPanel>
+        </Border>
         <StackPanel Orientation="Horizontal" Grid.Row="1" Margin="0,0,0,5">
-            <ComboBox ItemsSource="{Binding RecreationTypes}" SelectedItem="{Binding RecreationType}" Width="120" Margin="0,0,5,0"/>
-            <ComboBox ItemsSource="{Binding ActivityTypes}" SelectedItem="{Binding ActivityType}" Width="180"/>
+            <ComboBox ItemsSource="{Binding RecreationTypes}" SelectedItem="{Binding RecreationType}" Width="150" Margin="0,0,8,0"/>
+            <ComboBox ItemsSource="{Binding ActivityTypes}" SelectedItem="{Binding ActivityType}" Width="220"/>
         </StackPanel>
         <StackPanel Orientation="Horizontal" Grid.Row="2" Margin="0,0,0,5">
+            <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Foreground="{StaticResource PrimaryBrush}" Margin="0,0,6,0" VerticalAlignment="Center"/>
             <TextBlock Text="Points" VerticalAlignment="Center" Margin="0,0,5,0"/>
             <TextBox Text="{Binding Points}" Width="60" Margin="0,0,10,0"/>
             <TextBlock Text="Unit Day Value" VerticalAlignment="Center" Margin="0,0,5,0"/>
-            <TextBlock Text="{Binding UnitDayValue, StringFormat={}{0:F2}}" VerticalAlignment="Center"/>
+            <TextBlock Text="{Binding UnitDayValue, StringFormat={}{0:F2}}" VerticalAlignment="Center" FontWeight="SemiBold"/>
         </StackPanel>
         <StackPanel Orientation="Horizontal" Grid.Row="3" Margin="0,0,0,5">
+            <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Foreground="{StaticResource PrimaryBrush}" Margin="0,0,6,0" VerticalAlignment="Center"/>
             <TextBlock Text="Annual User Days" VerticalAlignment="Center" Margin="0,0,5,0"/>
             <TextBox Text="{Binding UserDays}" Width="80" Margin="0,0,10,0"/>
             <TextBlock Text="Visitation" VerticalAlignment="Center" Margin="0,0,5,0"/>
             <TextBox Text="{Binding Visitation}" Width="60" Margin="0,0,10,0"/>
-            <Button Content="Compute" Command="{Binding ComputeCommand}"/>
+            <Button Command="{Binding ComputeCommand}">
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                    <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Margin="0,0,6,0"/>
+                    <TextBlock Text="Compute"/>
+                </StackPanel>
+            </Button>
         </StackPanel>
-        <TextBlock Text="{Binding Result}" Grid.Row="4"/>
-        <DataGrid Grid.Row="5" ItemsSource="{Binding Table}" AutoGenerateColumns="False" CanUserAddRows="False" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto">
-            <DataGrid.Columns>
-                <DataGridTextColumn Header="Points" Binding="{Binding Points}"/>
-                <DataGridTextColumn Header="General Recreation" Binding="{Binding GeneralRecreation}"/>
-                <DataGridTextColumn Header="General Fishing &amp; Hunting" Binding="{Binding GeneralFishingHunting}"/>
-                <DataGridTextColumn Header="Specialized Fishing &amp; Hunting" Binding="{Binding SpecializedFishingHunting}"/>
-                <DataGridTextColumn Header="Specialized Recreation" Binding="{Binding SpecializedRecreation}"/>
-            </DataGrid.Columns>
-        </DataGrid>
+        <Border Grid.Row="4" Background="#FFF7F0" BorderBrush="#E9C28E" BorderThickness="1" CornerRadius="8" Padding="10" Margin="0,0,0,5">
+            <StackPanel>
+                <TextBlock Text="{Binding Result}" FontWeight="Bold"/>
+                <TextBlock TextWrapping="Wrap" Margin="0,4,0,0">
+                    This total monetizes recreation by multiplying the unit day value with annual user days and visitation share. Raising the points score moves you to a higher value tier, while more user days proportionally increase the annual benefit.
+                </TextBlock>
+            </StackPanel>
+        </Border>
+        <Border Grid.Row="5" Background="White" BorderBrush="#D0E4F2" BorderThickness="1" CornerRadius="10" Padding="10">
+            <StackPanel>
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                    <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="18" Foreground="{StaticResource PrimaryBrush}" Margin="0,0,8,0"/>
+                    <TextBlock Text="Point Scale Reference" FontWeight="Bold" Foreground="{StaticResource PrimaryBrush}"/>
+                </StackPanel>
+                <TextBlock TextWrapping="Wrap" FontSize="12" Margin="0,4,0,6">
+                    Reference this table to ensure your point selection matches the published ranges. The highlighted unit day value is chosen by matching your point entry to the correct column.
+                </TextBlock>
+                <DataGrid ItemsSource="{Binding Table}" AutoGenerateColumns="False" CanUserAddRows="False" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto">
+                    <DataGrid.Columns>
+                        <DataGridTextColumn Header="Points" Binding="{Binding Points}"/>
+                        <DataGridTextColumn Header="General Recreation" Binding="{Binding GeneralRecreation}"/>
+                        <DataGridTextColumn Header="General Fishing &amp; Hunting" Binding="{Binding GeneralFishingHunting}"/>
+                        <DataGridTextColumn Header="Specialized Fishing &amp; Hunting" Binding="{Binding SpecializedFishingHunting}"/>
+                        <DataGridTextColumn Header="Specialized Recreation" Binding="{Binding SpecializedRecreation}"/>
+                    </DataGrid.Columns>
+                </DataGrid>
+            </StackPanel>
+        </Border>
         </Grid>
     </ScrollViewer>
 </UserControl>

--- a/Views/UpdatedCostView.xaml
+++ b/Views/UpdatedCostView.xaml
@@ -6,56 +6,133 @@
              mc:Ignorable="d">
     <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
         <StackPanel>
-        <TextBlock Text="Complete each section and ensure year values are ascending. Use Calculate to process all sections." TextWrapping="Wrap" Margin="10,0,10,10"/>
+        <Border Margin="10,0,10,10" Background="#EEF6F8" BorderBrush="{StaticResource PrimaryBrush}" BorderThickness="1" CornerRadius="10" Padding="16">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <StackPanel Orientation="Horizontal" Grid.Column="0" VerticalAlignment="Top">
+                    <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="24" Foreground="{StaticResource PrimaryBrush}" Margin="0,0,10,0"/>
+                </StackPanel>
+                <StackPanel Grid.Column="1">
+                    <TextBlock Text="Updated Cost Workflow" FontSize="18" FontWeight="Bold" Foreground="{StaticResource PrimaryBrush}"/>
+                    <TextBlock TextWrapping="Wrap" Margin="0,6,0,0">
+                        Work through each sub-tab from left to right. Start with storage capacity, capture annual joint costs, update historical line items, then evaluate RR&amp;R/mitigation and total annual cost scenarios. Press Compute within each section before leaving the tab so downstream values stay synchronized.
+                    </TextBlock>
+                </StackPanel>
+                <Canvas Grid.Column="2" Width="80" Height="60" Margin="15,0,0,0">
+                    <Rectangle Width="70" Height="40" Fill="White" Stroke="{StaticResource AccentBrush}" RadiusX="6" RadiusY="6" Canvas.Left="5" Canvas.Top="15"/>
+                    <Polyline Points="5,45 25,25 45,30 65,10" Stroke="{StaticResource PrimaryBrush}" StrokeThickness="3" StrokeEndLineCap="Round" StrokeStartLineCap="Round"/>
+                    <Ellipse Width="8" Height="8" Fill="{StaticResource AccentBrush}" Canvas.Left="1" Canvas.Top="41"/>
+                    <Ellipse Width="8" Height="8" Fill="{StaticResource AccentBrush}" Canvas.Left="21" Canvas.Top="21"/>
+                    <Ellipse Width="8" Height="8" Fill="{StaticResource AccentBrush}" Canvas.Left="41" Canvas.Top="26"/>
+                    <Ellipse Width="8" Height="8" Fill="{StaticResource AccentBrush}" Canvas.Left="61" Canvas.Top="6"/>
+                </Canvas>
+            </Grid>
+        </Border>
         <TabControl Margin="10,0,10,10">
         <TabItem Header="Storage Cost">
-            <Grid Margin="10">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="*"/>
-                </Grid.RowDefinitions>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto"/>
-                    <ColumnDefinition Width="*"/>
-                </Grid.ColumnDefinitions>
-                <TextBlock Text="Total Usable Storage" Margin="0,0,5,5"/>
-                <TextBox Text="{Binding TotalStorage}" Grid.Column="1" Margin="0,0,0,5"/>
-                <TextBlock Text="Storage Recommendation" Grid.Row="1" Margin="0,0,5,5"/>
-                <TextBox Text="{Binding StorageRecommendation}" Grid.Row="1" Grid.Column="1" Margin="0,0,0,5"/>
-                <Button Content="Compute" Command="{Binding ComputeStorageCommand}" Grid.Row="2" Grid.ColumnSpan="2" Margin="0,5,0,5"/>
-                <TextBlock Text="{Binding Percent, StringFormat=P: {0:F5}}" Grid.Row="3" Grid.ColumnSpan="2" ToolTip="Percent = Storage Recommendation / Total Usable Storage"/>
-            </Grid>
+            <StackPanel Margin="10">
+                <Border Background="#FFF7F0" BorderBrush="#F2C089" BorderThickness="1" CornerRadius="8" Padding="12" Margin="0,0,0,10">
+                    <StackPanel>
+                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                            <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="18" Foreground="#B96A00" Margin="0,0,8,0"/>
+                            <TextBlock Text="Storage Guidance" FontWeight="Bold" Foreground="#B96A00"/>
+                        </StackPanel>
+                        <TextBlock TextWrapping="Wrap" Margin="0,6,0,0">
+                            Record the full system storage and the recommended storage allocation for your study. The compute action scales other sections by this proportion, so double-check the recommendation before proceeding.
+                        </TextBlock>
+                    </StackPanel>
+                </Border>
+                <Grid Margin="0,10,0,10">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <TextBlock Text="Total Usable Storage" Margin="0,0,5,5"/>
+                    <TextBox Text="{Binding TotalStorage}" Grid.Column="1" Margin="0,0,0,5"/>
+                    <TextBlock Text="Storage Recommendation" Grid.Row="1" Margin="0,0,5,5"/>
+                    <TextBox Text="{Binding StorageRecommendation}" Grid.Row="1" Grid.Column="1" Margin="0,0,0,5"/>
+                    <Button Command="{Binding ComputeStorageCommand}" Grid.Row="2" Grid.ColumnSpan="2" Margin="0,5,0,5">
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                            <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Margin="0,0,6,0"/>
+                            <TextBlock Text="Compute"/>
+                        </StackPanel>
+                    </Button>
+                    <TextBlock Text="{Binding Percent, StringFormat=P: {0:F5}}" Grid.Row="3" Grid.ColumnSpan="2" ToolTip="Percent = Storage Recommendation / Total Usable Storage"/>
+                </Grid>
+                <Border Background="#FFF3E2" BorderBrush="#F2C089" BorderThickness="1" CornerRadius="8" Padding="12">
+                    <TextBlock TextWrapping="Wrap">
+                        The resulting P value shows how much of the joint facilities support your recommendation. Increasing the recommendation or decreasing total storage raises the percentage and, consequently, the share of downstream costs assigned to this project.
+                    </TextBlock>
+                </Border>
+            </StackPanel>
         </TabItem>
         <TabItem Header="Joint Costs O&amp;M">
-            <Grid Margin="10">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="*"/>
-                </Grid.RowDefinitions>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto"/>
-                    <ColumnDefinition Width="*"/>
-                </Grid.ColumnDefinitions>
-                <TextBlock Text="Joint Operations Cost" Margin="0,0,5,5"/>
-                <TextBox Text="{Binding JointOperationsCost}" Grid.Column="1" Margin="0,0,0,5"/>
-                <TextBlock Text="Joint Maintenance Cost" Grid.Row="1" Margin="0,0,5,5"/>
-                <TextBox Text="{Binding JointMaintenanceCost}" Grid.Row="1" Grid.Column="1" Margin="0,0,0,5"/>
-                <Button Content="Compute" Command="{Binding ComputeJointCommand}" Grid.Row="2" Grid.ColumnSpan="2" Margin="0,5,0,5"/>
-                <TextBlock Text="{Binding TotalJointOm, StringFormat=Total Joint O&amp;M: {0:C2}}" Grid.Row="3" Grid.ColumnSpan="2" ToolTip="Total Joint O&amp;M = Joint Operations Cost + Joint Maintenance Cost"/>
-            </Grid>
+            <StackPanel Margin="10">
+                <Border Background="#EEF9F1" BorderBrush="#8BC999" BorderThickness="1" CornerRadius="8" Padding="12" Margin="0,0,0,10">
+                    <StackPanel>
+                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                            <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="18" Foreground="#2F855A" Margin="0,0,8,0"/>
+                            <TextBlock Text="Joint O&amp;M Entry" FontWeight="Bold" Foreground="#2F855A"/>
+                        </StackPanel>
+                        <TextBlock TextWrapping="Wrap" Margin="0,6,0,0">
+                            Enter the system-wide joint operating and maintenance costs on an annual basis. The compute step keeps a running total that is later scaled by the storage percentage.
+                        </TextBlock>
+                    </StackPanel>
+                </Border>
+                <Grid Margin="0,10,0,10">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <TextBlock Text="Joint Operations Cost" Margin="0,0,5,5"/>
+                    <TextBox Text="{Binding JointOperationsCost}" Grid.Column="1" Margin="0,0,0,5"/>
+                    <TextBlock Text="Joint Maintenance Cost" Grid.Row="1" Margin="0,0,5,5"/>
+                    <TextBox Text="{Binding JointMaintenanceCost}" Grid.Row="1" Grid.Column="1" Margin="0,0,0,5"/>
+                    <Button Grid.Row="2" Grid.ColumnSpan="2" Margin="0,5,0,5" Command="{Binding ComputeJointCommand}">
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                            <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Margin="0,0,6,0"/>
+                            <TextBlock Text="Compute"/>
+                        </StackPanel>
+                    </Button>
+                    <TextBlock Text="{Binding TotalJointOm, StringFormat=Total Joint O&amp;M: {0:C2}}" Grid.Row="3" Grid.ColumnSpan="2" ToolTip="Total Joint O&amp;M = Joint Operations Cost + Joint Maintenance Cost"/>
+                </Grid>
+                <Border Background="#E5F4EA" BorderBrush="#8BC999" BorderThickness="1" CornerRadius="8" Padding="12">
+                    <TextBlock TextWrapping="Wrap">
+                        This total represents the joint-system expenses before scaling. When the storage percentage increases, more of this amount will be allocated to the recommended plan in the Total Annual Cost tab.
+                    </TextBlock>
+                </Border>
+            </StackPanel>
         </TabItem>
         <TabItem Header="Updated Storage Cost">
-            <Grid Margin="10">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="*"/>
-                </Grid.RowDefinitions>
-                <DataGrid ItemsSource="{Binding UpdatedCostItems}" AutoGenerateColumns="False" Grid.Row="0" Height="150" Margin="0,0,0,5" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto">
+            <StackPanel Margin="10">
+                <Border Background="#F1F4FF" BorderBrush="#A2B4F5" BorderThickness="1" CornerRadius="8" Padding="12" Margin="0,0,0,10">
+                    <StackPanel>
+                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                            <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="18" Foreground="#3A55B5" Margin="0,0,8,0"/>
+                            <TextBlock Text="Update Legacy Costs" FontWeight="Bold" Foreground="#3A55B5"/>
+                        </StackPanel>
+                        <TextBlock TextWrapping="Wrap" Margin="0,6,0,0">
+                            Replace historical construction costs with current values by pairing each category with the proper update factor. Keep the categories clear so the export remains audit friendly.
+                        </TextBlock>
+                    </StackPanel>
+                </Border>
+                <DataGrid ItemsSource="{Binding UpdatedCostItems}" AutoGenerateColumns="False" Height="160" Margin="0,10,0,5" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto">
                     <DataGrid.Columns>
                         <DataGridTextColumn Header="Category" Binding="{Binding Category}"/>
                         <DataGridTextColumn Header="Actual Cost" Binding="{Binding ActualCost}"/>
@@ -63,98 +140,156 @@
                         <DataGridTextColumn Header="Updated Cost" Binding="{Binding UpdatedCost}" IsReadOnly="True"/>
                     </DataGrid.Columns>
                 </DataGrid>
-                <Button Content="Compute" Command="{Binding ComputeUpdatedStorageCommand}" Grid.Row="1" Margin="0,5,0,5"/>
-                <TextBlock Text="{Binding TotalUpdatedCost, StringFormat=Total Updated Cost: {0:C2}}" Grid.Row="2" ToolTip="Total Updated Cost = Σ(Actual Cost × Update Factor)"/>
-            </Grid>
+                <Button Margin="0,5,0,5" Command="{Binding ComputeUpdatedStorageCommand}">
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                        <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Margin="0,0,6,0"/>
+                        <TextBlock Text="Compute"/>
+                    </StackPanel>
+                </Button>
+                <Border Background="#E7ECFF" BorderBrush="#A2B4F5" BorderThickness="1" CornerRadius="8" Padding="12">
+                    <StackPanel>
+                        <TextBlock Text="{Binding TotalUpdatedCost, StringFormat=Total Updated Cost: {0:C2}}" FontWeight="Bold"/>
+                        <TextBlock TextWrapping="Wrap" Margin="0,6,0,0">
+                            The total updates each category by multiplying the actual cost with the provided factor. A higher factor or cost pushes the sum upward and flows into the capital cost scenarios later.
+                        </TextBlock>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
         </TabItem>
         <TabItem Header="RR&amp;R and Mitigation">
-            <Grid Margin="10">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="*"/>
-                    <RowDefinition Height="Auto"/>
-                </Grid.RowDefinitions>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto"/>
-                    <ColumnDefinition Width="*"/>
-                </Grid.ColumnDefinitions>
-                <TextBlock Text="Federal Discount Rate (%)" Margin="0,0,5,5"/>
-                <TextBox Text="{Binding RrrRate}" Grid.Column="1" Margin="0,0,0,5"/>
-                <TextBlock Text="Analysis Years" Grid.Row="1" Margin="0,0,5,5"/>
-                <TextBox Text="{Binding RrrPeriods}" Grid.Row="1" Grid.Column="1" Margin="0,0,0,5"/>
-                <TextBlock Text="CWCCI" Grid.Row="2" Margin="0,0,5,5"/>
-                <TextBox Text="{Binding RrrCwcci}" Grid.Row="2" Grid.Column="1" Margin="0,0,0,5"/>
-                <TextBlock Text="Base Year" Grid.Row="3" Margin="0,0,5,5"/>
-                <TextBox Text="{Binding RrrBaseYear}" Grid.Row="3" Grid.Column="1" Margin="0,0,0,5"/>
-                <DataGrid ItemsSource="{Binding RrrCostItems}" AutoGenerateColumns="False" Grid.Row="4" Grid.ColumnSpan="2" Height="150" Margin="0,0,0,5" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto">
-                    <DataGrid.Columns>
-                        <DataGridTextColumn Header="Item" Binding="{Binding Item}"/>
-                        <DataGridTextColumn Header="Future Cost" Binding="{Binding FutureCost}"/>
-                        <DataGridTextColumn Header="Year" Binding="{Binding Year}"/>
-                        <DataGridTextColumn Header="PV Factor" Binding="{Binding PvFactor}" IsReadOnly="True"/>
-                        <DataGridTextColumn Header="Present Value" Binding="{Binding PresentValue}" IsReadOnly="True"/>
-                    </DataGrid.Columns>
-                </DataGrid>
-                <Button Content="Compute" Command="{Binding ComputeRrrCommand}" Grid.Row="5" Grid.ColumnSpan="2" Margin="0,5,0,5"/>
-                <StackPanel Grid.Row="6" Grid.ColumnSpan="2">
-                    <TextBlock Text="{Binding RrrUpdatedCost, StringFormat=Updated Cost: {0:C2}}" ToolTip="Updated Cost = Present Value × CWCCI"/>
-                    <TextBlock Text="{Binding RrrAnnualized, StringFormat=Annualized: {0:C2}}" ToolTip="Annualized = Updated Cost × CRF"/>
-                </StackPanel>
-            </Grid>
-        </TabItem>
-        <TabItem Header="Total Annual Cost">
-            <Grid Margin="10">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="*"/>
-                </Grid.RowDefinitions>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto"/>
-                    <ColumnDefinition Width="*"/>
-                </Grid.ColumnDefinitions>
-                <TextBlock Text="Discount Rate 1 (%)" Margin="0,0,5,5"/>
-                <TextBox Text="{Binding DiscountRate1}" Grid.Column="1" Margin="0,0,0,5"/>
-                <TextBlock Text="Analysis Period 1" Grid.Row="1" Margin="0,0,5,5"/>
-                <TextBox Text="{Binding AnalysisPeriod1}" Grid.Row="1" Grid.Column="1" Margin="0,0,0,5"/>
-                <TextBlock Text="Discount Rate 2 (%)" Grid.Row="2" Margin="0,0,5,5"/>
-                <TextBox Text="{Binding DiscountRate2}" Grid.Row="2" Grid.Column="1" Margin="0,0,0,5"/>
-                <TextBlock Text="Analysis Period 2" Grid.Row="3" Margin="0,0,5,5"/>
-                <TextBox Text="{Binding AnalysisPeriod2}" Grid.Row="3" Grid.Column="1" Margin="0,0,0,5"/>
-                <Button Content="Compute" Command="{Binding ComputeTotalCommand}" Grid.Row="4" Grid.ColumnSpan="2" Margin="0,5,0,5"/>
-                <Grid Grid.Row="5" Grid.ColumnSpan="2">
+            <StackPanel Margin="10">
+                <Border Background="#F6F0FF" BorderBrush="#C3A4F6" BorderThickness="1" CornerRadius="8" Padding="12" Margin="0,0,0,10">
+                    <StackPanel>
+                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                            <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="18" Foreground="#6B35B2" Margin="0,0,8,0"/>
+                            <TextBlock Text="RR&amp;R / Mitigation Planner" FontWeight="Bold" Foreground="#6B35B2"/>
+                        </StackPanel>
+                        <TextBlock TextWrapping="Wrap" Margin="0,6,0,0">
+                            Capture future repair, replacement, rehabilitation, and mitigation costs. Use the grid to list each activity, the year it occurs, and its cost in that year dollars. The tool discounts everything back to the base year before applying the CWCCI.
+                        </TextBlock>
+                    </StackPanel>
+                </Border>
+                <Grid Margin="0,10,0,10">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
                         <ColumnDefinition Width="*"/>
                     </Grid.ColumnDefinitions>
-                    <GroupBox Header="Cost 1" Grid.Column="0" Margin="0,0,5,0">
-                        <StackPanel>
-                            <TextBlock Text="{Binding Percent, StringFormat=P: {0:F5}}" ToolTip="Percent = Storage Recommendation / Total Usable Storage"/>
-                            <TextBlock Text="{Binding CostRecommendation, StringFormat=Cost of Storage Recommendation: {0:C2}}" ToolTip="Cost Recommendation = Total Updated Cost × Percent"/>
-                            <TextBlock Text="{Binding Capital1, StringFormat=Annualized Storage Cost 1: {0:C2}}" ToolTip="Annualized Storage Cost 1 = Total Updated Cost × Percent × CRF1"/>
-                            <TextBlock Text="{Binding OmScaled, StringFormat=Joint O&amp;M: {0:C2}}" ToolTip="Joint O&amp;M = Total Joint O&amp;M × Percent"/>
-                            <TextBlock Text="{Binding RrrScaled, StringFormat=Annualized RR&amp;R/Mitigation: {0:C2}}" ToolTip="Annualized RR&amp;R/Mitigation = RRR Annualized × Percent"/>
-                            <TextBlock Text="{Binding Total1, StringFormat=Total Annual Cost 1: {0:C2}}" ToolTip="Total Annual Cost 1 = Capital1 + Joint O&amp;M + Annualized RR&amp;R/Mitigation"/>
+                    <TextBlock Text="Federal Discount Rate (%)" Margin="0,0,5,5"/>
+                    <TextBox Text="{Binding RrrRate}" Grid.Column="1" Margin="0,0,0,5"/>
+                    <TextBlock Text="Analysis Years" Grid.Row="1" Margin="0,0,5,5"/>
+                    <TextBox Text="{Binding RrrPeriods}" Grid.Row="1" Grid.Column="1" Margin="0,0,0,5"/>
+                    <TextBlock Text="CWCCI" Grid.Row="2" Margin="0,0,5,5"/>
+                    <TextBox Text="{Binding RrrCwcci}" Grid.Row="2" Grid.Column="1" Margin="0,0,0,5"/>
+                    <TextBlock Text="Base Year" Grid.Row="3" Margin="0,0,5,5"/>
+                    <TextBox Text="{Binding RrrBaseYear}" Grid.Row="3" Grid.Column="1" Margin="0,0,0,5"/>
+                    <DataGrid ItemsSource="{Binding RrrCostItems}" AutoGenerateColumns="False" Grid.Row="4" Grid.ColumnSpan="2" Height="150" Margin="0,0,0,5" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto">
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Header="Item" Binding="{Binding Item}"/>
+                            <DataGridTextColumn Header="Future Cost" Binding="{Binding FutureCost}"/>
+                            <DataGridTextColumn Header="Year" Binding="{Binding Year}"/>
+                            <DataGridTextColumn Header="PV Factor" Binding="{Binding PvFactor}" IsReadOnly="True"/>
+                            <DataGridTextColumn Header="Present Value" Binding="{Binding PresentValue}" IsReadOnly="True"/>
+                        </DataGrid.Columns>
+                    </DataGrid>
+                    <Button Grid.Row="5" Grid.ColumnSpan="2" Margin="0,5,0,5" Command="{Binding ComputeRrrCommand}">
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                            <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Margin="0,0,6,0"/>
+                            <TextBlock Text="Compute"/>
                         </StackPanel>
-                    </GroupBox>
-                    <GroupBox Header="Cost 2" Grid.Column="1" Margin="5,0,0,0">
-                        <StackPanel>
-                            <TextBlock Text="{Binding Percent, StringFormat=P: {0:F5}}" ToolTip="Percent = Storage Recommendation / Total Usable Storage"/>
-                            <TextBlock Text="{Binding CostRecommendation, StringFormat=Cost of Storage Recommendation: {0:C2}}" ToolTip="Cost Recommendation = Total Updated Cost × Percent"/>
-                            <TextBlock Text="{Binding Capital2, StringFormat=Annualized Storage Cost 2: {0:C2}}" ToolTip="Annualized Storage Cost 2 = Total Updated Cost × Percent × CRF2"/>
-                            <TextBlock Text="{Binding OmScaled, StringFormat=Joint O&amp;M: {0:C2}}" ToolTip="Joint O&amp;M = Total Joint O&amp;M × Percent"/>
-                            <TextBlock Text="{Binding Total2, StringFormat=Total Annual Cost 2: {0:C2}}" ToolTip="Total Annual Cost 2 = Capital2 + Joint O&amp;M"/>
-                        </StackPanel>
-                    </GroupBox>
+                    </Button>
+                    <StackPanel Grid.Row="6" Grid.ColumnSpan="2">
+                        <TextBlock Text="{Binding RrrUpdatedCost, StringFormat=Updated Cost: {0:C2}}" ToolTip="Updated Cost = Present Value × CWCCI" FontWeight="Bold" Margin="0,0,0,4"/>
+                        <TextBlock Text="{Binding RrrAnnualized, StringFormat=Annualized: {0:C2}}" ToolTip="Annualized = Updated Cost × CRF" FontWeight="Bold"/>
+                    </StackPanel>
                 </Grid>
-            </Grid>
+                <Border Background="#F1E8FF" BorderBrush="#C3A4F6" BorderThickness="1" CornerRadius="8" Padding="12">
+                    <TextBlock TextWrapping="Wrap">
+                        Present Value aggregates each scheduled cost using the discount rate and base year. The Updated Cost multiplies that total by CWCCI, and the Annualized figure then applies your capital recovery factor. Larger future costs, slower discounting, or higher CWCCI will elevate every downstream total.
+                    </TextBlock>
+                </Border>
+            </StackPanel>
+        </TabItem>
+        <TabItem Header="Total Annual Cost">
+            <StackPanel Margin="10">
+                <Border Background="#E9F3FF" BorderBrush="#8DB6E3" BorderThickness="1" CornerRadius="8" Padding="12" Margin="0,0,0,10">
+                    <StackPanel>
+                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                            <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="18" Foreground="#1F6AB0" Margin="0,0,8,0"/>
+                            <TextBlock Text="Compare Annual Cost Scenarios" FontWeight="Bold" Foreground="#1F6AB0"/>
+                        </StackPanel>
+                        <TextBlock TextWrapping="Wrap" Margin="0,6,0,0">
+                            Define up to two capital recovery scenarios. Each uses its own discount rate and analysis period to annualize the updated costs, then layers on scaled joint O&amp;M and RR&amp;R/mitigation values.
+                        </TextBlock>
+                    </StackPanel>
+                </Border>
+                <Grid Margin="0,10,0,10">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <TextBlock Text="Discount Rate 1 (%)" Margin="0,0,5,5"/>
+                    <TextBox Text="{Binding DiscountRate1}" Grid.Column="1" Margin="0,0,0,5"/>
+                    <TextBlock Text="Analysis Period 1" Grid.Row="1" Margin="0,0,5,5"/>
+                    <TextBox Text="{Binding AnalysisPeriod1}" Grid.Row="1" Grid.Column="1" Margin="0,0,0,5"/>
+                    <TextBlock Text="Discount Rate 2 (%)" Grid.Row="2" Margin="0,0,5,5"/>
+                    <TextBox Text="{Binding DiscountRate2}" Grid.Row="2" Grid.Column="1" Margin="0,0,0,5"/>
+                    <TextBlock Text="Analysis Period 2" Grid.Row="3" Margin="0,0,5,5"/>
+                    <TextBox Text="{Binding AnalysisPeriod2}" Grid.Row="3" Grid.Column="1" Margin="0,0,0,5"/>
+                    <Button Grid.Row="4" Grid.ColumnSpan="2" Margin="0,5,0,5" Command="{Binding ComputeTotalCommand}">
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                            <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Margin="0,0,6,0"/>
+                            <TextBlock Text="Compute"/>
+                        </StackPanel>
+                    </Button>
+                    <Grid Grid.Row="5" Grid.ColumnSpan="2">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <GroupBox Header="Cost 1" Grid.Column="0" Margin="0,0,5,0">
+                            <StackPanel>
+                                <TextBlock Text="{Binding Percent, StringFormat=P: {0:F5}}" ToolTip="Percent = Storage Recommendation / Total Usable Storage"/>
+                                <TextBlock Text="{Binding CostRecommendation, StringFormat=Cost of Storage Recommendation: {0:C2}}" ToolTip="Cost Recommendation = Total Updated Cost × Percent"/>
+                                <TextBlock Text="{Binding Capital1, StringFormat=Annualized Storage Cost 1: {0:C2}}" ToolTip="Annualized Storage Cost 1 = Total Updated Cost × Percent × CRF1"/>
+                                <TextBlock Text="{Binding OmScaled, StringFormat=Joint O&amp;M: {0:C2}}" ToolTip="Joint O&amp;M = Total Joint O&amp;M × Percent"/>
+                                <TextBlock Text="{Binding RrrScaled, StringFormat=Annualized RR&amp;R/Mitigation: {0:C2}}" ToolTip="Annualized RR&amp;R/Mitigation = RRR Annualized × Percent"/>
+                                <TextBlock Text="{Binding Total1, StringFormat=Total Annual Cost 1: {0:C2}}" ToolTip="Total Annual Cost 1 = Capital1 + Joint O&amp;M + Annualized RR&amp;R/Mitigation" FontWeight="Bold"/>
+                            </StackPanel>
+                        </GroupBox>
+                        <GroupBox Header="Cost 2" Grid.Column="1" Margin="5,0,0,0">
+                            <StackPanel>
+                                <TextBlock Text="{Binding Percent, StringFormat=P: {0:F5}}" ToolTip="Percent = Storage Recommendation / Total Usable Storage"/>
+                                <TextBlock Text="{Binding CostRecommendation, StringFormat=Cost of Storage Recommendation: {0:C2}}" ToolTip="Cost Recommendation = Total Updated Cost × Percent"/>
+                                <TextBlock Text="{Binding Capital2, StringFormat=Annualized Storage Cost 2: {0:C2}}" ToolTip="Annualized Storage Cost 2 = Total Updated Cost × Percent × CRF2"/>
+                                <TextBlock Text="{Binding OmScaled, StringFormat=Joint O&amp;M: {0:C2}}" ToolTip="Joint O&amp;M = Total Joint O&amp;M × Percent"/>
+                                <TextBlock Text="{Binding Total2, StringFormat=Total Annual Cost 2: {0:C2}}" ToolTip="Total Annual Cost 2 = Capital2 + Joint O&amp;M" FontWeight="Bold"/>
+                            </StackPanel>
+                        </GroupBox>
+                    </Grid>
+                </Grid>
+                <Border Background="#DBECFF" BorderBrush="#8DB6E3" BorderThickness="1" CornerRadius="8" Padding="12">
+                    <TextBlock TextWrapping="Wrap">
+                        Cost 1 and Cost 2 let you compare alternative discounting assumptions. Lower discount rates or longer analysis periods increase the capital recovery factor and therefore annualized storage costs. Because joint O&amp;M and RR&amp;R values scale with the storage percentage, any change you make on earlier tabs will ripple into both scenarios here.
+                    </TextBlock>
+                </Border>
+            </StackPanel>
         </TabItem>
         </TabControl>
         </StackPanel>

--- a/Views/WaterDemandView.xaml
+++ b/Views/WaterDemandView.xaml
@@ -10,8 +10,26 @@
                 <RowDefinition Height="*"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
-            <TextBlock Grid.Row="0" Text="Provide historical demand data, choose a forecast length and method, then compute results." TextWrapping="Wrap"/>
+            <Border Grid.Row="0" Background="#E6F5FF" BorderBrush="#7DC2E8" BorderThickness="1" CornerRadius="10" Padding="14" Margin="0,0,0,10">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <Canvas Width="60" Height="60">
+                        <Path Data="M30,5 C16,20 8,32 8,41 C8,52 17,60 30,60 C43,60 52,52 52,41 C52,32 44,20 30,5 Z" Fill="#7DC2E8"/>
+                        <Path Data="M30,12 C21,23 16,32 16,41 C16,48 22,53 30,53 C38,53 44,48 44,41 C44,32 39,23 30,12 Z" Fill="White" Opacity="0.6"/>
+                    </Canvas>
+                    <StackPanel Grid.Column="1" Margin="12,0,0,0">
+                        <TextBlock Text="Water Demand Forecast Instructions" FontSize="18" FontWeight="Bold" Foreground="#1F6AB0"/>
+                        <TextBlock TextWrapping="Wrap" Margin="0,6,0,0">
+                            Enter historic data first, choose or add scenarios, then specify forecast horizon and demographic assumptions. Use the Forecast button within each scenario to update charts and tables, and Export when you are ready to archive the scenario.
+                        </TextBlock>
+                    </StackPanel>
+                </Grid>
+            </Border>
             <TabControl Grid.Row="1" ItemsSource="{Binding Scenarios}" SelectedItem="{Binding SelectedScenario}">
                 <TabControl.ItemTemplate>
                     <DataTemplate>
@@ -109,8 +127,18 @@
                                     </Expander>
 
                                     <StackPanel Grid.Row="8" Grid.ColumnSpan="3" Orientation="Horizontal" HorizontalAlignment="Left">
-                                        <Button Content="Forecast" Width="80" Command="{Binding DataContext.ForecastCommand, ElementName=Root}" Margin="0,0,5,0"/>
-                                        <Button Content="Export" Width="80" Command="{Binding DataContext.ExportCommand, ElementName=Root}"/>
+                                        <Button Width="110" Command="{Binding DataContext.ForecastCommand, ElementName=Root}" Margin="0,0,5,0">
+                                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                                                <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Margin="0,0,6,0"/>
+                                                <TextBlock Text="Forecast"/>
+                                            </StackPanel>
+                                        </Button>
+                                        <Button Width="110" Command="{Binding DataContext.ExportCommand, ElementName=Root}">
+                                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                                                <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Margin="0,0,6,0"/>
+                                                <TextBlock Text="Export"/>
+                                            </StackPanel>
+                                        </Button>
                                     </StackPanel>
                                 </Grid>
                                 <Border Grid.Row="2" Background="White" CornerRadius="4" Padding="5">
@@ -188,8 +216,39 @@
                     </DataTemplate>
                 </TabControl.ContentTemplate>
             </TabControl>
-            <TextBlock Grid.Row="2" Text="{Binding SelectedScenario.Description}" FontWeight="SemiBold" TextWrapping="Wrap" Margin="0,10,0,0"/>
-            <TextBlock Grid.Row="3" Text="{Binding Explanation}" FontWeight="Bold" TextWrapping="Wrap" Margin="0,10,0,0"/>
+            <Border Grid.Row="2" Background="#F0F7FE" BorderBrush="#A6C4EB" BorderThickness="1" CornerRadius="8" Padding="12" Margin="0,10,0,0">
+                <StackPanel>
+                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                        <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="18" Foreground="#1F6AB0" Margin="0,0,8,0"/>
+                        <TextBlock Text="Scenario Summary" FontWeight="Bold" Foreground="#1F6AB0"/>
+                    </StackPanel>
+                    <TextBlock Text="{Binding SelectedScenario.Description}" TextWrapping="Wrap" Margin="0,6,0,0"/>
+                </StackPanel>
+            </Border>
+            <Border Grid.Row="3" Background="#FDF5E6" BorderBrush="#E8C97D" BorderThickness="1" CornerRadius="8" Padding="12" Margin="0,10,0,0">
+                <StackPanel>
+                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                        <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="18" Foreground="#B58900" Margin="0,0,8,0"/>
+                        <TextBlock Text="Forecast Logic" FontWeight="Bold" Foreground="#B58900"/>
+                    </StackPanel>
+                    <TextBlock Text="{Binding Explanation}" TextWrapping="Wrap" Margin="0,6,0,0"/>
+                </StackPanel>
+            </Border>
+            <Border Grid.Row="4" Background="#F6FFED" BorderBrush="#9CD06F" BorderThickness="1" CornerRadius="8" Padding="12" Margin="0,10,0,0">
+                <StackPanel>
+                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                        <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="18" Foreground="#417505" Margin="0,0,8,0"/>
+                        <TextBlock Text="How to Read the Results" FontWeight="Bold" Foreground="#417505"/>
+                    </StackPanel>
+                    <TextBlock TextWrapping="Wrap" Margin="0,6,0,0">
+                        • Growth Rate reflects the year-over-year percent change driven by your population and per-capita assumptions. Higher growth inputs raise this column.
+                        <LineBreak/>
+                        • Demand shows projected system demand before sector allocations. Each sector column (Residential, Commercial, Industrial, Agricultural) applies the percentages you supplied.
+                        <LineBreak/>
+                        • Adjusted demand applies the Advanced Adjustments so you can see conservation impacts immediately.
+                    </TextBlock>
+                </StackPanel>
+            </Border>
         </Grid>
     </ScrollViewer>
 </UserControl>


### PR DESCRIPTION
## Summary
- add an application banner and refreshed calculate/export buttons to reinforce user guidance across the toolbox
- expand each analytical tab with instructional cards, iconography, and narrative explanations of key outputs and their drivers
- refine individual tools (EAD, Updated Cost, Water Demand, and Unit Day Value) with wrapped text, compute/export controls, and interpretation panels

## Testing
- unable to run `dotnet build` (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68c832e922d08330bfe969e5f3f3b587