### PR TITLE
Enhance layout responsiveness and design

### DIFF
--- a/App.xaml
+++ b/App.xaml
@@ -3,37 +3,10 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              StartupUri="MainWindow.xaml">
     <Application.Resources>
-        <!-- Global color palette -->
-        <Color x:Key="PrimaryColor">#2D6A8E</Color>
-        <Color x:Key="AccentColor">#1ABC9C</Color>
-        <Color x:Key="BackgroundColor">#F4F7FB</Color>
-
-        <SolidColorBrush x:Key="PrimaryBrush" Color="{StaticResource PrimaryColor}"/>
-        <SolidColorBrush x:Key="AccentBrush" Color="{StaticResource AccentColor}"/>
-        <SolidColorBrush x:Key="BackgroundBrush" Color="{StaticResource BackgroundColor}"/>
-
-        <!-- Modernized control styles -->
-        <Style TargetType="Button">
-            <Setter Property="Background" Value="{StaticResource PrimaryBrush}"/>
-            <Setter Property="Foreground" Value="White"/>
-            <Setter Property="Padding" Value="10,5"/>
-            <Setter Property="Margin" Value="4"/>
-            <Setter Property="BorderThickness" Value="0"/>
-            <Setter Property="FontWeight" Value="SemiBold"/>
-        </Style>
-
-        <Style TargetType="TextBox">
-            <Setter Property="Margin" Value="4"/>
-            <Setter Property="Padding" Value="4"/>
-            <Setter Property="BorderBrush" Value="{StaticResource AccentBrush}"/>
-            <Setter Property="BorderThickness" Value="1"/>
-        </Style>
-
-        <Style TargetType="DataGrid">
-            <Setter Property="RowBackground" Value="White"/>
-            <Setter Property="AlternatingRowBackground" Value="#E9EFF5"/>
-            <Setter Property="GridLinesVisibility" Value="None"/>
-            <Setter Property="BorderBrush" Value="Transparent"/>
-        </Style>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="Themes/Design.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/Converters/WidthToLayoutModeConverter.cs
+++ b/Converters/WidthToLayoutModeConverter.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace EconToolbox.Desktop.Converters
+{
+    public class WidthToLayoutModeConverter : IValueConverter
+    {
+        public double Threshold { get; set; } = 800;
+
+        private const string WideMode = "Wide";
+        private const string NarrowMode = "Narrow";
+
+        public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            if (value is double width && !double.IsNaN(width))
+            {
+                return width >= Threshold ? WideMode : NarrowMode;
+            }
+
+            return NarrowMode;
+        }
+
+        public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            return Binding.DoNothing;
+        }
+    }
+}

--- a/EconToolbox.Desktop.csproj
+++ b/EconToolbox.Desktop.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <Nullable>enable</Nullable>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ClosedXML" Version="0.104.0" />

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -3,271 +3,427 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:vm="clr-namespace:EconToolbox.Desktop.ViewModels"
         xmlns:views="clr-namespace:EconToolbox.Desktop.Views"
-        Title="Economic Toolbox" Height="700" Width="960" MinWidth="640" MinHeight="600"
-        ResizeMode="CanResize" Background="{StaticResource BackgroundBrush}" FontFamily="Segoe UI">
+        Title="Economic Toolbox"
+        Height="700"
+        Width="960"
+        MinWidth="640"
+        MinHeight="600"
+        ResizeMode="CanResize"
+        SnapsToDevicePixels="True"
+        UseLayoutRounding="True">
     <Window.DataContext>
         <vm:MainViewModel/>
     </Window.DataContext>
+
+    <Window.Resources>
+        <ResourceDictionary>
+            <DataTemplate x:Key="HeroWideTemplate">
+                <Grid Margin="0"
+                      HorizontalAlignment="Stretch">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="*" MinWidth="300"/>
+                    </Grid.ColumnDefinitions>
+                    <Canvas Width="120"
+                            Height="80"
+                            Margin="{StaticResource Margin.InlineLarge}">
+                        <Path Data="M10,70 L30,45 L55,55 L85,20"
+                              Stroke="White"
+                              StrokeThickness="4"
+                              StrokeEndLineCap="Round"
+                              StrokeStartLineCap="Round"/>
+                        <Ellipse Width="10" Height="10" Fill="{StaticResource Brush.Accent}" Canvas.Left="6" Canvas.Top="65"/>
+                        <Ellipse Width="10" Height="10" Fill="{StaticResource Brush.Accent}" Canvas.Left="26" Canvas.Top="40"/>
+                        <Ellipse Width="10" Height="10" Fill="{StaticResource Brush.Accent}" Canvas.Left="51" Canvas.Top="50"/>
+                        <Ellipse Width="12" Height="12" Fill="White" Canvas.Left="79" Canvas.Top="14"/>
+                    </Canvas>
+                    <StackPanel Grid.Column="1">
+                        <StackPanel Orientation="Horizontal" Margin="{StaticResource Margin.Stack}">
+                            <TextBlock FontFamily="Segoe MDL2 Assets"
+                                       Text=""
+                                       FontSize="30"
+                                       Foreground="White"
+                                       Margin="{StaticResource Margin.Inline}"/>
+                            <TextBlock Text="Economic Toolbox"
+                                       Style="{StaticResource Text.Title}"/>
+                        </StackPanel>
+                        <TextBlock Style="{StaticResource Text.Body}"
+                                   Foreground="White"
+                                   Margin="{StaticResource Margin.Stack}">
+                            Review each tab to build a complete project narrative. Enter inputs carefully, press Calculate when
+                            available, and use Export to capture your work. Context-sensitive tips below explain what each result
+                            means and how your assumptions drive it.
+                        </TextBlock>
+                    </StackPanel>
+                </Grid>
+            </DataTemplate>
+
+            <DataTemplate x:Key="HeroNarrowTemplate">
+                <StackPanel Margin="0"
+                            HorizontalAlignment="Stretch">
+                    <Canvas Width="100"
+                            Height="70"
+                            HorizontalAlignment="Center"
+                            Margin="{StaticResource Margin.Stack}">
+                        <Path Data="M10,60 L25,35 L45,45 L70,15"
+                              Stroke="White"
+                              StrokeThickness="4"
+                              StrokeEndLineCap="Round"
+                              StrokeStartLineCap="Round"/>
+                        <Ellipse Width="10" Height="10" Fill="{StaticResource Brush.Accent}" Canvas.Left="6" Canvas.Top="55"/>
+                        <Ellipse Width="10" Height="10" Fill="{StaticResource Brush.Accent}" Canvas.Left="24" Canvas.Top="30"/>
+                        <Ellipse Width="10" Height="10" Fill="{StaticResource Brush.Accent}" Canvas.Left="44" Canvas.Top="40"/>
+                        <Ellipse Width="12" Height="12" Fill="White" Canvas.Left="68" Canvas.Top="10"/>
+                    </Canvas>
+                    <StackPanel Margin="{StaticResource Margin.Stack}"
+                                HorizontalAlignment="Center">
+                        <TextBlock Text="Economic Toolbox"
+                                   Style="{StaticResource Text.Title}"/>
+                    </StackPanel>
+                    <TextBlock Style="{StaticResource Text.Body}"
+                               Foreground="White"
+                               TextAlignment="Center"
+                               Margin="{StaticResource Margin.Stack}">
+                        Review each tab to build a complete project narrative. Enter inputs carefully, press Calculate when
+                        available, and use Export to capture your work. Context-sensitive tips below explain what each result means
+                        and how your assumptions drive it.
+                    </TextBlock>
+                </StackPanel>
+            </DataTemplate>
+
+            <DataTemplate x:Key="ActionsWideTemplate">
+                <Grid HorizontalAlignment="Right"
+                      Grid.IsSharedSizeScope="True">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" SharedSizeGroup="ActionButtons"/>
+                        <ColumnDefinition Width="Auto" SharedSizeGroup="ActionButtons"/>
+                    </Grid.ColumnDefinitions>
+                    <Button x:Name="CalculateButton"
+                            Command="{Binding CalculateCommand}"
+                            Margin="{StaticResource Margin.Inline}"
+                            HorizontalAlignment="Stretch">
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                            <TextBlock FontFamily="Segoe MDL2 Assets"
+                                       Text=""
+                                       Margin="{StaticResource Margin.Inline}"
+                                       FontSize="16"/>
+                            <TextBlock Text="Calculate"/>
+                        </StackPanel>
+                    </Button>
+                    <Button Grid.Column="1"
+                            Command="{Binding ExportCommand}"
+                            HorizontalAlignment="Stretch">
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                            <TextBlock FontFamily="Segoe MDL2 Assets"
+                                       Text=""
+                                       Margin="{StaticResource Margin.Inline}"
+                                       FontSize="16"/>
+                            <TextBlock Text="Export"/>
+                        </StackPanel>
+                    </Button>
+                </Grid>
+            </DataTemplate>
+
+            <DataTemplate x:Key="ActionsNarrowTemplate">
+                <StackPanel>
+                    <Button Command="{Binding CalculateCommand}">
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                            <TextBlock FontFamily="Segoe MDL2 Assets"
+                                       Text=""
+                                       Margin="{StaticResource Margin.Inline}"
+                                       FontSize="16"/>
+                            <TextBlock Text="Calculate"/>
+                        </StackPanel>
+                    </Button>
+                    <Button Command="{Binding ExportCommand}">
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                            <TextBlock FontFamily="Segoe MDL2 Assets"
+                                       Text=""
+                                       Margin="{StaticResource Margin.Inline}"
+                                       FontSize="16"/>
+                            <TextBlock Text="Export"/>
+                        </StackPanel>
+                    </Button>
+                </StackPanel>
+            </DataTemplate>
+        </ResourceDictionary>
+    </Window.Resources>
+
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
-        <Border Grid.Row="0" Background="{StaticResource PrimaryBrush}" Padding="20" CornerRadius="0,0,12,12">
-            <Grid>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto"/>
-                    <ColumnDefinition Width="*"/>
-                </Grid.ColumnDefinitions>
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                </Grid.RowDefinitions>
-                <Canvas Grid.Row="0" Grid.RowSpan="2" Width="120" Height="80" Margin="0,0,16,0"
-                        HorizontalAlignment="Left" VerticalAlignment="Center">
-                    <Path Data="M10,70 L30,45 L55,55 L85,20" Stroke="White" StrokeThickness="4" StrokeEndLineCap="Round" StrokeStartLineCap="Round"/>
-                    <Ellipse Width="10" Height="10" Fill="{StaticResource AccentBrush}" Canvas.Left="6" Canvas.Top="65"/>
-                    <Ellipse Width="10" Height="10" Fill="{StaticResource AccentBrush}" Canvas.Left="26" Canvas.Top="40"/>
-                    <Ellipse Width="10" Height="10" Fill="{StaticResource AccentBrush}" Canvas.Left="51" Canvas.Top="50"/>
-                    <Ellipse Width="12" Height="12" Fill="White" Canvas.Left="79" Canvas.Top="14"/>
-                </Canvas>
-                <StackPanel Grid.Column="1" Grid.Row="0" Grid.RowSpan="2" Margin="0" HorizontalAlignment="Stretch">
-                    <Grid Margin="0,0,0,10">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto"/>
-                            <ColumnDefinition Width="*"/>
-                        </Grid.ColumnDefinitions>
-                        <TextBlock Grid.Column="0" FontFamily="Segoe MDL2 Assets" Text="" FontSize="28" Foreground="White" Margin="0,0,8,0"/>
-                        <TextBlock Grid.Column="1" Text="Economic Toolbox" FontSize="28" FontWeight="Bold" Foreground="White" TextWrapping="Wrap"/>
-                    </Grid>
-                    <TextBlock TextWrapping="Wrap" Foreground="White">
-                        <Run Text="Review each tab to build a complete project narrative."/>
-                        <LineBreak/>
-                        <Run Text="Enter inputs carefully, press Calculate when available, and use Export to capture your work."/>
-                        <LineBreak/>
-                        <Run Text="Context-sensitive tips below explain what each result means and how your assumptions drive it."/>
-                    </TextBlock>
-                </StackPanel>
-            </Grid>
-        </Border>
-        <ScrollViewer Grid.Row="1" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
-            <TabControl Margin="10" SelectedIndex="{Binding SelectedIndex}" FontSize="14" Background="White">
-                <TabControl.Resources>
-                    <Style TargetType="TabItem">
-                        <Setter Property="MinWidth" Value="120"/>
-                        <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+
+        <Border Grid.Row="0"
+                Background="{StaticResource Brush.Primary}"
+                Padding="{StaticResource Padding.Section}"
+                CornerRadius="0,0,12,12">
+            <ContentControl Content="{Binding}">
+                <ContentControl.Style>
+                    <Style TargetType="ContentControl">
+                        <Setter Property="ContentTemplate" Value="{StaticResource HeroNarrowTemplate}"/>
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding ActualWidth, RelativeSource={RelativeSource AncestorType=Window}, Converter={StaticResource WidthToLayoutModeConverter}}"
+                                         Value="Wide">
+                                <Setter Property="ContentTemplate" Value="{StaticResource HeroWideTemplate}"/>
+                            </DataTrigger>
+                        </Style.Triggers>
                     </Style>
-                </TabControl.Resources>
-                
-                <TabItem DataContext="{Binding Ead}">
-                    <TabItem.Header>
-                        <TextBlock Text="EAD" TextWrapping="Wrap" TextAlignment="Center"/>
-                    </TabItem.Header>
-                    <views:EadView/>
-                </TabItem>
-                <TabItem DataContext="{Binding UpdatedCost}">
-                    <TabItem.Header>
-                        <TextBlock Text="Updated Cost of Storage" TextWrapping="Wrap" TextAlignment="Center"/>
-                    </TabItem.Header>
-                    <views:UpdatedCostView/>
-                </TabItem>
-                <TabItem DataContext="{Binding Annualizer}">
-                    <TabItem.Header>
-                        <TextBlock Text="Cost Annualization" TextWrapping="Wrap" TextAlignment="Center"/>
-                    </TabItem.Header>
-                    <StackPanel Margin="10">
-                        <Border Background="#E8F4FB" BorderBrush="{StaticResource PrimaryBrush}" BorderThickness="1" CornerRadius="8" Padding="15" Margin="0,0,0,10">
-                            <StackPanel>
-                                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                    <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="20" Foreground="{StaticResource PrimaryBrush}" Margin="0,0,8,0"/>
-                                    <TextBlock Text="Cost Annualization Workflow" FontWeight="Bold" FontSize="16" Foreground="{StaticResource PrimaryBrush}"/>
-                                </StackPanel>
-                                <TextBlock TextWrapping="Wrap" Margin="0,8,0,0">
-                                    <Run Text="1. Document upfront investments, financing assumptions, and the analysis period."/>
-                                    <LineBreak/>
-                                    <Run Text="2. Capture the construction cash flow in the IDC schedule and list all future costs in the year they occur."/>
-                                    <LineBreak/>
-                                    <Run Text="3. Provide annual O&amp;M and annual benefits so the tool can translate capital outlays into comparable annual metrics."/>
-                                    <LineBreak/>
-                                    <Run Text="Use the Calculate button at the bottom of the window whenever you update inputs."/>
-                                </TextBlock>
-                            </StackPanel>
-                        </Border>
-                        <Grid Margin="0,10,0,0">
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                        </Grid.RowDefinitions>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto"/>
-                            <ColumnDefinition Width="*"/>
-                        </Grid.ColumnDefinitions>
-                        <TextBlock Text="First Cost" Margin="0,0,5,5" ToolTip="Initial project cost."/>
-                        <TextBox Text="{Binding FirstCost}" Grid.Column="1" Margin="0,0,0,5"
-                                 ToolTip="Initial project cost."/>
-                        <TextBlock Text="Rate (%)" Grid.Row="1" Margin="0,0,5,5" ToolTip="Discount rate in percent."/>
-                        <TextBox Text="{Binding Rate}" Grid.Row="1" Grid.Column="1" Margin="0,0,0,5"
-                                 ToolTip="Discount rate in percent."/>
-                        <TextBlock Text="Base Year" Grid.Row="2" Margin="0,0,5,5"/>
-                        <TextBox Text="{Binding BaseYear}" Grid.Row="2" Grid.Column="1" Margin="0,0,0,5"/>
-                        <TextBlock Text="Analysis Period" Grid.Row="3" Margin="0,0,5,5" ToolTip="Number of periods for capital recovery."/>
-                        <TextBox Text="{Binding AnalysisPeriod}" Grid.Row="3" Grid.Column="1" Margin="0,0,0,5"
-                                 ToolTip="Number of periods for capital recovery."/>
-                        <TextBlock Text="Annual O&amp;M" Grid.Row="4" Margin="0,0,5,5" ToolTip="Annual operations and maintenance cost."/>
-                        <TextBox Text="{Binding AnnualOm}" Grid.Row="4" Grid.Column="1" Margin="0,0,0,5"
-                                 ToolTip="Annual operations and maintenance cost."/>
-                        <TextBlock Text="Annual Benefits" Grid.Row="5" Margin="0,0,5,5" ToolTip="Expected annual benefits."/>
-                        <TextBox Text="{Binding AnnualBenefits}" Grid.Row="5" Grid.Column="1" Margin="0,0,0,5"
-                                 ToolTip="Expected annual benefits."/>
-                        <TextBlock Text="Construction Months" Grid.Row="6" Margin="0,0,5,5"/>
-                        <TextBox Text="{Binding ConstructionMonths}" Grid.Row="6" Grid.Column="1" Margin="0,0,0,5"/>
-                        <TextBlock Text="IDC Schedule" Grid.Row="7" Margin="0,0,5,5"/>
-                        <DataGrid ItemsSource="{Binding IdcEntries}" Grid.Row="7" Grid.Column="1" AutoGenerateColumns="False" Margin="0,0,0,5" VerticalAlignment="Stretch" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto">
-                            <DataGrid.Columns>
-                                <DataGridTextColumn Header="Cost" Binding="{Binding Cost}"/>
-                                <DataGridTextColumn Header="Month" Binding="{Binding Year}"/>
-                                <DataGridComboBoxColumn Header="Timing" SelectedItemBinding="{Binding Timing}">
-                                    <DataGridComboBoxColumn.ItemsSource>
-                                        <x:Array Type="sys:String" xmlns:sys="clr-namespace:System;assembly=mscorlib">
-                                            <sys:String>beginning</sys:String>
-                                            <sys:String>midpoint</sys:String>
-                                            <sys:String>end</sys:String>
-                                        </x:Array>
-                                    </DataGridComboBoxColumn.ItemsSource>
-                                </DataGridComboBoxColumn>
-                                <DataGridTextColumn Header="PV Factor" Binding="{Binding PvFactor}" IsReadOnly="True"/>
-                            </DataGrid.Columns>
-                        </DataGrid>
-                        <TextBlock Text="Future Costs" Grid.Row="8" Margin="0,0,5,5"/>
-                        <DataGrid ItemsSource="{Binding FutureCosts}" Grid.Row="8" Grid.Column="1" AutoGenerateColumns="False" Margin="0,0,0,5" VerticalAlignment="Stretch" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto">
-                            <DataGrid.Columns>
-                                <DataGridTextColumn Header="Cost" Binding="{Binding Cost}"/>
-                                <DataGridTextColumn Header="Year" Binding="{Binding Year}"/>
-                                <DataGridComboBoxColumn Header="Timing" SelectedItemBinding="{Binding Timing}">
-                                    <DataGridComboBoxColumn.ItemsSource>
-                                        <x:Array Type="sys:String" xmlns:sys="clr-namespace:System;assembly=mscorlib">
-                                            <sys:String>beginning</sys:String>
-                                            <sys:String>midpoint</sys:String>
-                                            <sys:String>end</sys:String>
-                                        </x:Array>
-                                    </DataGridComboBoxColumn.ItemsSource>
-                                </DataGridComboBoxColumn>
-                                <DataGridTextColumn Header="PV Factor" Binding="{Binding PvFactor}" IsReadOnly="True"/>
-                            </DataGrid.Columns>
-                        </DataGrid>
-                        <StackPanel Grid.Row="9" Grid.ColumnSpan="2">
-                            <Border Background="White" CornerRadius="6" Padding="10" BorderBrush="#D0E4F2" BorderThickness="1" Margin="0,0,0,8">
-                                <Grid>
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="Auto"/>
-                                        <ColumnDefinition Width="Auto"/>
-                                        <ColumnDefinition Width="*"/>
-                                    </Grid.ColumnDefinitions>
-                                    <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="18" Foreground="{StaticResource PrimaryBrush}" Margin="0,0,8,0" VerticalAlignment="Center"/>
-                                    <TextBlock Grid.Column="1" FontWeight="Bold" Text="{Binding Idc, StringFormat=IDC: {0:C2}}" VerticalAlignment="Center"/>
-                                    <TextBlock Grid.Column="2" TextWrapping="Wrap" Margin="12,0,0,0" Foreground="#31556F">
-                                        Interest during construction accumulates from the IDC schedule using your month, timing, and rate inputs. Higher rates or longer construction windows increase this value.
-                                    </TextBlock>
-                                </Grid>
-                            </Border>
-                            <Border Background="White" CornerRadius="6" Padding="10" BorderBrush="#D0E4F2" BorderThickness="1" Margin="0,0,0,8">
-                                <Grid>
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="Auto"/>
-                                        <ColumnDefinition Width="Auto"/>
-                                        <ColumnDefinition Width="*"/>
-                                    </Grid.ColumnDefinitions>
-                                    <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="18" Foreground="{StaticResource PrimaryBrush}" Margin="0,0,8,0" VerticalAlignment="Center"/>
-                                    <TextBlock Grid.Column="1" FontWeight="Bold" Text="{Binding TotalInvestment, StringFormat=Total Investment: {0:C2}}" VerticalAlignment="Center"/>
-                                    <TextBlock Grid.Column="2" TextWrapping="Wrap" Margin="12,0,0,0" Foreground="#31556F">
-                                        Total investment combines First Cost, IDC, and the present value of Future Costs. Adding more future expenses or higher IDC immediately raises this figure.
-                                    </TextBlock>
-                                </Grid>
-                            </Border>
-                            <Border Background="White" CornerRadius="6" Padding="10" BorderBrush="#D0E4F2" BorderThickness="1" Margin="0,0,0,8">
-                                <Grid>
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="Auto"/>
-                                        <ColumnDefinition Width="Auto"/>
-                                        <ColumnDefinition Width="*"/>
-                                    </Grid.ColumnDefinitions>
-                                    <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="18" Foreground="{StaticResource PrimaryBrush}" Margin="0,0,8,0" VerticalAlignment="Center"/>
-                                    <TextBlock Grid.Column="1" FontWeight="Bold" Text="{Binding Crf, StringFormat=CRF: {0:F4}}" VerticalAlignment="Center"/>
-                                    <TextBlock Grid.Column="2" TextWrapping="Wrap" Margin="12,0,0,0" Foreground="#31556F">
-                                        The capital recovery factor converts present investment into an equivalent annual cost. It is entirely driven by your discount rate and analysis period selections.
-                                    </TextBlock>
-                                </Grid>
-                            </Border>
-                            <Border Background="White" CornerRadius="6" Padding="10" BorderBrush="#D0E4F2" BorderThickness="1" Margin="0,0,0,8">
-                                <Grid>
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="Auto"/>
-                                        <ColumnDefinition Width="Auto"/>
-                                        <ColumnDefinition Width="*"/>
-                                    </Grid.ColumnDefinitions>
-                                    <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="18" Foreground="{StaticResource PrimaryBrush}" Margin="0,0,8,0" VerticalAlignment="Center"/>
-                                    <TextBlock Grid.Column="1" FontWeight="Bold" Text="{Binding AnnualCost, StringFormat=Annual Cost: {0:C2}}" VerticalAlignment="Center"/>
-                                    <TextBlock Grid.Column="2" TextWrapping="Wrap" Margin="12,0,0,0" Foreground="#31556F">
-                                        Annual cost reflects how the total investment and your O&amp;M inputs translate into yearly expenses. Increasing either component will raise this annualized value.
-                                    </TextBlock>
-                                </Grid>
-                            </Border>
-                            <Border Background="White" CornerRadius="6" Padding="10" BorderBrush="#D0E4F2" BorderThickness="1">
-                                <Grid>
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="Auto"/>
-                                        <ColumnDefinition Width="Auto"/>
-                                        <ColumnDefinition Width="*"/>
-                                    </Grid.ColumnDefinitions>
-                                    <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="18" Foreground="{StaticResource PrimaryBrush}" Margin="0,0,8,0" VerticalAlignment="Center"/>
-                                    <TextBlock Grid.Column="1" FontWeight="Bold" Text="{Binding Bcr, StringFormat=BCR: {0:F2}}" VerticalAlignment="Center"/>
-                                    <TextBlock Grid.Column="2" TextWrapping="Wrap" Margin="12,0,0,0" Foreground="#31556F">
-                                        Benefit-cost ratio compares annual benefits against annual costs. Greater benefits or lower annual costs will push the BCR upward, signaling a stronger economic case.
-                                    </TextBlock>
-                                </Grid>
-                            </Border>
-                        </StackPanel>
-                    </Grid>
-                    </StackPanel>
-                </TabItem>
-                <TabItem DataContext="{Binding WaterDemand}">
-                    <TabItem.Header>
-                        <TextBlock Text="Water Demand" TextWrapping="Wrap" TextAlignment="Center"/>
-                    </TabItem.Header>
-                    <views:WaterDemandView/>
-                </TabItem>
-                <TabItem DataContext="{Binding Udv}">
-                    <TabItem.Header>
-                        <TextBlock Text="Unit Day Value" TextWrapping="Wrap" TextAlignment="Center"/>
-                    </TabItem.Header>
-                    <views:UdvView/>
-                </TabItem>
+                </ContentControl.Style>
+            </ContentControl>
+        </Border>
+
+        <Border Grid.Row="1"
+                Margin="{StaticResource Margin.Container}"
+                Padding="0"
+                Background="{StaticResource Brush.SurfaceAlt}"
+                CornerRadius="12">
+            <ScrollViewer Focusable="False">
+                <TabControl SelectedIndex="{Binding SelectedIndex}" Background="{StaticResource Brush.Surface}">
+                    <TabControl.Resources>
+                        <Style TargetType="TabItem">
+                            <Setter Property="Margin" Value="{StaticResource Margin.TopSmall}"/>
+                            <Setter Property="Padding" Value="{StaticResource Padding.Content}"/>
+                            <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+                            <Setter Property="FontSize" Value="14"/>
+                        </Style>
+                    </TabControl.Resources>
+
+                    <TabItem DataContext="{Binding Ead}">
+                        <TabItem.Header>
+                            <TextBlock Text="EAD" TextAlignment="Center"/>
+                        </TabItem.Header>
+                        <views:EadView Margin="{StaticResource Margin.Container}"/>
+                    </TabItem>
+                    <TabItem DataContext="{Binding UpdatedCost}">
+                        <TabItem.Header>
+                            <TextBlock Text="Updated Cost of Storage" TextAlignment="Center"/>
+                        </TabItem.Header>
+                        <views:UpdatedCostView Margin="{StaticResource Margin.Container}"/>
+                    </TabItem>
+                    <TabItem DataContext="{Binding Annualizer}">
+                        <TabItem.Header>
+                            <TextBlock Text="Cost Annualization" TextAlignment="Center"/>
+                        </TabItem.Header>
+                        <ScrollViewer Padding="{StaticResource Padding.Card}">
+                            <Grid>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                </Grid.RowDefinitions>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" MinWidth="160"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+
+                                <Border Grid.Row="0" Grid.ColumnSpan="2"
+                                        Background="#E8F4FB"
+                                        BorderBrush="{StaticResource Brush.Primary}"
+                                        BorderThickness="1"
+                                        CornerRadius="8"
+                                        Padding="{StaticResource Padding.Card}"
+                                        Margin="{StaticResource Margin.StackLarge}">
+                                    <StackPanel>
+                                        <StackPanel Orientation="Horizontal" Margin="{StaticResource Margin.Stack}">
+                                            <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="20" Foreground="{StaticResource Brush.SurfaceAlt}" Margin="{StaticResource Margin.Inline}"/>
+                                            <TextBlock Text="Cost Annualization Workflow" FontWeight="Bold" FontSize="16" Foreground="{StaticResource Brush.Primary}"/>
+                                        </StackPanel>
+                                        <TextBlock TextWrapping="Wrap">
+                                            1. Document upfront investments, financing assumptions, and the analysis period.
+                                            2. Capture the construction cash flow in the IDC schedule and list all future costs in the year they occur.
+                                            3. Provide annual O&amp;M and annual benefits so the tool can translate capital outlays into comparable annual metrics.
+                                            Use the Calculate button at the bottom of the window whenever you update inputs.
+                                        </TextBlock>
+                                    </StackPanel>
+                                </Border>
+
+                                <TextBlock Grid.Row="1" Text="First Cost" Margin="{StaticResource Margin.Inline}" VerticalAlignment="Center"/>
+                                <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding FirstCost}" ToolTip="Initial project cost."/>
+
+                                <TextBlock Grid.Row="2" Text="Rate (%)" Margin="{StaticResource Margin.Inline}" VerticalAlignment="Center"/>
+                                <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding Rate}" ToolTip="Discount rate in percent."/>
+
+                                <TextBlock Grid.Row="3" Text="Base Year" Margin="{StaticResource Margin.Inline}" VerticalAlignment="Center"/>
+                                <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding BaseYear}"/>
+
+                                <TextBlock Grid.Row="4" Text="Analysis Period" Margin="{StaticResource Margin.Inline}" VerticalAlignment="Center"/>
+                                <TextBox Grid.Row="4" Grid.Column="1" Text="{Binding AnalysisPeriod}" ToolTip="Number of periods for capital recovery."/>
+
+                                <TextBlock Grid.Row="5" Text="Annual O&amp;M" Margin="{StaticResource Margin.Inline}" VerticalAlignment="Center"/>
+                                <TextBox Grid.Row="5" Grid.Column="1" Text="{Binding AnnualOm}" ToolTip="Annual operations and maintenance cost."/>
+
+                                <TextBlock Grid.Row="6" Text="Annual Benefits" Margin="{StaticResource Margin.Inline}" VerticalAlignment="Center"/>
+                                <TextBox Grid.Row="6" Grid.Column="1" Text="{Binding AnnualBenefits}" ToolTip="Expected annual benefits."/>
+
+                                <TextBlock Grid.Row="7" Text="Construction Months" Margin="{StaticResource Margin.Inline}" VerticalAlignment="Center"/>
+                                <TextBox Grid.Row="7" Grid.Column="1" Text="{Binding ConstructionMonths}"/>
+
+                                <TextBlock Grid.Row="8" Text="IDC Schedule" Margin="{StaticResource Margin.Inline}" VerticalAlignment="Center"/>
+                                <DataGrid Grid.Row="8" Grid.Column="1" ItemsSource="{Binding IdcEntries}" AutoGenerateColumns="False">
+                                    <DataGrid.Columns>
+                                        <DataGridTextColumn Header="Cost" Binding="{Binding Cost}"/>
+                                        <DataGridTextColumn Header="Month" Binding="{Binding Year}"/>
+                                        <DataGridComboBoxColumn Header="Timing" SelectedItemBinding="{Binding Timing}">
+                                            <DataGridComboBoxColumn.ItemsSource>
+                                                <x:Array Type="sys:String" xmlns:sys="clr-namespace:System;assembly=mscorlib">
+                                                    <sys:String>beginning</sys:String>
+                                                    <sys:String>midpoint</sys:String>
+                                                    <sys:String>end</sys:String>
+                                                </x:Array>
+                                            </DataGridComboBoxColumn.ItemsSource>
+                                        </DataGridComboBoxColumn>
+                                        <DataGridTextColumn Header="PV Factor" Binding="{Binding PvFactor}" IsReadOnly="True"/>
+                                    </DataGrid.Columns>
+                                </DataGrid>
+
+                                <TextBlock Grid.Row="9" Text="Future Costs" Margin="{StaticResource Margin.Inline}" VerticalAlignment="Center"/>
+                                <DataGrid Grid.Row="9" Grid.Column="1" ItemsSource="{Binding FutureCosts}" AutoGenerateColumns="False">
+                                    <DataGrid.Columns>
+                                        <DataGridTextColumn Header="Cost" Binding="{Binding Cost}"/>
+                                        <DataGridTextColumn Header="Year" Binding="{Binding Year}"/>
+                                        <DataGridComboBoxColumn Header="Timing" SelectedItemBinding="{Binding Timing}">
+                                            <DataGridComboBoxColumn.ItemsSource>
+                                                <x:Array Type="sys:String" xmlns:sys="clr-namespace:System;assembly=mscorlib">
+                                                    <sys:String>beginning</sys:String>
+                                                    <sys:String>midpoint</sys:String>
+                                                    <sys:String>end</sys:String>
+                                                </x:Array>
+                                            </DataGridComboBoxColumn.ItemsSource>
+                                        </DataGridComboBoxColumn>
+                                        <DataGridTextColumn Header="PV Factor" Binding="{Binding PvFactor}" IsReadOnly="True"/>
+                                    </DataGrid.Columns>
+                                </DataGrid>
+
+                                <UniformGrid Grid.Row="10" Grid.ColumnSpan="2" Columns="1" Margin="{StaticResource Margin.TopLarge}">
+                                    <UniformGrid.Style>
+                                        <Style TargetType="UniformGrid">
+                                            <Setter Property="Columns" Value="1"/>
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding ActualWidth, RelativeSource={RelativeSource AncestorType=TabItem}, Converter={StaticResource WidthToLayoutModeConverter}}"
+                                                             Value="Wide">
+                                                    <Setter Property="Columns" Value="2"/>
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </UniformGrid.Style>
+                                    <Border Background="White" CornerRadius="6" Padding="{StaticResource Padding.Content}" BorderBrush="{StaticResource Brush.Border}" BorderThickness="1" Margin="{StaticResource Margin.Stack}">
+                                        <Grid>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="Auto"/>
+                                                <ColumnDefinition Width="Auto"/>
+                                                <ColumnDefinition Width="*"/>
+                                            </Grid.ColumnDefinitions>
+                                            <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="18" Foreground="{StaticResource Brush.Primary}" Margin="{StaticResource Margin.Inline}" VerticalAlignment="Center"/>
+                                            <TextBlock Grid.Column="1" FontWeight="Bold" Text="{Binding Idc, StringFormat=IDC: {0:C2}}" VerticalAlignment="Center"/>
+                                            <TextBlock Grid.Column="2" TextWrapping="Wrap" Margin="{StaticResource Margin.InlineMedium}" Foreground="{StaticResource Brush.TextSecondary}">
+                                                Interest during construction accumulates from the IDC schedule using your month, timing, and rate inputs. Higher rates or longer construction windows increase this value.
+                                            </TextBlock>
+                                        </Grid>
+                                    </Border>
+                                    <Border Background="White" CornerRadius="6" Padding="{StaticResource Padding.Content}" BorderBrush="{StaticResource Brush.Border}" BorderThickness="1" Margin="{StaticResource Margin.Stack}">
+                                        <Grid>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="Auto"/>
+                                                <ColumnDefinition Width="Auto"/>
+                                                <ColumnDefinition Width="*"/>
+                                            </Grid.ColumnDefinitions>
+                                            <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="18" Foreground="{StaticResource Brush.Primary}" Margin="{StaticResource Margin.Inline}" VerticalAlignment="Center"/>
+                                            <TextBlock Grid.Column="1" FontWeight="Bold" Text="{Binding TotalInvestment, StringFormat=Total Investment: {0:C2}}" VerticalAlignment="Center"/>
+                                            <TextBlock Grid.Column="2" TextWrapping="Wrap" Margin="{StaticResource Margin.InlineMedium}" Foreground="{StaticResource Brush.TextSecondary}">
+                                                Total investment combines First Cost, IDC, and the present value of Future Costs. Adding more future expenses or higher IDC immediately raises this figure.
+                                            </TextBlock>
+                                        </Grid>
+                                    </Border>
+                                    <Border Background="White" CornerRadius="6" Padding="{StaticResource Padding.Content}" BorderBrush="{StaticResource Brush.Border}" BorderThickness="1" Margin="{StaticResource Margin.Stack}">
+                                        <Grid>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="Auto"/>
+                                                <ColumnDefinition Width="Auto"/>
+                                                <ColumnDefinition Width="*"/>
+                                            </Grid.ColumnDefinitions>
+                                            <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="18" Foreground="{StaticResource Brush.Primary}" Margin="{StaticResource Margin.Inline}" VerticalAlignment="Center"/>
+                                            <TextBlock Grid.Column="1" FontWeight="Bold" Text="{Binding Crf, StringFormat=CRF: {0:F4}}" VerticalAlignment="Center"/>
+                                            <TextBlock Grid.Column="2" TextWrapping="Wrap" Margin="{StaticResource Margin.InlineMedium}" Foreground="{StaticResource Brush.TextSecondary}">
+                                                The capital recovery factor converts present investment into an equivalent annual cost. It is entirely driven by your discount rate and analysis period selections.
+                                            </TextBlock>
+                                        </Grid>
+                                    </Border>
+                                    <Border Background="White" CornerRadius="6" Padding="{StaticResource Padding.Content}" BorderBrush="{StaticResource Brush.Border}" BorderThickness="1" Margin="{StaticResource Margin.Stack}">
+                                        <Grid>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="Auto"/>
+                                                <ColumnDefinition Width="Auto"/>
+                                                <ColumnDefinition Width="*"/>
+                                            </Grid.ColumnDefinitions>
+                                            <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="18" Foreground="{StaticResource Brush.Primary}" Margin="{StaticResource Margin.Inline}" VerticalAlignment="Center"/>
+                                            <TextBlock Grid.Column="1" FontWeight="Bold" Text="{Binding AnnualCost, StringFormat=Annual Cost: {0:C2}}" VerticalAlignment="Center"/>
+                                            <TextBlock Grid.Column="2" TextWrapping="Wrap" Margin="{StaticResource Margin.InlineMedium}" Foreground="{StaticResource Brush.TextSecondary}">
+                                                Annual cost reflects how the total investment and your O&amp;M inputs translate into yearly expenses. Increasing either component will raise this annualized value.
+                                            </TextBlock>
+                                        </Grid>
+                                    </Border>
+                                    <Border Background="White" CornerRadius="6" Padding="{StaticResource Padding.Content}" BorderBrush="{StaticResource Brush.Border}" BorderThickness="1">
+                                        <Grid>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="Auto"/>
+                                                <ColumnDefinition Width="Auto"/>
+                                                <ColumnDefinition Width="*"/>
+                                            </Grid.ColumnDefinitions>
+                                            <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="18" Foreground="{StaticResource Brush.Primary}" Margin="{StaticResource Margin.Inline}" VerticalAlignment="Center"/>
+                                            <TextBlock Grid.Column="1" FontWeight="Bold" Text="{Binding Bcr, StringFormat=BCR: {0:F2}}" VerticalAlignment="Center"/>
+                                            <TextBlock Grid.Column="2" TextWrapping="Wrap" Margin="{StaticResource Margin.InlineMedium}" Foreground="{StaticResource Brush.TextSecondary}">
+                                                Benefit-cost ratio compares annual benefits against annual costs. Greater benefits or lower annual costs will push the BCR upward, signaling a stronger economic case.
+                                            </TextBlock>
+                                        </Grid>
+                                    </Border>
+                                </UniformGrid>
+                            </Grid>
+                        </ScrollViewer>
+                    </TabItem>
+                    <TabItem DataContext="{Binding WaterDemand}">
+                        <TabItem.Header>
+                            <TextBlock Text="Water Demand" TextAlignment="Center"/>
+                        </TabItem.Header>
+                        <views:WaterDemandView Margin="{StaticResource Margin.Container}"/>
+                    </TabItem>
+                    <TabItem DataContext="{Binding Udv}">
+                        <TabItem.Header>
+                            <TextBlock Text="Unit Day Value" TextAlignment="Center"/>
+                        </TabItem.Header>
+                        <views:UdvView Margin="{StaticResource Margin.Container}"/>
+                    </TabItem>
                 </TabControl>
-        </ScrollViewer>
-        <WrapPanel Grid.Row="2" HorizontalAlignment="Right" Margin="10,0,10,10">
-            <Button x:Name="CalculateButton" Command="{Binding CalculateCommand}" Margin="0,0,5,5">
-                <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-                    <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Margin="0,0,6,0" FontSize="16"/>
-                    <TextBlock Text="Calculate"/>
-                </StackPanel>
-            </Button>
-            <Button Width="{Binding ElementName=CalculateButton, Path=ActualWidth}" Command="{Binding ExportCommand}" Margin="0,0,0,5">
-                <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-                    <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Margin="0,0,6,0" FontSize="16"/>
-                    <TextBlock Text="Export"/>
-                </StackPanel>
-            </Button>
-        </WrapPanel>
+            </ScrollViewer>
+        </Border>
+
+        <Border Grid.Row="2"
+                Background="{StaticResource Brush.SurfaceAlt}"
+                Padding="{StaticResource Padding.Section}">
+            <ContentControl Content="{Binding}">
+                <ContentControl.Style>
+                    <Style TargetType="ContentControl">
+                        <Setter Property="ContentTemplate" Value="{StaticResource ActionsNarrowTemplate}"/>
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding ActualWidth, RelativeSource={RelativeSource AncestorType=Window}, Converter={StaticResource WidthToLayoutModeConverter}}"
+                                         Value="Wide">
+                                <Setter Property="ContentTemplate" Value="{StaticResource ActionsWideTemplate}"/>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </ContentControl.Style>
+            </ContentControl>
+        </Border>
     </Grid>
 </Window>

--- a/Themes/Design.xaml
+++ b/Themes/Design.xaml
@@ -1,0 +1,125 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:converters="clr-namespace:EconToolbox.Desktop.Converters">
+    <!-- Color palette -->
+    <Color x:Key="Color.Primary">#2D6A8E</Color>
+    <Color x:Key="Color.Accent">#1ABC9C</Color>
+    <Color x:Key="Color.Surface">#FFFFFFFF</Color>
+    <Color x:Key="Color.SurfaceAlt">#F4F7FB</Color>
+    <Color x:Key="Color.Border">#D0E4F2</Color>
+    <Color x:Key="Color.TextPrimary">#12212F</Color>
+    <Color x:Key="Color.TextSecondary">#31556F</Color>
+
+    <!-- Brushes -->
+    <SolidColorBrush x:Key="Brush.Primary" Color="{StaticResource Color.Primary}"/>
+    <SolidColorBrush x:Key="Brush.Accent" Color="{StaticResource Color.Accent}"/>
+    <SolidColorBrush x:Key="Brush.Surface" Color="{StaticResource Color.Surface}"/>
+    <SolidColorBrush x:Key="Brush.SurfaceAlt" Color="{StaticResource Color.SurfaceAlt}"/>
+    <SolidColorBrush x:Key="Brush.Border" Color="{StaticResource Color.Border}"/>
+    <SolidColorBrush x:Key="Brush.TextPrimary" Color="{StaticResource Color.TextPrimary}"/>
+    <SolidColorBrush x:Key="Brush.TextSecondary" Color="{StaticResource Color.TextSecondary}"/>
+
+    <!-- Spacing tokens -->
+    <x:Double x:Key="Space.XS">4</x:Double>
+    <x:Double x:Key="Space.SM">8</x:Double>
+    <x:Double x:Key="Space.MD">16</x:Double>
+    <x:Double x:Key="Space.LG">24</x:Double>
+    <x:Double x:Key="Space.XL">32</x:Double>
+
+    <Thickness x:Key="Padding.Card">16</Thickness>
+    <Thickness x:Key="Padding.Section">20</Thickness>
+    <Thickness x:Key="Padding.Content">12</Thickness>
+    <Thickness x:Key="Margin.Container">16</Thickness>
+    <Thickness x:Key="Margin.Stack">0,0,0,8</Thickness>
+    <Thickness x:Key="Margin.StackLarge">0,0,0,16</Thickness>
+    <Thickness x:Key="Margin.Inline">0,0,8,0</Thickness>
+    <Thickness x:Key="Margin.InlineLarge">0,0,24,0</Thickness>
+    <Thickness x:Key="Margin.InlineMedium">0,0,16,0</Thickness>
+    <Thickness x:Key="Margin.TopSmall">0,8,0,0</Thickness>
+    <Thickness x:Key="Margin.TopLarge">0,16,0,0</Thickness>
+    <Thickness x:Key="Margin.TopXSmall">0,4,0,0</Thickness>
+    <Thickness x:Key="Margin.None">0</Thickness>
+
+    <!-- Type ramp -->
+    <Style x:Key="Text.Caption" TargetType="TextBlock">
+        <Setter Property="FontFamily" Value="Segoe UI"/>
+        <Setter Property="FontSize" Value="12"/>
+        <Setter Property="FontWeight" Value="SemiBold"/>
+        <Setter Property="Foreground" Value="{StaticResource Brush.TextSecondary}"/>
+    </Style>
+
+    <Style x:Key="Text.Body" TargetType="TextBlock">
+        <Setter Property="FontFamily" Value="Segoe UI"/>
+        <Setter Property="FontSize" Value="14"/>
+        <Setter Property="Foreground" Value="{StaticResource Brush.TextPrimary}"/>
+        <Setter Property="TextWrapping" Value="Wrap"/>
+    </Style>
+
+    <Style x:Key="Text.Title" TargetType="TextBlock">
+        <Setter Property="FontFamily" Value="Segoe UI Semibold"/>
+        <Setter Property="FontSize" Value="24"/>
+        <Setter Property="Foreground" Value="White"/>
+    </Style>
+
+    <!-- Control styles -->
+    <Style TargetType="Window">
+        <Setter Property="FontFamily" Value="Segoe UI"/>
+        <Setter Property="Foreground" Value="{StaticResource Brush.TextPrimary}"/>
+        <Setter Property="Background" Value="{StaticResource Brush.SurfaceAlt}"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+        <Setter Property="UseLayoutRounding" Value="True"/>
+    </Style>
+
+    <Style TargetType="UserControl">
+        <Setter Property="FontFamily" Value="Segoe UI"/>
+        <Setter Property="Foreground" Value="{StaticResource Brush.TextPrimary}"/>
+        <Setter Property="Background" Value="{StaticResource Brush.SurfaceAlt}"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+        <Setter Property="UseLayoutRounding" Value="True"/>
+    </Style>
+
+    <Style TargetType="Button">
+        <Setter Property="Background" Value="{StaticResource Brush.Primary}"/>
+        <Setter Property="Foreground" Value="White"/>
+        <Setter Property="Padding" Value="12,6"/>
+        <Setter Property="Margin" Value="{StaticResource Margin.Stack}"/>
+        <Setter Property="BorderThickness" Value="0"/>
+        <Setter Property="FontWeight" Value="SemiBold"/>
+        <Setter Property="HorizontalAlignment" Value="Stretch"/>
+    </Style>
+
+    <Style TargetType="TextBox">
+        <Setter Property="Margin" Value="{StaticResource Margin.Stack}"/>
+        <Setter Property="Padding" Value="6"/>
+        <Setter Property="MinWidth" Value="140"/>
+        <Setter Property="BorderBrush" Value="{StaticResource Brush.Border}"/>
+        <Setter Property="BorderThickness" Value="1"/>
+    </Style>
+
+    <Style TargetType="ComboBox">
+        <Setter Property="Margin" Value="{StaticResource Margin.Stack}"/>
+        <Setter Property="MinWidth" Value="160"/>
+    </Style>
+
+    <Style TargetType="DataGrid">
+        <Setter Property="RowBackground" Value="{StaticResource Brush.Surface}"/>
+        <Setter Property="AlternatingRowBackground" Value="#F0F5FA"/>
+        <Setter Property="GridLinesVisibility" Value="None"/>
+        <Setter Property="BorderBrush" Value="{StaticResource Brush.Border}"/>
+        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="Margin" Value="{StaticResource Margin.StackLarge}"/>
+        <Setter Property="SelectionUnit" Value="CellOrRowHeader"/>
+    </Style>
+
+    <Style TargetType="TabControl">
+        <Setter Property="Margin" Value="{StaticResource Margin.Container}"/>
+        <Setter Property="Padding" Value="0"/>
+    </Style>
+
+    <Style TargetType="ScrollViewer">
+        <Setter Property="HorizontalScrollBarVisibility" Value="Auto"/>
+        <Setter Property="VerticalScrollBarVisibility" Value="Auto"/>
+    </Style>
+
+    <converters:WidthToLayoutModeConverter x:Key="WidthToLayoutModeConverter" Threshold="800"/>
+</ResourceDictionary>

--- a/Views/EadView.xaml
+++ b/Views/EadView.xaml
@@ -1,104 +1,183 @@
 <UserControl x:Class="EconToolbox.Desktop.Views.EadView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
-        <Grid Margin="10">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="*"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-        </Grid.RowDefinitions>
-        <Border Grid.Row="0" Background="#FFF2FBFF" BorderBrush="{StaticResource PrimaryBrush}" BorderThickness="1" CornerRadius="8" Padding="12" Margin="0,0,0,5">
-            <StackPanel>
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="20" Foreground="{StaticResource PrimaryBrush}" Margin="0,0,8,0"/>
-                    <TextBlock Text="Expected Annual Damage Instructions" FontWeight="Bold" FontSize="16" Foreground="{StaticResource PrimaryBrush}"/>
-                </StackPanel>
-                <TextBlock TextWrapping="Wrap" Margin="0,6,0,0">
-                    <Run Text="List probability-damage pairs for each category. The tool auto-completes the curve by inserting 0% and 100% points using the trapezoidal method."/>
-                    <LineBreak/>
-                    <Run Text="Toggle Include Stage if you have stage data aligned with the same probabilities."/>
-                    <LineBreak/>
-                    <Run Text="After editing the grid, click Calculate EAD so charts and statistics capture your latest entries."/>
-                </TextBlock>
-            </StackPanel>
-        </Border>
-        <WrapPanel Grid.Row="1" Margin="0,0,0,5" ItemHeight="36" ItemWidth="220" MinWidth="200">
-            <Button Command="{Binding AddDamageColumnCommand}">
-                <StackPanel Orientation="Horizontal">
-                    <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Margin="0,0,6,0"/>
-                    <TextBlock Text="Add Damage Column"/>
-                </StackPanel>
-            </Button>
-            <Button Command="{Binding RemoveDamageColumnCommand}">
-                <StackPanel Orientation="Horizontal">
-                    <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Margin="0,0,6,0"/>
-                    <TextBlock Text="Remove Damage Column"/>
-                </StackPanel>
-            </Button>
-            <CheckBox Content="Include Stage" IsChecked="{Binding UseStage}" VerticalAlignment="Center" Margin="4"/>
-            <Button Command="{Binding ComputeCommand}">
-                <StackPanel Orientation="Horizontal">
-                    <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Margin="0,0,6,0"/>
-                    <TextBlock Text="Calculate EAD"/>
-                </StackPanel>
-            </Button>
-            <Button Command="{Binding ExportCommand}">
-                <StackPanel Orientation="Horizontal">
-                    <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Margin="0,0,6,0"/>
-                    <TextBlock Text="Export Summary"/>
-                </StackPanel>
-            </Button>
-        </WrapPanel>
-        <Grid Grid.Row="2">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="*"/>
-            </Grid.ColumnDefinitions>
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:sys="clr-namespace:System;assembly=mscorlib"
+             SnapsToDevicePixels="True"
+             UseLayoutRounding="True">
+    <Grid>
+        <ScrollViewer Focusable="False" Padding="{StaticResource Padding.Card}">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
 
-            <Border Grid.Column="0" Background="White" CornerRadius="4" Padding="5">
-                <DataGrid x:Name="EadDataGrid" ItemsSource="{Binding Rows}" AutoGenerateColumns="False"
-                          CanUserAddRows="True" CanUserDeleteRows="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto"/>
-            </Border>
+                <Border Grid.Row="0"
+                        Background="#FFF2FBFF"
+                        BorderBrush="{StaticResource Brush.Primary}"
+                        BorderThickness="1"
+                        CornerRadius="8"
+                        Padding="{StaticResource Padding.Content}"
+                        Margin="{StaticResource Margin.StackLarge}">
+                    <StackPanel>
+                        <StackPanel Orientation="Horizontal" Margin="{StaticResource Margin.Stack}">
+                            <TextBlock FontFamily="Segoe MDL2 Assets"
+                                       Text=""
+                                       FontSize="20"
+                                       Foreground="{StaticResource Brush.Primary}"
+                                       Margin="{StaticResource Margin.Inline}"/>
+                            <TextBlock Text="Expected Annual Damage Instructions"
+                                       FontWeight="Bold"
+                                       FontSize="16"
+                                       Foreground="{StaticResource Brush.Primary}"/>
+                        </StackPanel>
+                        <TextBlock Style="{StaticResource Text.Body}">
+                            <Run Text="List probability-damage pairs for each category. The tool auto-completes the curve by inserting 0% and 100% points using the trapezoidal method."/>
+                            <LineBreak/>
+                            <Run Text="Toggle Include Stage if you have stage data aligned with the same probabilities."/>
+                            <LineBreak/>
+                            <Run Text="After editing the grid, click Calculate EAD so charts and statistics capture your latest entries."/>
+                        </TextBlock>
+                    </StackPanel>
+                </Border>
 
-            <Border Grid.Column="1" Margin="10,0,0,0" Background="White" CornerRadius="4" Padding="5">
-                <StackPanel>
-                    <TextBlock FontWeight="SemiBold" Text="Visualize Your Curve" Margin="0,0,0,5"/>
-                    <Canvas Height="160">
-                        <Polyline Points="{Binding FrequencyDamagePoints}" Stroke="{StaticResource AccentBrush}" StrokeThickness="2"/>
-                        <Polyline Points="{Binding StageDamagePoints}" Stroke="{StaticResource PrimaryBrush}" StrokeThickness="2"/>
-                    </Canvas>
-                    <TextBlock TextWrapping="Wrap" FontSize="12" Foreground="#31556F">
-                        The teal line plots damages against exceedance probability, while the navy line (when stage is supplied) shows the paired stage-damage curve. Smoother, monotonic inputs yield clearer charts.
-                    </TextBlock>
-                </StackPanel>
-            </Border>
-        </Grid>
-        <ItemsControl ItemsSource="{Binding Results}" Grid.Row="3" Margin="0,5,0,5">
-            <ItemsControl.ItemTemplate>
-                <DataTemplate>
-                    <Border Background="White" BorderBrush="#D0E4F2" BorderThickness="1" CornerRadius="6" Padding="8" Margin="0,0,0,5">
-                        <StackPanel Orientation="Horizontal">
-                            <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="16" Foreground="{StaticResource PrimaryBrush}" Margin="0,0,8,0"/>
-                            <TextBlock Text="{Binding}" TextWrapping="Wrap"/>
+                <WrapPanel Grid.Row="1"
+                           Margin="{StaticResource Margin.StackLarge}"
+                           ItemHeight="36"
+                           ItemWidth="220"
+                           MinWidth="200">
+                    <WrapPanel.Style>
+                        <Style TargetType="WrapPanel">
+                            <Setter Property="ItemWidth" Value="220"/>
+                            <Setter Property="ItemHeight" Value="36"/>
+                            <Setter Property="HorizontalAlignment" Value="Stretch"/>
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding ActualWidth, RelativeSource={RelativeSource AncestorType=UserControl}, Converter={StaticResource WidthToLayoutModeConverter}}"
+                                             Value="Narrow">
+                                    <Setter Property="ItemWidth" Value="{x:Static sys:Double.NaN}"/>
+                                    <Setter Property="ItemHeight" Value="{x:Static sys:Double.NaN}"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </WrapPanel.Style>
+                    <Button Command="{Binding AddDamageColumnCommand}" Margin="{StaticResource Margin.Inline}">
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                            <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Margin="{StaticResource Margin.Inline}"/>
+                            <TextBlock Text="Add Damage Column"/>
+                        </StackPanel>
+                    </Button>
+                    <Button Command="{Binding RemoveDamageColumnCommand}" Margin="{StaticResource Margin.Inline}">
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                            <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Margin="{StaticResource Margin.Inline}"/>
+                            <TextBlock Text="Remove Damage Column"/>
+                        </StackPanel>
+                    </Button>
+                    <CheckBox Content="Include Stage"
+                              IsChecked="{Binding UseStage}"
+                              VerticalAlignment="Center"
+                              Margin="{StaticResource Margin.Inline}"/>
+                    <Button Command="{Binding ComputeCommand}" Margin="{StaticResource Margin.Inline}">
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                            <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Margin="{StaticResource Margin.Inline}"/>
+                            <TextBlock Text="Calculate EAD"/>
+                        </StackPanel>
+                    </Button>
+                    <Button Command="{Binding ExportCommand}" Margin="{StaticResource Margin.Inline}">
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                            <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Margin="{StaticResource Margin.Inline}"/>
+                            <TextBlock Text="Export Summary"/>
+                        </StackPanel>
+                    </Button>
+                </WrapPanel>
+
+                <Grid Grid.Row="2" Margin="{StaticResource Margin.StackLarge}">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" MinWidth="280"/>
+                        <ColumnDefinition Width="*" MinWidth="220"/>
+                    </Grid.ColumnDefinitions>
+
+                    <Border Grid.Column="0" Background="{StaticResource Brush.Surface}" CornerRadius="6" Padding="{StaticResource Padding.Content}" BorderBrush="{StaticResource Brush.Border}" BorderThickness="1">
+                        <DataGrid x:Name="EadDataGrid"
+                                  ItemsSource="{Binding Rows}"
+                                  AutoGenerateColumns="False"
+                                  CanUserAddRows="True"
+                                  CanUserDeleteRows="True"/>
+                    </Border>
+
+                    <Border Grid.Column="1"
+                            Margin="{StaticResource Margin.InlineLarge}"
+                            Background="{StaticResource Brush.Surface}"
+                            CornerRadius="6"
+                            Padding="{StaticResource Padding.Content}"
+                            BorderBrush="{StaticResource Brush.Border}"
+                            BorderThickness="1">
+                        <StackPanel>
+                            <TextBlock Text="Visualize Your Curve"
+                                       FontWeight="SemiBold"
+                                       Margin="{StaticResource Margin.Stack}"/>
+                            <Canvas Height="160" Margin="{StaticResource Margin.Stack}">
+                                <Polyline Points="{Binding FrequencyDamagePoints}"
+                                          Stroke="{StaticResource Brush.Accent}"
+                                          StrokeThickness="2"/>
+                                <Polyline Points="{Binding StageDamagePoints}"
+                                          Stroke="{StaticResource Brush.Primary}"
+                                          StrokeThickness="2"/>
+                            </Canvas>
+                            <TextBlock Style="{StaticResource Text.Caption}" TextWrapping="Wrap">
+                                The teal line plots damages against exceedance probability, while the navy line (when stage is supplied) shows the paired stage-damage curve. Smoother, monotonic inputs yield clearer charts.
+                            </TextBlock>
                         </StackPanel>
                     </Border>
-                </DataTemplate>
-            </ItemsControl.ItemTemplate>
-        </ItemsControl>
-        <Border Grid.Row="4" Background="#FFF8FD" BorderBrush="#E0CAE7" BorderThickness="1" CornerRadius="8" Padding="12">
-            <StackPanel>
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="18" Foreground="#8A4BAF" Margin="0,0,8,0"/>
-                    <TextBlock Text="Result Interpretation" FontWeight="Bold" Foreground="#8A4BAF"/>
-                </StackPanel>
-                <TextBlock TextWrapping="Wrap" Margin="0,6,0,0">
-                    Each Expected Annual Damage value averages the damage column across the entire probability curve you supplied. Higher damages at frequent events raise the EAD most dramatically. The plotted curves update with every calculation, helping you confirm the shape of the probability and stage relationships before exporting your Excel summary.
-                </TextBlock>
-            </StackPanel>
-        </Border>
-        </Grid>
-    </ScrollViewer>
+                </Grid>
+
+                <ItemsControl ItemsSource="{Binding Results}" Grid.Row="3" Margin="{StaticResource Margin.StackLarge}">
+                    <ItemsControl.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <WrapPanel/> 
+                        </ItemsPanelTemplate>
+                    </ItemsControl.ItemsPanel>
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <Border Background="{StaticResource Brush.Surface}"
+                                    BorderBrush="{StaticResource Brush.Border}"
+                                    BorderThickness="1"
+                                    CornerRadius="6"
+                                    Padding="{StaticResource Padding.Content}"
+                                    Margin="{StaticResource Margin.Inline}">
+                                <StackPanel Orientation="Horizontal">
+                                    <TextBlock FontFamily="Segoe MDL2 Assets"
+                                               Text=""
+                                               FontSize="16"
+                                               Foreground="{StaticResource Brush.Primary}"
+                                               Margin="{StaticResource Margin.Inline}"/>
+                                    <TextBlock Text="{Binding}" Style="{StaticResource Text.Body}"/>
+                                </StackPanel>
+                            </Border>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+
+                <Border Grid.Row="4"
+                        Background="#FFF8FD"
+                        BorderBrush="#E0CAE7"
+                        BorderThickness="1"
+                        CornerRadius="8"
+                        Padding="{StaticResource Padding.Content}"
+                        Margin="{StaticResource Margin.StackLarge}">
+                    <StackPanel>
+                        <StackPanel Orientation="Horizontal" Margin="{StaticResource Margin.Stack}" VerticalAlignment="Center">
+                            <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="18" Foreground="#8A4BAF" Margin="{StaticResource Margin.Inline}"/>
+                            <TextBlock Text="Result Interpretation" FontWeight="Bold" Foreground="#8A4BAF"/>
+                        </StackPanel>
+                        <TextBlock Style="{StaticResource Text.Body}">
+                            Each Expected Annual Damage value averages the damage column across the entire probability curve you supplied. Higher damages at frequent events raise the EAD most dramatically. The plotted curves update with every calculation, helping you confirm the shape of the probability and stage relationships before exporting your Excel summary.
+                        </TextBlock>
+                    </StackPanel>
+                </Border>
+            </Grid>
+        </ScrollViewer>
+    </Grid>
 </UserControl>

--- a/Views/UdvView.xaml
+++ b/Views/UdvView.xaml
@@ -1,8 +1,10 @@
 <UserControl x:Class="EconToolbox.Desktop.Views.UdvView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
-        <Grid Margin="10">
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             SnapsToDevicePixels="True"
+             UseLayoutRounding="True">
+    <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" Padding="{StaticResource Padding.Card}">
+        <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
@@ -11,56 +13,56 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
-        <Border Grid.Row="0" Background="#FFF4F7" BorderBrush="#E8A6B8" BorderThickness="1" CornerRadius="10" Padding="12" Margin="0,0,0,8">
+        <Border Grid.Row="0" Background="#FFF4F7" BorderBrush="#E8A6B8" BorderThickness="1" CornerRadius="10" Padding="12" Margin="{StaticResource Margin.Stack}">
             <StackPanel>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="18" Foreground="#C23E64" Margin="0,0,8,0"/>
+                    <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="18" Foreground="#C23E64" Margin="{StaticResource Margin.Inline}"/>
                     <TextBlock Text="Unit Day Value Overview" FontWeight="Bold" Foreground="#C23E64"/>
                 </StackPanel>
-                <TextBlock TextWrapping="Wrap" Margin="0,6,0,0">
+                <TextBlock TextWrapping="Wrap" Margin="{StaticResource Margin.TopSmall}">
                     Choose the recreation and activity classification, then supply point scores, user days, and visitation. Points must align with the table order to return the correct value tier.
                 </TextBlock>
             </StackPanel>
         </Border>
-        <StackPanel Orientation="Horizontal" Grid.Row="1" Margin="0,0,0,5">
-            <ComboBox ItemsSource="{Binding RecreationTypes}" SelectedItem="{Binding RecreationType}" Width="150" Margin="0,0,8,0"/>
+        <StackPanel Orientation="Horizontal" Grid.Row="1" Margin="{StaticResource Margin.Stack}">
+            <ComboBox ItemsSource="{Binding RecreationTypes}" SelectedItem="{Binding RecreationType}" Width="150" Margin="{StaticResource Margin.Inline}"/>
             <ComboBox ItemsSource="{Binding ActivityTypes}" SelectedItem="{Binding ActivityType}" Width="220"/>
         </StackPanel>
-        <StackPanel Orientation="Horizontal" Grid.Row="2" Margin="0,0,0,5">
-            <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Foreground="{StaticResource PrimaryBrush}" Margin="0,0,6,0" VerticalAlignment="Center"/>
-            <TextBlock Text="Points" VerticalAlignment="Center" Margin="0,0,5,0"/>
-            <TextBox Text="{Binding Points}" Width="60" Margin="0,0,10,0"/>
-            <TextBlock Text="Unit Day Value" VerticalAlignment="Center" Margin="0,0,5,0"/>
+        <StackPanel Orientation="Horizontal" Grid.Row="2" Margin="{StaticResource Margin.Stack}">
+            <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Foreground="{StaticResource Brush.Primary}" Margin="{StaticResource Margin.Inline}" VerticalAlignment="Center"/>
+            <TextBlock Text="Points" VerticalAlignment="Center" Margin="{StaticResource Margin.Inline}"/>
+            <TextBox Text="{Binding Points}" Width="60" Margin="{StaticResource Margin.InlineMedium}"/>
+            <TextBlock Text="Unit Day Value" VerticalAlignment="Center" Margin="{StaticResource Margin.Inline}"/>
             <TextBlock Text="{Binding UnitDayValue, StringFormat={}{0:F2}}" VerticalAlignment="Center" FontWeight="SemiBold"/>
         </StackPanel>
-        <StackPanel Orientation="Horizontal" Grid.Row="3" Margin="0,0,0,5">
-            <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Foreground="{StaticResource PrimaryBrush}" Margin="0,0,6,0" VerticalAlignment="Center"/>
-            <TextBlock Text="Annual User Days" VerticalAlignment="Center" Margin="0,0,5,0"/>
-            <TextBox Text="{Binding UserDays}" Width="80" Margin="0,0,10,0"/>
-            <TextBlock Text="Visitation" VerticalAlignment="Center" Margin="0,0,5,0"/>
-            <TextBox Text="{Binding Visitation}" Width="60" Margin="0,0,10,0"/>
+        <StackPanel Orientation="Horizontal" Grid.Row="3" Margin="{StaticResource Margin.Stack}">
+            <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Foreground="{StaticResource Brush.Primary}" Margin="{StaticResource Margin.Inline}" VerticalAlignment="Center"/>
+            <TextBlock Text="Annual User Days" VerticalAlignment="Center" Margin="{StaticResource Margin.Inline}"/>
+            <TextBox Text="{Binding UserDays}" Width="80" Margin="{StaticResource Margin.InlineMedium}"/>
+            <TextBlock Text="Visitation" VerticalAlignment="Center" Margin="{StaticResource Margin.Inline}"/>
+            <TextBox Text="{Binding Visitation}" Width="60" Margin="{StaticResource Margin.InlineMedium}"/>
             <Button Command="{Binding ComputeCommand}">
                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-                    <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Margin="0,0,6,0"/>
+                    <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Margin="{StaticResource Margin.Inline}"/>
                     <TextBlock Text="Compute"/>
                 </StackPanel>
             </Button>
         </StackPanel>
-        <Border Grid.Row="4" Background="#FFF7F0" BorderBrush="#E9C28E" BorderThickness="1" CornerRadius="8" Padding="10" Margin="0,0,0,5">
+        <Border Grid.Row="4" Background="#FFF7F0" BorderBrush="#E9C28E" BorderThickness="1" CornerRadius="8" Padding="{StaticResource Padding.Content}" Margin="{StaticResource Margin.Stack}">
             <StackPanel>
                 <TextBlock Text="{Binding Result}" FontWeight="Bold"/>
-                <TextBlock TextWrapping="Wrap" Margin="0,4,0,0">
+                <TextBlock TextWrapping="Wrap" Margin="{StaticResource Margin.TopXSmall}">
                     This total monetizes recreation by multiplying the unit day value with annual user days and visitation share. Raising the points score moves you to a higher value tier, while more user days proportionally increase the annual benefit.
                 </TextBlock>
             </StackPanel>
         </Border>
-        <Border Grid.Row="5" Background="White" BorderBrush="#D0E4F2" BorderThickness="1" CornerRadius="10" Padding="10">
+        <Border Grid.Row="5" Background="White" BorderBrush="#D0E4F2" BorderThickness="1" CornerRadius="10" Padding="{StaticResource Padding.Content}">
             <StackPanel>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="18" Foreground="{StaticResource PrimaryBrush}" Margin="0,0,8,0"/>
-                    <TextBlock Text="Point Scale Reference" FontWeight="Bold" Foreground="{StaticResource PrimaryBrush}"/>
+                    <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="18" Foreground="{StaticResource Brush.Primary}" Margin="{StaticResource Margin.Inline}"/>
+                    <TextBlock Text="Point Scale Reference" FontWeight="Bold" Foreground="{StaticResource Brush.Primary}"/>
                 </StackPanel>
-                <TextBlock TextWrapping="Wrap" FontSize="12" Margin="0,4,0,6">
+                <TextBlock TextWrapping="Wrap" FontSize="12" Margin="{StaticResource Margin.Stack}">
                     Reference this table to ensure your point selection matches the published ranges. The highlighted unit day value is chosen by matching your point entry to the correct column.
                 </TextBlock>
                 <DataGrid ItemsSource="{Binding Table}" AutoGenerateColumns="False" CanUserAddRows="False" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto">

--- a/Views/UpdatedCostView.xaml
+++ b/Views/UpdatedCostView.xaml
@@ -3,10 +3,12 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             mc:Ignorable="d">
-    <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
+             mc:Ignorable="d"
+             SnapsToDevicePixels="True"
+             UseLayoutRounding="True">
+    <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" Padding="{StaticResource Padding.Card}">
         <StackPanel>
-        <Border Margin="10,0,10,10" Background="#EEF6F8" BorderBrush="{StaticResource PrimaryBrush}" BorderThickness="1" CornerRadius="10" Padding="16">
+        <Border Margin="10,0,10,10" Background="#EEF6F8" BorderBrush="{StaticResource Brush.Primary}" BorderThickness="1" CornerRadius="10" Padding="16">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto"/>
@@ -14,21 +16,21 @@
                     <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
                 <StackPanel Orientation="Horizontal" Grid.Column="0" VerticalAlignment="Top">
-                    <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="24" Foreground="{StaticResource PrimaryBrush}" Margin="0,0,10,0"/>
+                    <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="24" Foreground="{StaticResource Brush.Primary}" Margin="0,0,10,0"/>
                 </StackPanel>
                 <StackPanel Grid.Column="1">
-                    <TextBlock Text="Updated Cost Workflow" FontSize="18" FontWeight="Bold" Foreground="{StaticResource PrimaryBrush}"/>
+                    <TextBlock Text="Updated Cost Workflow" FontSize="18" FontWeight="Bold" Foreground="{StaticResource Brush.Primary}"/>
                     <TextBlock TextWrapping="Wrap" Margin="0,6,0,0">
                         Work through each sub-tab from left to right. Start with storage capacity, capture annual joint costs, update historical line items, then evaluate RR&amp;R/mitigation and total annual cost scenarios. Press Compute within each section before leaving the tab so downstream values stay synchronized.
                     </TextBlock>
                 </StackPanel>
                 <Canvas Grid.Column="2" Width="80" Height="60" Margin="15,0,0,0">
-                    <Rectangle Width="70" Height="40" Fill="White" Stroke="{StaticResource AccentBrush}" RadiusX="6" RadiusY="6" Canvas.Left="5" Canvas.Top="15"/>
-                    <Polyline Points="5,45 25,25 45,30 65,10" Stroke="{StaticResource PrimaryBrush}" StrokeThickness="3" StrokeEndLineCap="Round" StrokeStartLineCap="Round"/>
-                    <Ellipse Width="8" Height="8" Fill="{StaticResource AccentBrush}" Canvas.Left="1" Canvas.Top="41"/>
-                    <Ellipse Width="8" Height="8" Fill="{StaticResource AccentBrush}" Canvas.Left="21" Canvas.Top="21"/>
-                    <Ellipse Width="8" Height="8" Fill="{StaticResource AccentBrush}" Canvas.Left="41" Canvas.Top="26"/>
-                    <Ellipse Width="8" Height="8" Fill="{StaticResource AccentBrush}" Canvas.Left="61" Canvas.Top="6"/>
+                    <Rectangle Width="70" Height="40" Fill="White" Stroke="{StaticResource Brush.Accent}" RadiusX="6" RadiusY="6" Canvas.Left="5" Canvas.Top="15"/>
+                    <Polyline Points="5,45 25,25 45,30 65,10" Stroke="{StaticResource Brush.Primary}" StrokeThickness="3" StrokeEndLineCap="Round" StrokeStartLineCap="Round"/>
+                    <Ellipse Width="8" Height="8" Fill="{StaticResource Brush.Accent}" Canvas.Left="1" Canvas.Top="41"/>
+                    <Ellipse Width="8" Height="8" Fill="{StaticResource Brush.Accent}" Canvas.Left="21" Canvas.Top="21"/>
+                    <Ellipse Width="8" Height="8" Fill="{StaticResource Brush.Accent}" Canvas.Left="41" Canvas.Top="26"/>
+                    <Ellipse Width="8" Height="8" Fill="{StaticResource Brush.Accent}" Canvas.Left="61" Canvas.Top="6"/>
                 </Canvas>
             </Grid>
         </Border>

--- a/Views/WaterDemandView.xaml
+++ b/Views/WaterDemandView.xaml
@@ -2,9 +2,11 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Name="Root"
-             Background="{StaticResource BackgroundBrush}">
-    <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
-        <Grid Margin="10">
+             Background="{StaticResource Brush.SurfaceAlt}"
+             SnapsToDevicePixels="True"
+             UseLayoutRounding="True">
+    <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto" Padding="{StaticResource Padding.Card}">
+        <Grid>
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="*"/>

--- a/app.manifest
+++ b/app.manifest
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <assemblyIdentity version="1.0.0.0" name="EconToolbox.Desktop.app"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="asInvoker" uiAccess="false"/>
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pmv2</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+    </windowsSettings>
+  </application>
+</assembly>


### PR DESCRIPTION
## Summary
- centralize palette, type ramp, spacing tokens, and a reusable width-to-layout converter in a shared resource dictionary
- refactor the main window hero, tab shell, and action area to swap responsive templates and adjust summary grids at different widths
- align feature views with the new spacing system, add layout rounding, and update DPI awareness via an application manifest

## Testing
- dotnet build *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c83d2859cc8330a927436588521e39