### PR TITLE
Fix design spacing resources using sys:Double

### DIFF
--- a/Themes/Design.xaml
+++ b/Themes/Design.xaml
@@ -1,5 +1,6 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:sys="clr-namespace:System;assembly=System.Runtime"
                     xmlns:converters="clr-namespace:EconToolbox.Desktop.Converters">
     <!-- Color palette -->
     <Color x:Key="Color.Primary">#2D6A8E</Color>
@@ -20,11 +21,11 @@
     <SolidColorBrush x:Key="Brush.TextSecondary" Color="{StaticResource Color.TextSecondary}"/>
 
     <!-- Spacing tokens -->
-    <x:Double x:Key="Space.XS">4</x:Double>
-    <x:Double x:Key="Space.SM">8</x:Double>
-    <x:Double x:Key="Space.MD">16</x:Double>
-    <x:Double x:Key="Space.LG">24</x:Double>
-    <x:Double x:Key="Space.XL">32</x:Double>
+    <sys:Double x:Key="Space.XS">4</sys:Double>
+    <sys:Double x:Key="Space.SM">8</sys:Double>
+    <sys:Double x:Key="Space.MD">16</sys:Double>
+    <sys:Double x:Key="Space.LG">24</sys:Double>
+    <sys:Double x:Key="Space.XL">32</sys:Double>
 
     <Thickness x:Key="Padding.Card">16</Thickness>
     <Thickness x:Key="Padding.Section">20</Thickness>


### PR DESCRIPTION
## Summary
- add the System namespace alias to the design resource dictionary
- convert spacing resources to use sys:Double to avoid the MC6002 error

## Testing
- dotnet build *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c841086b288330bf72143759999605