### PR TITLE
Improve water demand chart and acre-foot outputs

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -401,9 +401,9 @@
                                         </Style>
                                     </TextBlock.Style>
                                 </TextBlock>
-                                <DataGrid Grid.Row="16" ItemsSource="{Binding IdcEntries}" AutoGenerateColumns="False">
-                                    <DataGrid.Style>
-                                        <Style TargetType="DataGrid" BasedOn="{StaticResource AnnualizerInputStyle}">
+                                <Grid Grid.Row="16">
+                                    <Grid.Style>
+                                        <Style TargetType="Grid" BasedOn="{StaticResource AnnualizerInputStyle}">
                                             <Style.Triggers>
                                                 <DataTrigger Binding="{Binding ActualWidth, RelativeSource={RelativeSource AncestorType=TabItem}, Converter={StaticResource WidthToLayoutModeConverter}}"
                                                              Value="Wide">
@@ -411,22 +411,38 @@
                                                 </DataTrigger>
                                             </Style.Triggers>
                                         </Style>
-                                    </DataGrid.Style>
-                                    <DataGrid.Columns>
-                                        <DataGridTextColumn Header="Cost" Binding="{Binding Cost}"/>
-                                        <DataGridTextColumn Header="Month" Binding="{Binding Year}"/>
-                                        <DataGridComboBoxColumn Header="Timing" SelectedItemBinding="{Binding Timing}">
-                                            <DataGridComboBoxColumn.ItemsSource>
-                                                <x:Array Type="sys:String" xmlns:sys="clr-namespace:System;assembly=mscorlib">
-                                                    <sys:String>beginning</sys:String>
-                                                    <sys:String>midpoint</sys:String>
-                                                    <sys:String>end</sys:String>
-                                                </x:Array>
-                                            </DataGridComboBoxColumn.ItemsSource>
-                                        </DataGridComboBoxColumn>
-                                        <DataGridTextColumn Header="PV Factor" Binding="{Binding PvFactor}" IsReadOnly="True"/>
-                                    </DataGrid.Columns>
-                                </DataGrid>
+                                    </Grid.Style>
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                    </Grid.RowDefinitions>
+                                    <Border Background="White" BorderBrush="{StaticResource Brush.Border}" BorderThickness="1" CornerRadius="6" Padding="6">
+                                        <DataGrid ItemsSource="{Binding IdcEntries}" AutoGenerateColumns="False" Margin="0" HeadersVisibility="All">
+                                            <DataGrid.Columns>
+                                                <DataGridTextColumn Header="Cost" Binding="{Binding Cost}"/>
+                                                <DataGridTextColumn Header="Month" Binding="{Binding Year}"/>
+                                                <DataGridComboBoxColumn Header="Timing" SelectedItemBinding="{Binding Timing}">
+                                                    <DataGridComboBoxColumn.ItemsSource>
+                                                        <x:Array Type="sys:String" xmlns:sys="clr-namespace:System;assembly=mscorlib">
+                                                            <sys:String>beginning</sys:String>
+                                                            <sys:String>midpoint</sys:String>
+                                                            <sys:String>end</sys:String>
+                                                        </x:Array>
+                                                    </DataGridComboBoxColumn.ItemsSource>
+                                                </DataGridComboBoxColumn>
+                                                <DataGridTextColumn Header="PV Factor" Binding="{Binding PvFactor}" IsReadOnly="True"/>
+                                            </DataGrid.Columns>
+                                        </DataGrid>
+                                    </Border>
+                                    <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,8,0,0">
+                                        <Button Command="{Binding ResetIdcCommand}" MinWidth="160" ToolTip="Clear all IDC schedule entries">
+                                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                                                <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Margin="{StaticResource Margin.Inline}"/>
+                                                <TextBlock Text="Reset IDC Inputs"/>
+                                            </StackPanel>
+                                        </Button>
+                                    </StackPanel>
+                                </Grid>
 
                                 <TextBlock Grid.Row="17" Text="Future Costs">
                                     <TextBlock.Style>
@@ -441,9 +457,9 @@
                                         </Style>
                                     </TextBlock.Style>
                                 </TextBlock>
-                                <DataGrid Grid.Row="18" ItemsSource="{Binding FutureCosts}" AutoGenerateColumns="False">
-                                    <DataGrid.Style>
-                                        <Style TargetType="DataGrid" BasedOn="{StaticResource AnnualizerInputStyle}">
+                                <Grid Grid.Row="18">
+                                    <Grid.Style>
+                                        <Style TargetType="Grid" BasedOn="{StaticResource AnnualizerInputStyle}">
                                             <Style.Triggers>
                                                 <DataTrigger Binding="{Binding ActualWidth, RelativeSource={RelativeSource AncestorType=TabItem}, Converter={StaticResource WidthToLayoutModeConverter}}"
                                                              Value="Wide">
@@ -451,22 +467,38 @@
                                                 </DataTrigger>
                                             </Style.Triggers>
                                         </Style>
-                                    </DataGrid.Style>
-                                    <DataGrid.Columns>
-                                        <DataGridTextColumn Header="Cost" Binding="{Binding Cost}"/>
-                                        <DataGridTextColumn Header="Year" Binding="{Binding Year}"/>
-                                        <DataGridComboBoxColumn Header="Timing" SelectedItemBinding="{Binding Timing}">
-                                            <DataGridComboBoxColumn.ItemsSource>
-                                                <x:Array Type="sys:String" xmlns:sys="clr-namespace:System;assembly=mscorlib">
-                                                    <sys:String>beginning</sys:String>
-                                                    <sys:String>midpoint</sys:String>
-                                                    <sys:String>end</sys:String>
-                                                </x:Array>
-                                            </DataGridComboBoxColumn.ItemsSource>
-                                        </DataGridComboBoxColumn>
-                                        <DataGridTextColumn Header="PV Factor" Binding="{Binding PvFactor}" IsReadOnly="True"/>
-                                    </DataGrid.Columns>
-                                </DataGrid>
+                                    </Grid.Style>
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                    </Grid.RowDefinitions>
+                                    <Border Background="White" BorderBrush="{StaticResource Brush.Border}" BorderThickness="1" CornerRadius="6" Padding="6">
+                                        <DataGrid ItemsSource="{Binding FutureCosts}" AutoGenerateColumns="False" Margin="0">
+                                            <DataGrid.Columns>
+                                                <DataGridTextColumn Header="Cost" Binding="{Binding Cost}"/>
+                                                <DataGridTextColumn Header="Year" Binding="{Binding Year}"/>
+                                                <DataGridComboBoxColumn Header="Timing" SelectedItemBinding="{Binding Timing}">
+                                                    <DataGridComboBoxColumn.ItemsSource>
+                                                        <x:Array Type="sys:String" xmlns:sys="clr-namespace:System;assembly=mscorlib">
+                                                            <sys:String>beginning</sys:String>
+                                                            <sys:String>midpoint</sys:String>
+                                                            <sys:String>end</sys:String>
+                                                        </x:Array>
+                                                    </DataGridComboBoxColumn.ItemsSource>
+                                                </DataGridComboBoxColumn>
+                                                <DataGridTextColumn Header="PV Factor" Binding="{Binding PvFactor}" IsReadOnly="True"/>
+                                            </DataGrid.Columns>
+                                        </DataGrid>
+                                    </Border>
+                                    <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,8,0,0">
+                                        <Button Command="{Binding ResetFutureCostsCommand}" MinWidth="160" ToolTip="Clear all future cost entries">
+                                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                                                <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Margin="{StaticResource Margin.Inline}"/>
+                                                <TextBlock Text="Reset Future Costs"/>
+                                            </StackPanel>
+                                        </Button>
+                                    </StackPanel>
+                                </Grid>
 
                                 <UniformGrid Grid.Row="19" Grid.ColumnSpan="2" Columns="1" Margin="{StaticResource Margin.TopLarge}">
                                     <UniformGrid.Style>

--- a/Models/DemandEntry.cs
+++ b/Models/DemandEntry.cs
@@ -2,6 +2,8 @@ namespace EconToolbox.Desktop.Models
 {
     public class DemandEntry : ObservableObject
     {
+        private const double GallonsPerAcreFoot = 325851.0;
+        private const double DaysPerYear = 365.0;
         private int _year;
         private double _demand;
         private double _residentialDemand;
@@ -20,7 +22,14 @@ namespace EconToolbox.Desktop.Models
         public double Demand
         {
             get => _demand;
-            set { _demand = value; OnPropertyChanged(); }
+            set
+            {
+                if (_demand == value)
+                    return;
+                _demand = value;
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(DemandAcreFeet));
+            }
         }
 
         public double ResidentialDemand
@@ -50,7 +59,14 @@ namespace EconToolbox.Desktop.Models
         public double AdjustedDemand
         {
             get => _adjustedDemand;
-            set { _adjustedDemand = value; OnPropertyChanged(); }
+            set
+            {
+                if (_adjustedDemand == value)
+                    return;
+                _adjustedDemand = value;
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(AdjustedDemandAcreFeet));
+            }
         }
 
         public double GrowthRate
@@ -58,5 +74,9 @@ namespace EconToolbox.Desktop.Models
             get => _growthRate;
             set { _growthRate = value; OnPropertyChanged(); }
         }
+
+        public double DemandAcreFeet => _demand * DaysPerYear / GallonsPerAcreFoot;
+
+        public double AdjustedDemandAcreFeet => _adjustedDemand * DaysPerYear / GallonsPerAcreFoot;
     }
 }

--- a/Services/ExcelExporter.cs
+++ b/Services/ExcelExporter.cs
@@ -40,12 +40,14 @@ namespace EconToolbox.Desktop.Services
                 ws.Cell(1,5).Value = "Industrial";
                 ws.Cell(1,6).Value = "Agricultural";
                 ws.Cell(1,7).Value = "Adjusted";
+                ws.Cell(1,8).Value = "Adjusted (ac-ft/yr)";
                 ws.Cell(1,2).GetComment().AddText("Demand = Prior Demand × (1 + Growth Rate)");
                 ws.Cell(1,3).GetComment().AddText("Residential = Demand × Residential %");
                 ws.Cell(1,4).GetComment().AddText("Commercial = Demand × Commercial %");
                 ws.Cell(1,5).GetComment().AddText("Industrial = Demand × Industrial %");
                 ws.Cell(1,6).GetComment().AddText("Agricultural = Demand × Agricultural %");
                 ws.Cell(1,7).GetComment().AddText("Adjusted = Demand × (1 - Improvements %) × (1 - Losses %)");
+                ws.Cell(1,8).GetComment().AddText("Adjusted Acre-Feet = Adjusted Demand × 365 ÷ 325,851");
                 int row = 2;
                 foreach (var d in scenario.Results)
                 {
@@ -56,6 +58,7 @@ namespace EconToolbox.Desktop.Services
                     ws.Cell(row,5).Value = d.IndustrialDemand;
                     ws.Cell(row,6).Value = d.AgriculturalDemand;
                     ws.Cell(row,7).Value = d.AdjustedDemand;
+                    ws.Cell(row,8).Value = d.AdjustedDemandAcreFeet;
                     row++;
                 }
             }
@@ -224,9 +227,11 @@ namespace EconToolbox.Desktop.Services
                 wdSheet.Cell(1,2).Value = "Demand";
                 wdSheet.Cell(1,3).Value = "Industrial";
                 wdSheet.Cell(1,4).Value = "Adjusted";
+                wdSheet.Cell(1,5).Value = "Adjusted (ac-ft/yr)";
                 wdSheet.Cell(1,2).GetComment().AddText("Demand = Prior Demand × (1 + Growth Rate)");
                 wdSheet.Cell(1,3).GetComment().AddText("Industrial = Demand × Industrial %");
                 wdSheet.Cell(1,4).GetComment().AddText("Adjusted = Demand × (1 - Improvements %) × (1 - Losses %)");
+                wdSheet.Cell(1,5).GetComment().AddText("Adjusted Acre-Feet = Adjusted Demand × 365 ÷ 325,851");
                 rowIdx = 2;
                 foreach (var d in scenario.Results)
                 {
@@ -234,6 +239,7 @@ namespace EconToolbox.Desktop.Services
                     wdSheet.Cell(rowIdx,2).Value = d.Demand;
                     wdSheet.Cell(rowIdx,3).Value = d.IndustrialDemand;
                     wdSheet.Cell(rowIdx,4).Value = d.AdjustedDemand;
+                    wdSheet.Cell(rowIdx,5).Value = d.AdjustedDemandAcreFeet;
                     rowIdx++;
                 }
             }

--- a/ViewModels/AnnualizerViewModel.cs
+++ b/ViewModels/AnnualizerViewModel.cs
@@ -121,11 +121,15 @@ namespace EconToolbox.Desktop.ViewModels
 
         public ICommand ComputeCommand { get; }
         public ICommand ExportCommand { get; }
+        public ICommand ResetIdcCommand { get; }
+        public ICommand ResetFutureCostsCommand { get; }
 
         public AnnualizerViewModel()
         {
             ComputeCommand = new RelayCommand(Compute);
             ExportCommand = new RelayCommand(Export);
+            ResetIdcCommand = new RelayCommand(ResetIdcEntries);
+            ResetFutureCostsCommand = new RelayCommand(ResetFutureCostEntries);
 
             FutureCosts.CollectionChanged += EntriesChanged;
             IdcEntries.CollectionChanged += EntriesChanged;
@@ -133,6 +137,11 @@ namespace EconToolbox.Desktop.ViewModels
 
         private void EntriesChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
+            if (e.OldItems != null)
+            {
+                foreach (FutureCostEntry entry in e.OldItems)
+                    entry.PropertyChanged -= EntryOnPropertyChanged;
+            }
             if (e.NewItems != null)
                 foreach (FutureCostEntry entry in e.NewItems)
                     entry.PropertyChanged += EntryOnPropertyChanged;
@@ -225,6 +234,24 @@ namespace EconToolbox.Desktop.ViewModels
                 Services.ExcelExporter.ExportAnnualizer(FirstCost, Rate, AnnualOm, AnnualBenefits,
                     FutureCosts, Idc, TotalInvestment, Crf, AnnualCost, Bcr, dlg.FileName);
             }
+        }
+
+        private void ResetIdcEntries()
+        {
+            if (IdcEntries.Count == 0)
+                return;
+            foreach (var entry in IdcEntries.ToList())
+                entry.PropertyChanged -= EntryOnPropertyChanged;
+            IdcEntries.Clear();
+        }
+
+        private void ResetFutureCostEntries()
+        {
+            if (FutureCosts.Count == 0)
+                return;
+            foreach (var entry in FutureCosts.ToList())
+                entry.PropertyChanged -= EntryOnPropertyChanged;
+            FutureCosts.Clear();
         }
     }
 }

--- a/ViewModels/WaterDemandViewModel.cs
+++ b/ViewModels/WaterDemandViewModel.cs
@@ -387,8 +387,8 @@ namespace EconToolbox.Desktop.ViewModels
                 if (d.Demand > maxDemand) maxDemand = d.Demand;
             }
 
-            double width = 300; // Canvas width used in XAML
-            double height = 150; // Canvas height used in XAML
+            const double width = 300; // Canvas width used in XAML
+            const double height = 168; // Canvas height used in XAML
             double yearRange = maxYear - minYear;
             if (yearRange == 0) yearRange = 1;
             double demandRange = maxDemand - minDemand;

--- a/Views/UdvView.xaml
+++ b/Views/UdvView.xaml
@@ -16,7 +16,16 @@
         <Border Grid.Row="0" Background="#FFF4F7" BorderBrush="#E8A6B8" BorderThickness="1" CornerRadius="10" Padding="12" Margin="{StaticResource Margin.Stack}">
             <StackPanel>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="18" Foreground="#C23E64" Margin="{StaticResource Margin.Inline}"/>
+                    <Viewbox Width="28" Height="28" Margin="{StaticResource Margin.Inline}">
+                        <Canvas Width="28" Height="28">
+                            <Polygon Points="14,3 8,13 11,13 6,20 22,20 17,13 20,13" Fill="#C23E64"/>
+                            <Rectangle Width="3" Height="6" Fill="#7A1F3E" RadiusX="1" RadiusY="1" Canvas.Left="12.5" Canvas.Top="20"/>
+                            <Rectangle Width="18" Height="3" Fill="#C23E64" RadiusX="1.5" RadiusY="1.5" Canvas.Left="5" Canvas.Top="19"/>
+                            <Rectangle Width="2.5" Height="5" Fill="#7A1F3E" RadiusX="1" RadiusY="1" Canvas.Left="7" Canvas.Top="21.5"/>
+                            <Rectangle Width="2.5" Height="5" Fill="#7A1F3E" RadiusX="1" RadiusY="1" Canvas.Left="18.5" Canvas.Top="21.5"/>
+                            <Path Data="M5,25 L23,25" Stroke="#C23E64" StrokeThickness="1.8" StrokeEndLineCap="Round" StrokeStartLineCap="Round"/>
+                        </Canvas>
+                    </Viewbox>
                     <TextBlock Text="Unit Day Value Overview" FontWeight="Bold" Foreground="#C23E64"/>
                 </StackPanel>
                 <TextBlock TextWrapping="Wrap" Margin="{StaticResource Margin.TopSmall}">

--- a/Views/WaterDemandView.xaml
+++ b/Views/WaterDemandView.xaml
@@ -215,11 +215,18 @@
                                                     </Style>
                                                 </DataGridTextColumn.ElementStyle>
                                             </DataGridTextColumn>
+                                            <DataGridTextColumn Header="Adjusted (ac-ft/yr)" Binding="{Binding AdjustedDemandAcreFeet, StringFormat={}{0:N2}}">
+                                                <DataGridTextColumn.ElementStyle>
+                                                    <Style TargetType="TextBlock">
+                                                        <Setter Property="ToolTip" Value="Adjusted Acre-Feet = Adjusted Demand × 365 ÷ 325,851"/>
+                                                    </Style>
+                                                </DataGridTextColumn.ElementStyle>
+                                            </DataGridTextColumn>
                                         </DataGrid.Columns>
                                     </DataGrid>
                                 </Border>
                             </Grid>
-                            <Border Background="White" CornerRadius="4" Padding="5">
+                            <Border Background="White" CornerRadius="4" Padding="12">
                                 <Border.Style>
                                     <Style TargetType="Border">
                                         <Setter Property="Grid.Column" Value="1"/>
@@ -235,18 +242,67 @@
                                         </Style.Triggers>
                                     </Style>
                                 </Border.Style>
-                                <ItemsControl ItemsSource="{Binding DataContext.Scenarios, ElementName=Root}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
-                                    <ItemsControl.ItemsPanel>
-                                        <ItemsPanelTemplate>
-                                            <Canvas/>
-                                        </ItemsPanelTemplate>
-                                    </ItemsControl.ItemsPanel>
-                                    <ItemsControl.ItemTemplate>
-                                        <DataTemplate>
-                                            <Polyline Points="{Binding ChartPoints}" Stroke="{Binding LineBrush}" StrokeThickness="2"/>
-                                        </DataTemplate>
-                                    </ItemsControl.ItemTemplate>
-                                </ItemsControl>
+                                <Grid>
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="*"/>
+                                    </Grid.RowDefinitions>
+                                    <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,10">
+                                        <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="18" Foreground="#1F6AB0" Margin="0,0,8,0"/>
+                                        <TextBlock Text="Forecast Demand Trend" FontWeight="SemiBold" Foreground="#1F6AB0"/>
+                                    </StackPanel>
+                                    <Viewbox Grid.Row="1" Stretch="Uniform" HorizontalAlignment="Stretch" MinHeight="220">
+                                        <Grid Width="360" Height="220">
+                                            <Border Background="#F7FBFF" BorderBrush="#CCE0F5" BorderThickness="1.5" CornerRadius="10"/>
+                                            <Canvas Width="360" Height="220" IsHitTestVisible="False">
+                                                <Line X1="36" Y1="20" X2="36" Y2="200" Stroke="#B6CCE5" StrokeThickness="1.2" StrokeEndLineCap="Round"/>
+                                                <Line X1="36" Y1="200" X2="340" Y2="200" Stroke="#B6CCE5" StrokeThickness="1.2" StrokeEndLineCap="Round"/>
+                                                <Line X1="36" Y1="140" X2="340" Y2="140" Stroke="#E0EBF5" StrokeThickness="1" StrokeDashArray="2 4"/>
+                                                <Line X1="36" Y1="80" X2="340" Y2="80" Stroke="#E0EBF5" StrokeThickness="1" StrokeDashArray="2 4"/>
+                                                <Line X1="130" Y1="20" X2="130" Y2="200" Stroke="#E0EBF5" StrokeThickness="1" StrokeDashArray="2 4"/>
+                                                <Line X1="220" Y1="20" X2="220" Y2="200" Stroke="#E0EBF5" StrokeThickness="1" StrokeDashArray="2 4"/>
+                                            </Canvas>
+                                            <ItemsControl Margin="36,20,20,32"
+                                                          ItemsSource="{Binding DataContext.Scenarios, ElementName=Root}"
+                                                          HorizontalAlignment="Stretch"
+                                                          VerticalAlignment="Stretch"
+                                                          ClipToBounds="True">
+                                                <ItemsControl.ItemsPanel>
+                                                    <ItemsPanelTemplate>
+                                                        <Canvas Width="300" Height="168"/>
+                                                    </ItemsPanelTemplate>
+                                                </ItemsControl.ItemsPanel>
+                                                <ItemsControl.ItemTemplate>
+                                                    <DataTemplate>
+                                                        <Polyline Points="{Binding ChartPoints}"
+                                                                  Stroke="{Binding LineBrush}"
+                                                                  StrokeThickness="3"
+                                                                  StrokeEndLineCap="Round"
+                                                                  StrokeStartLineCap="Round"
+                                                                  Fill="Transparent"/>
+                                                    </DataTemplate>
+                                                </ItemsControl.ItemTemplate>
+                                            </ItemsControl>
+                                            <TextBlock Text="Year"
+                                                       Foreground="#31556F"
+                                                       FontSize="12"
+                                                       HorizontalAlignment="Center"
+                                                       VerticalAlignment="Bottom"
+                                                       Margin="0,0,0,6"/>
+                                            <TextBlock Text="Adjusted Demand (gallons/day)"
+                                                       Foreground="#31556F"
+                                                       FontSize="12"
+                                                       RenderTransformOrigin="0.5,0.5"
+                                                       HorizontalAlignment="Left"
+                                                       VerticalAlignment="Center"
+                                                       Margin="-4,0,0,0">
+                                                <TextBlock.RenderTransform>
+                                                    <RotateTransform Angle="-90"/>
+                                                </TextBlock.RenderTransform>
+                                            </TextBlock>
+                                        </Grid>
+                                    </Viewbox>
+                                </Grid>
                             </Border>
                         </Grid>
                     </DataTemplate>
@@ -282,6 +338,8 @@
                         • Demand shows projected system demand before sector allocations. Each sector column (Residential, Commercial, Industrial, Agricultural) applies the percentages you supplied.
                         <LineBreak/>
                         • Adjusted demand applies the Advanced Adjustments so you can see conservation impacts immediately.
+                        <LineBreak/>
+                        • Adjusted (ac-ft/yr) multiplies the adjusted demand by 365 and divides by 325,851 so you can translate daily demand into reservoir storage requirements.
                     </TextBlock>
                 </StackPanel>
             </Border>


### PR DESCRIPTION
## Summary
- Redesign the water demand forecast chart to scale with the window, add axis styling, and surface an adjusted acre-foot column in the results grid
- Compute acre-foot values in the forecast model and include them in Excel exports alongside the existing gallon-based figures
- Tidy the cost annualization tab by wrapping the IDC and future cost inputs in bordered panes, add clear buttons, and swap the UDV tab icon for a recreation-themed graphic

## Testing
- `dotnet build` *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c85205df0c8330bd638e94eed777c2