### PR TITLE
Improve responsive layout for toolbox views

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -180,7 +180,9 @@
                 Padding="0"
                 Background="{StaticResource Brush.SurfaceAlt}"
                 CornerRadius="12">
-            <ScrollViewer Focusable="False">
+            <ScrollViewer Focusable="False"
+                          HorizontalScrollBarVisibility="Disabled"
+                          VerticalScrollBarVisibility="Auto">
                 <TabControl SelectedIndex="{Binding SelectedIndex}" Background="{StaticResource Brush.Surface}">
                     <TabControl.Resources>
                         <Style TargetType="TabItem">

--- a/Themes/Design.xaml
+++ b/Themes/Design.xaml
@@ -92,7 +92,7 @@
     <Style TargetType="TextBox">
         <Setter Property="Margin" Value="{StaticResource Margin.Stack}"/>
         <Setter Property="Padding" Value="6"/>
-        <Setter Property="MinWidth" Value="140"/>
+        <Setter Property="MinWidth" Value="120"/>
         <Setter Property="BorderBrush" Value="{StaticResource Brush.Border}"/>
         <Setter Property="BorderThickness" Value="1"/>
     </Style>

--- a/Views/EadView.xaml
+++ b/Views/EadView.xaml
@@ -5,7 +5,10 @@
              SnapsToDevicePixels="True"
              UseLayoutRounding="True">
     <Grid>
-        <ScrollViewer Focusable="False" Padding="{StaticResource Padding.Card}">
+        <ScrollViewer Focusable="False"
+                      HorizontalScrollBarVisibility="Disabled"
+                      VerticalScrollBarVisibility="Auto"
+                      Padding="{StaticResource Padding.Card}">
             <Grid>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
@@ -93,27 +96,60 @@
                     </Button>
                 </WrapPanel>
 
-                <Grid Grid.Row="2" Margin="{StaticResource Margin.StackLarge}">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*" MinWidth="280"/>
-                        <ColumnDefinition Width="*" MinWidth="220"/>
-                    </Grid.ColumnDefinitions>
+                <UniformGrid Grid.Row="2"
+                             Margin="{StaticResource Margin.StackLarge}">
+                    <UniformGrid.Style>
+                        <Style TargetType="UniformGrid">
+                            <Setter Property="Columns" Value="1"/>
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding ActualWidth, RelativeSource={RelativeSource AncestorType=UserControl}, Converter={StaticResource WidthToLayoutModeConverter}}"
+                                             Value="Wide">
+                                    <Setter Property="Columns" Value="2"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </UniformGrid.Style>
 
-                    <Border Grid.Column="0" Background="{StaticResource Brush.Surface}" CornerRadius="6" Padding="{StaticResource Padding.Content}" BorderBrush="{StaticResource Brush.Border}" BorderThickness="1">
-                        <DataGrid x:Name="EadDataGrid"
-                                  ItemsSource="{Binding Rows}"
-                                  AutoGenerateColumns="False"
-                                  CanUserAddRows="True"
-                                  CanUserDeleteRows="True"/>
-                    </Border>
-
-                    <Border Grid.Column="1"
-                            Margin="{StaticResource Margin.InlineLarge}"
-                            Background="{StaticResource Brush.Surface}"
+                    <Border Background="{StaticResource Brush.Surface}"
                             CornerRadius="6"
                             Padding="{StaticResource Padding.Content}"
                             BorderBrush="{StaticResource Brush.Border}"
                             BorderThickness="1">
+                        <Border.Style>
+                            <Style TargetType="Border">
+                                <Setter Property="Margin" Value="0,0,0,16"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding ActualWidth, RelativeSource={RelativeSource AncestorType=UserControl}, Converter={StaticResource WidthToLayoutModeConverter}}"
+                                                 Value="Wide">
+                                        <Setter Property="Margin" Value="0,0,16,0"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Border.Style>
+                        <DataGrid x:Name="EadDataGrid"
+                                  ItemsSource="{Binding Rows}"
+                                  AutoGenerateColumns="False"
+                                  CanUserAddRows="True"
+                                  CanUserDeleteRows="True"
+                                  ScrollViewer.HorizontalScrollBarVisibility="Auto"/>
+                    </Border>
+
+                    <Border Background="{StaticResource Brush.Surface}"
+                            CornerRadius="6"
+                            Padding="{StaticResource Padding.Content}"
+                            BorderBrush="{StaticResource Brush.Border}"
+                            BorderThickness="1">
+                        <Border.Style>
+                            <Style TargetType="Border">
+                                <Setter Property="Margin" Value="0"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding ActualWidth, RelativeSource={RelativeSource AncestorType=UserControl}, Converter={StaticResource WidthToLayoutModeConverter}}"
+                                                 Value="Wide">
+                                        <Setter Property="Margin" Value="{StaticResource Margin.InlineLarge}"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Border.Style>
                         <StackPanel>
                             <TextBlock Text="Visualize Your Curve"
                                        FontWeight="SemiBold"
@@ -131,7 +167,7 @@
                             </TextBlock>
                         </StackPanel>
                     </Border>
-                </Grid>
+                </UniformGrid>
 
                 <ItemsControl ItemsSource="{Binding Results}" Grid.Row="3" Margin="{StaticResource Margin.StackLarge}">
                     <ItemsControl.ItemsPanel>

--- a/Views/UdvView.xaml
+++ b/Views/UdvView.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              SnapsToDevicePixels="True"
              UseLayoutRounding="True">
-    <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" Padding="{StaticResource Padding.Card}">
+    <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto" Padding="{StaticResource Padding.Card}">
         <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
@@ -25,10 +25,34 @@
             </StackPanel>
         </Border>
         <StackPanel Orientation="Horizontal" Grid.Row="1" Margin="{StaticResource Margin.Stack}">
-            <ComboBox ItemsSource="{Binding RecreationTypes}" SelectedItem="{Binding RecreationType}" Width="150" Margin="{StaticResource Margin.Inline}"/>
-            <ComboBox ItemsSource="{Binding ActivityTypes}" SelectedItem="{Binding ActivityType}" Width="220"/>
+            <StackPanel.Style>
+                <Style TargetType="StackPanel">
+                    <Setter Property="Orientation" Value="Horizontal"/>
+                    <Setter Property="HorizontalAlignment" Value="Stretch"/>
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding ActualWidth, RelativeSource={RelativeSource AncestorType=UserControl}, Converter={StaticResource WidthToLayoutModeConverter}}"
+                                     Value="Narrow">
+                            <Setter Property="Orientation" Value="Vertical"/>
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </StackPanel.Style>
+            <ComboBox ItemsSource="{Binding RecreationTypes}" SelectedItem="{Binding RecreationType}" MinWidth="150" Margin="{StaticResource Margin.Inline}"/>
+            <ComboBox ItemsSource="{Binding ActivityTypes}" SelectedItem="{Binding ActivityType}" MinWidth="200"/>
         </StackPanel>
         <StackPanel Orientation="Horizontal" Grid.Row="2" Margin="{StaticResource Margin.Stack}">
+            <StackPanel.Style>
+                <Style TargetType="StackPanel">
+                    <Setter Property="Orientation" Value="Horizontal"/>
+                    <Setter Property="HorizontalAlignment" Value="Stretch"/>
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding ActualWidth, RelativeSource={RelativeSource AncestorType=UserControl}, Converter={StaticResource WidthToLayoutModeConverter}}"
+                                     Value="Narrow">
+                            <Setter Property="Orientation" Value="Vertical"/>
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </StackPanel.Style>
             <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Foreground="{StaticResource Brush.Primary}" Margin="{StaticResource Margin.Inline}" VerticalAlignment="Center"/>
             <TextBlock Text="Points" VerticalAlignment="Center" Margin="{StaticResource Margin.Inline}"/>
             <TextBox Text="{Binding Points}" Width="60" Margin="{StaticResource Margin.InlineMedium}"/>
@@ -36,6 +60,19 @@
             <TextBlock Text="{Binding UnitDayValue, StringFormat={}{0:F2}}" VerticalAlignment="Center" FontWeight="SemiBold"/>
         </StackPanel>
         <StackPanel Orientation="Horizontal" Grid.Row="3" Margin="{StaticResource Margin.Stack}">
+            <StackPanel.Style>
+                <Style TargetType="StackPanel">
+                    <Setter Property="Orientation" Value="Horizontal"/>
+                    <Setter Property="HorizontalAlignment" Value="Stretch"/>
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding ActualWidth, RelativeSource={RelativeSource AncestorType=UserControl}, Converter={StaticResource WidthToLayoutModeConverter}}"
+                                     Value="Narrow">
+                            <Setter Property="Orientation" Value="Vertical"/>
+                            <Setter Property="HorizontalAlignment" Value="Left"/>
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </StackPanel.Style>
             <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Foreground="{StaticResource Brush.Primary}" Margin="{StaticResource Margin.Inline}" VerticalAlignment="Center"/>
             <TextBlock Text="Annual User Days" VerticalAlignment="Center" Margin="{StaticResource Margin.Inline}"/>
             <TextBox Text="{Binding UserDays}" Width="80" Margin="{StaticResource Margin.InlineMedium}"/>

--- a/Views/UpdatedCostView.xaml
+++ b/Views/UpdatedCostView.xaml
@@ -6,7 +6,7 @@
              mc:Ignorable="d"
              SnapsToDevicePixels="True"
              UseLayoutRounding="True">
-    <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" Padding="{StaticResource Padding.Card}">
+    <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto" Padding="{StaticResource Padding.Card}">
         <StackPanel>
         <Border Margin="10,0,10,10" Background="#EEF6F8" BorderBrush="{StaticResource Brush.Primary}" BorderThickness="1" CornerRadius="10" Padding="16">
             <Grid>
@@ -15,16 +15,49 @@
                     <ColumnDefinition Width="*"/>
                     <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
                 <StackPanel Orientation="Horizontal" Grid.Column="0" VerticalAlignment="Top">
                     <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="24" Foreground="{StaticResource Brush.Primary}" Margin="0,0,10,0"/>
                 </StackPanel>
                 <StackPanel Grid.Column="1">
+                    <StackPanel.Style>
+                        <Style TargetType="StackPanel">
+                            <Setter Property="Grid.Row" Value="0"/>
+                            <Setter Property="Grid.ColumnSpan" Value="1"/>
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding ActualWidth, RelativeSource={RelativeSource AncestorType=Border}, Converter={StaticResource WidthToLayoutModeConverter}}"
+                                             Value="Narrow">
+                                    <Setter Property="Grid.ColumnSpan" Value="2"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </StackPanel.Style>
                     <TextBlock Text="Updated Cost Workflow" FontSize="18" FontWeight="Bold" Foreground="{StaticResource Brush.Primary}"/>
                     <TextBlock TextWrapping="Wrap" Margin="0,6,0,0">
                         Work through each sub-tab from left to right. Start with storage capacity, capture annual joint costs, update historical line items, then evaluate RR&amp;R/mitigation and total annual cost scenarios. Press Compute within each section before leaving the tab so downstream values stay synchronized.
                     </TextBlock>
                 </StackPanel>
-                <Canvas Grid.Column="2" Width="80" Height="60" Margin="15,0,0,0">
+                <Canvas Width="80" Height="60">
+                    <Canvas.Style>
+                        <Style TargetType="Canvas">
+                            <Setter Property="Grid.Column" Value="2"/>
+                            <Setter Property="Grid.Row" Value="0"/>
+                            <Setter Property="Margin" Value="15,0,0,0"/>
+                            <Setter Property="HorizontalAlignment" Value="Right"/>
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding ActualWidth, RelativeSource={RelativeSource AncestorType=Border}, Converter={StaticResource WidthToLayoutModeConverter}}"
+                                             Value="Narrow">
+                                    <Setter Property="Grid.Column" Value="0"/>
+                                    <Setter Property="Grid.Row" Value="1"/>
+                                    <Setter Property="Margin" Value="0,12,0,0"/>
+                                    <Setter Property="HorizontalAlignment" Value="Center"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Canvas.Style>
                     <Rectangle Width="70" Height="40" Fill="White" Stroke="{StaticResource Brush.Accent}" RadiusX="6" RadiusY="6" Canvas.Left="5" Canvas.Top="15"/>
                     <Polyline Points="5,45 25,25 45,30 65,10" Stroke="{StaticResource Brush.Primary}" StrokeThickness="3" StrokeEndLineCap="Round" StrokeStartLineCap="Round"/>
                     <Ellipse Width="8" Height="8" Fill="{StaticResource Brush.Accent}" Canvas.Left="1" Canvas.Top="41"/>
@@ -34,7 +67,7 @@
                 </Canvas>
             </Grid>
         </Border>
-        <TabControl Margin="10,0,10,10">
+        <TabControl Margin="10,0,10,10" HorizontalContentAlignment="Stretch">
         <TabItem Header="Storage Cost">
             <StackPanel Margin="10">
                 <Border Background="#FFF7F0" BorderBrush="#F2C089" BorderThickness="1" CornerRadius="8" Padding="12" Margin="0,0,0,10">

--- a/Views/WaterDemandView.xaml
+++ b/Views/WaterDemandView.xaml
@@ -5,7 +5,9 @@
              Background="{StaticResource Brush.SurfaceAlt}"
              SnapsToDevicePixels="True"
              UseLayoutRounding="True">
-    <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto" Padding="{StaticResource Padding.Card}">
+    <ScrollViewer VerticalScrollBarVisibility="Auto"
+                  HorizontalScrollBarVisibility="Disabled"
+                  Padding="{StaticResource Padding.Card}">
         <Grid>
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>
@@ -32,7 +34,7 @@
                     </StackPanel>
                 </Grid>
             </Border>
-            <TabControl Grid.Row="1" ItemsSource="{Binding Scenarios}" SelectedItem="{Binding SelectedScenario}">
+            <TabControl Grid.Row="1" ItemsSource="{Binding Scenarios}" SelectedItem="{Binding SelectedScenario}" HorizontalContentAlignment="Stretch">
                 <TabControl.ItemTemplate>
                     <DataTemplate>
                         <TextBlock Text="{Binding Name}" ToolTip="{Binding Description}"/>
@@ -40,12 +42,16 @@
                 </TabControl.ItemTemplate>
                 <TabControl.ContentTemplate>
                     <DataTemplate>
-                        <Grid>
+                        <Grid x:Name="ScenarioLayout">
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="3*"/>
-                                <ColumnDefinition Width="2*"/>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="Auto"/>
                             </Grid.ColumnDefinitions>
-                            <Grid Grid.Column="0">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+                            <Grid Grid.Column="0" Grid.Row="0">
                                 <Grid.RowDefinitions>
                                     <RowDefinition Height="2*"/>
                                     <RowDefinition Height="Auto"/>
@@ -59,7 +65,7 @@
                                         </DataGrid.Columns>
                                     </DataGrid>
                                 </Border>
-                                <Grid Grid.Row="1" Margin="0,0,0,5" VerticalAlignment="Top" HorizontalAlignment="Left">
+                                <Grid Grid.Row="1" Margin="0,0,0,5" VerticalAlignment="Top" HorizontalAlignment="Stretch">
                                     <Grid.RowDefinitions>
                                         <RowDefinition Height="Auto"/>
                                         <RowDefinition Height="Auto"/>
@@ -73,13 +79,13 @@
                                     </Grid.RowDefinitions>
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="Auto"/>
-                                        <ColumnDefinition Width="Auto"/>
+                                        <ColumnDefinition Width="*"/>
                                         <ColumnDefinition Width="Auto"/>
                                     </Grid.ColumnDefinitions>
                                     <Grid.Resources>
                                         <Style TargetType="TextBox">
-                                            <Setter Property="Width" Value="120"/>
-                                            <Setter Property="HorizontalAlignment" Value="Left"/>
+                                            <Setter Property="MinWidth" Value="120"/>
+                                            <Setter Property="HorizontalAlignment" Value="Stretch"/>
                                             <Setter Property="Margin" Value="0,0,10,0"/>
                                         </Style>
                                     </Grid.Resources>
@@ -129,13 +135,26 @@
                                     </Expander>
 
                                     <StackPanel Grid.Row="8" Grid.ColumnSpan="3" Orientation="Horizontal" HorizontalAlignment="Left">
-                                        <Button Width="110" Command="{Binding DataContext.ForecastCommand, ElementName=Root}" Margin="0,0,5,0">
+                                        <StackPanel.Style>
+                                            <Style TargetType="StackPanel">
+                                                <Setter Property="Orientation" Value="Horizontal"/>
+                                                <Setter Property="HorizontalAlignment" Value="Left"/>
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding ActualWidth, RelativeSource={RelativeSource AncestorType=ContentPresenter}, Converter={StaticResource WidthToLayoutModeConverter}}"
+                                                                 Value="Narrow">
+                                                        <Setter Property="Orientation" Value="Vertical"/>
+                                                        <Setter Property="HorizontalAlignment" Value="Stretch"/>
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </StackPanel.Style>
+                                        <Button MinWidth="110" Command="{Binding DataContext.ForecastCommand, ElementName=Root}" Margin="0,0,5,0">
                                             <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
                                                 <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Margin="0,0,6,0"/>
                                                 <TextBlock Text="Forecast"/>
                                             </StackPanel>
                                         </Button>
-                                        <Button Width="110" Command="{Binding DataContext.ExportCommand, ElementName=Root}">
+                                        <Button MinWidth="110" Command="{Binding DataContext.ExportCommand, ElementName=Root}">
                                             <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
                                                 <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Margin="0,0,6,0"/>
                                                 <TextBlock Text="Export"/>
@@ -200,7 +219,22 @@
                                     </DataGrid>
                                 </Border>
                             </Grid>
-                            <Border Grid.Column="1" Margin="10,0,0,0" Background="White" CornerRadius="4" Padding="5">
+                            <Border Background="White" CornerRadius="4" Padding="5">
+                                <Border.Style>
+                                    <Style TargetType="Border">
+                                        <Setter Property="Grid.Column" Value="1"/>
+                                        <Setter Property="Grid.Row" Value="0"/>
+                                        <Setter Property="Margin" Value="10,0,0,0"/>
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding ActualWidth, RelativeSource={RelativeSource AncestorType=ContentPresenter}, Converter={StaticResource WidthToLayoutModeConverter}}"
+                                                         Value="Narrow">
+                                                <Setter Property="Grid.Column" Value="0"/>
+                                                <Setter Property="Grid.Row" Value="1"/>
+                                                <Setter Property="Margin" Value="0,10,0,0"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Border.Style>
                                 <ItemsControl ItemsSource="{Binding DataContext.Scenarios, ElementName=Root}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
                                     <ItemsControl.ItemsPanel>
                                         <ItemsPanelTemplate>


### PR DESCRIPTION
## Summary
- reduce global TextBox minimum width and eliminate horizontal scrolling in the main shell so layouts can shrink with the window
- rework the EAD view grid into an adaptive uniform grid and add scroll settings so tables and charts stack gracefully on narrow screens
- add width-based layout triggers across the Updated Cost, Water Demand, and Unit Day Value views to stack controls, relocate charts, and wrap command areas when space is limited

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c84352b14c83308812d4bc6e2e2f61