### PR TITLE
Add mind map planning workspace

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -225,6 +225,12 @@
                         </TabItem.Header>
                         <views:UdvView Margin="{StaticResource Margin.Container}"/>
                     </TabItem>
+                    <TabItem DataContext="{Binding MindMap}">
+                        <TabItem.Header>
+                            <TextBlock Text="Mind Map" TextAlignment="Center"/>
+                        </TabItem.Header>
+                        <views:MindMapView Margin="{StaticResource Margin.Container}"/>
+                    </TabItem>
                 </TabControl>
             </ScrollViewer>
         </Border>

--- a/Services/ExcelExporter.cs
+++ b/Services/ExcelExporter.cs
@@ -146,7 +146,7 @@ namespace EconToolbox.Desktop.Services
             wb.SaveAs(filePath);
         }
 
-        public static void ExportAll(EadViewModel ead, UpdatedCostViewModel updated, AnnualizerViewModel annualizer, WaterDemandViewModel waterDemand, UdvViewModel udv, string filePath)
+        public static void ExportAll(EadViewModel ead, UpdatedCostViewModel updated, AnnualizerViewModel annualizer, WaterDemandViewModel waterDemand, UdvViewModel udv, MindMapViewModel mindMap, string filePath)
         {
             using var wb = new XLWorkbook();
 
@@ -346,6 +346,27 @@ namespace EconToolbox.Desktop.Services
                 // each value explicitly to an XLCellValue before assignment.
                 udvSheet.Cell(rowIdx,2).Value = XLCellValue.FromObject(kv.Value);
                 rowIdx++;
+            }
+
+            // Mind Map Sheet
+            var mindMapSheet = wb.Worksheets.Add("MindMap");
+            mindMapSheet.Cell(1,1).Value = "Depth";
+            mindMapSheet.Cell(1,2).Value = "Idea";
+            mindMapSheet.Cell(1,3).Value = "Path";
+            mindMapSheet.Cell(1,4).Value = "Notes";
+            int mindMapRow = 2;
+            foreach (var node in mindMap.Flatten())
+            {
+                var path = node.GetPath().ToList();
+                mindMapSheet.Cell(mindMapRow,1).Value = path.Count - 1;
+                mindMapSheet.Cell(mindMapRow,2).Value = node.Title;
+                mindMapSheet.Cell(mindMapRow,3).Value = string.Join(" > ", path.Select(p => p.Title));
+                mindMapSheet.Cell(mindMapRow,4).Value = node.Notes;
+                mindMapRow++;
+            }
+            if (mindMapRow > 2)
+            {
+                mindMapSheet.Columns(1,4).AdjustToContents();
             }
 
             wb.SaveAs(filePath);

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -10,6 +10,7 @@ namespace EconToolbox.Desktop.ViewModels
         public AnnualizerViewModel Annualizer { get; } = new();
         public UdvViewModel Udv { get; } = new();
         public WaterDemandViewModel WaterDemand { get; } = new();
+        public MindMapViewModel MindMap { get; } = new();
 
         private int _selectedIndex;
         public int SelectedIndex
@@ -46,6 +47,8 @@ namespace EconToolbox.Desktop.ViewModels
                 case 4:
                     if (Udv.ComputeCommand.CanExecute(null)) Udv.ComputeCommand.Execute(null);
                     break;
+                case 5:
+                    break;
             }
         }
 
@@ -58,7 +61,7 @@ namespace EconToolbox.Desktop.ViewModels
             };
             if (dlg.ShowDialog() == true)
             {
-                ExcelExporter.ExportAll(Ead, UpdatedCost, Annualizer, WaterDemand, Udv, dlg.FileName);
+                ExcelExporter.ExportAll(Ead, UpdatedCost, Annualizer, WaterDemand, Udv, MindMap, dlg.FileName);
             }
         }
     }

--- a/ViewModels/MindMapViewModel.cs
+++ b/ViewModels/MindMapViewModel.cs
@@ -1,0 +1,344 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Windows.Input;
+
+namespace EconToolbox.Desktop.ViewModels
+{
+    public class MindMapViewModel : BaseViewModel
+    {
+        private readonly RelayCommand _addChildCommand;
+        private readonly RelayCommand _addSiblingCommand;
+        private readonly RelayCommand _removeNodeCommand;
+        private readonly List<MindMapNodeViewModel> _pathSubscriptions = new();
+        private bool _suppressSelectionSync;
+        private int _nodeCounter = 1;
+
+        public ObservableCollection<MindMapNodeViewModel> Nodes { get; } = new();
+
+        private MindMapNodeViewModel? _selectedNode;
+        public MindMapNodeViewModel? SelectedNode
+        {
+            get => _selectedNode;
+            set
+            {
+                if (_selectedNode == value)
+                    return;
+
+                var previous = _selectedNode;
+                _selectedNode = value;
+
+                _suppressSelectionSync = true;
+                if (previous != null)
+                    previous.IsSelected = false;
+                if (_selectedNode != null)
+                    _selectedNode.IsSelected = true;
+                _suppressSelectionSync = false;
+
+                UpdatePathSubscriptions();
+
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(HasSelection));
+                OnPropertyChanged(nameof(SelectedPath));
+
+                UpdateCommandStates();
+            }
+        }
+
+        public bool HasSelection => SelectedNode != null;
+
+        public string SelectedPath => SelectedNode == null
+            ? string.Empty
+            : string.Join("  ›  ", SelectedNode.GetPath().Select(n => n.Title));
+
+        public ICommand AddRootNodeCommand { get; }
+        public ICommand AddChildNodeCommand => _addChildCommand;
+        public ICommand AddSiblingNodeCommand => _addSiblingCommand;
+        public ICommand RemoveNodeCommand => _removeNodeCommand;
+
+        public MindMapViewModel()
+        {
+            AddRootNodeCommand = new RelayCommand(AddRootNode);
+            _addChildCommand = new RelayCommand(AddChildNode, () => SelectedNode != null);
+            _addSiblingCommand = new RelayCommand(AddSiblingNode, () => SelectedNode != null);
+            _removeNodeCommand = new RelayCommand(RemoveNode, () => SelectedNode != null);
+
+            var coreIdea = CreateNode("Central Idea");
+            coreIdea.Notes = "Capture the main question, opportunity, or challenge you are exploring.";
+            Nodes.Add(coreIdea);
+
+            var themes = CreateNode("Key Themes", coreIdea);
+            themes.Notes = "Break the central idea into major themes, components, or workstreams.";
+            coreIdea.Children.Add(themes);
+
+            var actions = CreateNode("Next Actions", coreIdea);
+            actions.Notes = "Record immediate tasks, owners, and follow-ups.";
+            coreIdea.Children.Add(actions);
+
+            coreIdea.IsExpanded = true;
+            themes.IsExpanded = true;
+            actions.IsExpanded = true;
+
+            SelectedNode = coreIdea;
+        }
+
+        private string GetDefaultTitle() => $"New Idea {_nodeCounter++}";
+
+        private MindMapNodeViewModel CreateNode(string title, MindMapNodeViewModel? parent = null)
+        {
+            var node = new MindMapNodeViewModel(title)
+            {
+                Parent = parent
+            };
+            AttachNode(node);
+            return node;
+        }
+
+        private void AddRootNode()
+        {
+            var node = CreateNode(GetDefaultTitle());
+            node.IsExpanded = true;
+            Nodes.Add(node);
+            SelectedNode = node;
+        }
+
+        private void AddChildNode()
+        {
+            if (SelectedNode == null)
+                return;
+
+            var child = CreateNode(GetDefaultTitle(), SelectedNode);
+            SelectedNode.Children.Add(child);
+            SelectedNode.IsExpanded = true;
+            SelectedNode = child;
+        }
+
+        private void AddSiblingNode()
+        {
+            if (SelectedNode == null)
+                return;
+
+            if (SelectedNode.Parent == null)
+            {
+                var node = CreateNode(GetDefaultTitle());
+                node.IsExpanded = true;
+                Nodes.Add(node);
+                SelectedNode = node;
+            }
+            else
+            {
+                var parent = SelectedNode.Parent;
+                var sibling = CreateNode(GetDefaultTitle(), parent);
+                parent.Children.Add(sibling);
+                SelectedNode = sibling;
+            }
+        }
+
+        private void RemoveNode()
+        {
+            if (SelectedNode == null)
+                return;
+
+            var current = SelectedNode;
+            var parent = current.Parent;
+
+            if (parent == null)
+            {
+                int index = Nodes.IndexOf(current);
+                Nodes.Remove(current);
+                DetachNode(current);
+                current.Parent = null;
+
+                if (Nodes.Count == 0)
+                {
+                    SelectedNode = null;
+                }
+                else
+                {
+                    if (index >= Nodes.Count)
+                        index = Nodes.Count - 1;
+                    SelectedNode = Nodes[index];
+                }
+            }
+            else
+            {
+                int index = parent.Children.IndexOf(current);
+                parent.Children.Remove(current);
+                DetachNode(current);
+                current.Parent = null;
+
+                if (parent.Children.Count == 0)
+                {
+                    SelectedNode = parent;
+                }
+                else
+                {
+                    if (index >= parent.Children.Count)
+                        index = parent.Children.Count - 1;
+                    SelectedNode = parent.Children[index];
+                }
+            }
+        }
+
+        private void AttachNode(MindMapNodeViewModel node)
+        {
+            node.SelectionChanged += NodeOnSelectionChanged;
+        }
+
+        private void DetachNode(MindMapNodeViewModel node)
+        {
+            node.SelectionChanged -= NodeOnSelectionChanged;
+            node.PropertyChanged -= PathNodeOnPropertyChanged;
+            foreach (var child in node.Children.ToList())
+            {
+                DetachNode(child);
+            }
+        }
+
+        private void NodeOnSelectionChanged(object? sender, bool isSelected)
+        {
+            if (!isSelected || _suppressSelectionSync)
+                return;
+
+            if (sender is MindMapNodeViewModel node && node != SelectedNode)
+                SelectedNode = node;
+        }
+
+        private void UpdateCommandStates()
+        {
+            _addChildCommand.RaiseCanExecuteChanged();
+            _addSiblingCommand.RaiseCanExecuteChanged();
+            _removeNodeCommand.RaiseCanExecuteChanged();
+        }
+
+        private void UpdatePathSubscriptions()
+        {
+            foreach (var node in _pathSubscriptions)
+            {
+                node.PropertyChanged -= PathNodeOnPropertyChanged;
+            }
+            _pathSubscriptions.Clear();
+
+            if (SelectedNode == null)
+                return;
+
+            foreach (var node in SelectedNode.GetPath())
+            {
+                node.PropertyChanged += PathNodeOnPropertyChanged;
+                _pathSubscriptions.Add(node);
+            }
+        }
+
+        private void PathNodeOnPropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(MindMapNodeViewModel.Title))
+                OnPropertyChanged(nameof(SelectedPath));
+        }
+
+        public IEnumerable<MindMapNodeViewModel> Flatten()
+        {
+            foreach (var node in Nodes)
+            {
+                foreach (var descendant in Flatten(node))
+                    yield return descendant;
+            }
+        }
+
+        private IEnumerable<MindMapNodeViewModel> Flatten(MindMapNodeViewModel node)
+        {
+            yield return node;
+
+            foreach (var child in node.Children)
+            {
+                foreach (var descendant in Flatten(child))
+                    yield return descendant;
+            }
+        }
+    }
+
+    public class MindMapNodeViewModel : BaseViewModel
+    {
+        private string _title;
+        private string _notes = string.Empty;
+        private bool _isExpanded;
+        private bool _isSelected;
+
+        public MindMapNodeViewModel(string title)
+        {
+            _title = title;
+        }
+
+        public string Title
+        {
+            get => _title;
+            set
+            {
+                if (_title != value)
+                {
+                    _title = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public string Notes
+        {
+            get => _notes;
+            set
+            {
+                if (_notes != value)
+                {
+                    _notes = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public ObservableCollection<MindMapNodeViewModel> Children { get; } = new();
+
+        public MindMapNodeViewModel? Parent { get; internal set; }
+
+        public bool IsExpanded
+        {
+            get => _isExpanded;
+            set
+            {
+                if (_isExpanded != value)
+                {
+                    _isExpanded = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public bool IsSelected
+        {
+            get => _isSelected;
+            set
+            {
+                if (_isSelected != value)
+                {
+                    _isSelected = value;
+                    OnPropertyChanged();
+                    SelectionChanged?.Invoke(this, value);
+                }
+            }
+        }
+
+        public event EventHandler<bool>? SelectionChanged;
+
+        public IEnumerable<MindMapNodeViewModel> GetPath()
+        {
+            var stack = new Stack<MindMapNodeViewModel>();
+            var current = this;
+            while (current != null)
+            {
+                stack.Push(current);
+                current = current.Parent;
+            }
+            return stack;
+        }
+    }
+}

--- a/Views/MindMapView.xaml
+++ b/Views/MindMapView.xaml
@@ -1,0 +1,282 @@
+<UserControl x:Class="EconToolbox.Desktop.Views.MindMapView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:EconToolbox.Desktop.ViewModels"
+             Background="{StaticResource Brush.SurfaceAlt}"
+             SnapsToDevicePixels="True"
+             UseLayoutRounding="True">
+    <UserControl.Resources>
+        <HierarchicalDataTemplate DataType="{x:Type vm:MindMapNodeViewModel}" ItemsSource="{Binding Children}">
+            <StackPanel Orientation="Horizontal" Margin="0,2,0,2">
+                <Ellipse Width="8"
+                         Height="8"
+                         Fill="{StaticResource Brush.Accent}"
+                         Margin="0,0,6,0"/>
+                <TextBlock Text="{Binding Title}"/>
+            </StackPanel>
+        </HierarchicalDataTemplate>
+    </UserControl.Resources>
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <Border Grid.Row="0"
+                Background="#EEF6FF"
+                BorderBrush="#AACDF1"
+                BorderThickness="1"
+                CornerRadius="10"
+                Padding="14"
+                Margin="0,0,0,12">
+            <StackPanel>
+                <TextBlock Text="Mind Map Planner"
+                           FontSize="18"
+                           FontWeight="Bold"
+                           Foreground="#1F6AB0"/>
+                <TextBlock TextWrapping="Wrap"
+                           Margin="0,6,0,0">
+                    Use the mind map to capture a central theme, break it into connected ideas, and note the actions
+                    needed to move forward. Create root nodes for major pillars, child nodes for deeper details, and keep
+                    explanatory notes on the right.
+                </TextBlock>
+            </StackPanel>
+        </Border>
+
+        <Grid Grid.Row="1">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="3*"/>
+                <ColumnDefinition Width="4*"/>
+            </Grid.ColumnDefinitions>
+
+            <Border Grid.Column="0"
+                    Background="White"
+                    CornerRadius="8"
+                    Padding="12"
+                    Margin="0,0,12,0"
+                    BorderBrush="#E2E8F0"
+                    BorderThickness="1">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
+
+                    <TextBlock Text="Structure"
+                               FontWeight="Bold"
+                               FontSize="16"/>
+
+                    <WrapPanel Grid.Row="1"
+                               Margin="0,8,0,8"
+                               ItemHeight="36"
+                               ItemWidth="140">
+                        <Button Command="{Binding AddRootNodeCommand}"
+                                Margin="0,0,8,8"
+                                MinWidth="120"
+                                ToolTip="Create a new top-level pillar">
+                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                                <TextBlock Text="+"
+                                           FontSize="16"
+                                           FontWeight="Bold"
+                                           Margin="0,0,6,0"/>
+                                <TextBlock Text="Add Root"/>
+                            </StackPanel>
+                        </Button>
+                        <Button Command="{Binding AddChildNodeCommand}"
+                                Margin="0,0,8,8"
+                                MinWidth="120"
+                                ToolTip="Add a child idea under the selected node">
+                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                                <TextBlock Text="↳"
+                                           FontSize="16"
+                                           FontWeight="Bold"
+                                           Margin="0,0,6,0"/>
+                                <TextBlock Text="Add Child"/>
+                            </StackPanel>
+                        </Button>
+                        <Button Command="{Binding AddSiblingNodeCommand}"
+                                Margin="0,0,8,8"
+                                MinWidth="120"
+                                ToolTip="Create another idea at the same level as the selected node">
+                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                                <TextBlock Text="⇢"
+                                           FontSize="16"
+                                           FontWeight="Bold"
+                                           Margin="0,0,6,0"/>
+                                <TextBlock Text="Add Sibling"/>
+                            </StackPanel>
+                        </Button>
+                        <Button Command="{Binding RemoveNodeCommand}"
+                                Margin="0,0,8,8"
+                                MinWidth="120"
+                                ToolTip="Remove the selected idea and its descendants">
+                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                                <TextBlock Text="×"
+                                           FontSize="16"
+                                           FontWeight="Bold"
+                                           Margin="0,0,6,0"/>
+                                <TextBlock Text="Remove"/>
+                            </StackPanel>
+                        </Button>
+                    </WrapPanel>
+
+                    <ScrollViewer Grid.Row="2"
+                                  VerticalScrollBarVisibility="Auto"
+                                  HorizontalScrollBarVisibility="Disabled">
+                        <TreeView ItemsSource="{Binding Nodes}">
+                            <TreeView.ItemContainerStyle>
+                                <Style TargetType="TreeViewItem">
+                                    <Setter Property="IsExpanded" Value="{Binding IsExpanded, Mode=TwoWay}"/>
+                                    <Setter Property="IsSelected" Value="{Binding IsSelected, Mode=TwoWay}"/>
+                                    <Setter Property="Margin" Value="0,2,0,2"/>
+                                </Style>
+                            </TreeView.ItemContainerStyle>
+                        </TreeView>
+                    </ScrollViewer>
+                </Grid>
+            </Border>
+
+            <Border Grid.Column="1"
+                    Background="White"
+                    CornerRadius="8"
+                    Padding="16"
+                    BorderBrush="#E2E8F0"
+                    BorderThickness="1">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
+
+                    <TextBlock Grid.Row="0"
+                               Text="{Binding SelectedPath}"
+                               FontSize="16"
+                               FontWeight="Bold"
+                               Margin="0,0,0,12">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Visibility" Value="Visible"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding SelectedNode}" Value="{x:Null}">
+                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+
+                    <TextBlock Grid.Row="1"
+                               Text="Select an idea on the left to add notes, context, and next steps."
+                               VerticalAlignment="Center"
+                               HorizontalAlignment="Center"
+                               Foreground="#5F6B7C"
+                               FontSize="14"
+                               TextWrapping="Wrap"
+                               TextAlignment="Center">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Visibility" Value="Collapsed"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding SelectedNode}" Value="{x:Null}">
+                                        <Setter Property="Visibility" Value="Visible"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+
+                    <ContentControl Grid.Row="1"
+                                    Content="{Binding SelectedNode}">
+                        <ContentControl.Style>
+                            <Style TargetType="ContentControl">
+                                <Setter Property="Visibility" Value="Visible"/>
+                                <Style.Triggers>
+                                    <Trigger Property="Content" Value="{x:Null}">
+                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                    </Trigger>
+                                </Style.Triggers>
+                            </Style>
+                        </ContentControl.Style>
+                        <ContentControl.ContentTemplate>
+                            <DataTemplate DataType="{x:Type vm:MindMapNodeViewModel}">
+                                <Grid>
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="*"/>
+                                    </Grid.RowDefinitions>
+
+                                    <StackPanel Grid.Row="0" Margin="0,0,0,12">
+                                        <TextBlock Text="Idea Title" FontWeight="SemiBold"/>
+                                        <TextBox Text="{Binding Title, UpdateSourceTrigger=PropertyChanged}"
+                                                 Margin="0,6,0,0"/>
+                                    </StackPanel>
+
+                                    <StackPanel Grid.Row="1" Margin="0,0,0,12">
+                                        <TextBlock Text="Key Points / Notes" FontWeight="SemiBold"/>
+                                        <TextBox Text="{Binding Notes, UpdateSourceTrigger=PropertyChanged}"
+                                                 Margin="0,6,0,0"
+                                                 AcceptsReturn="True"
+                                                 TextWrapping="Wrap"
+                                                 Height="160"
+                                                 VerticalScrollBarVisibility="Auto"/>
+                                    </StackPanel>
+
+                                    <Border Grid.Row="2"
+                                            Background="#F8FAFC"
+                                            BorderBrush="#E2E8F0"
+                                            BorderThickness="1"
+                                            CornerRadius="6"
+                                            Padding="12">
+                                        <StackPanel>
+                                            <TextBlock Text="Child ideas" FontWeight="SemiBold" Margin="0,0,0,8"/>
+                                            <ItemsControl ItemsSource="{Binding Children}">
+                                                <ItemsControl.ItemTemplate>
+                                                    <DataTemplate>
+                                                        <StackPanel Orientation="Horizontal" Margin="0,2,0,2">
+                                                            <TextBlock Text="•"
+                                                                       FontSize="16"
+                                                                       Margin="0,0,6,0"
+                                                                       Foreground="#2D6A8E"/>
+                                                            <TextBlock Text="{Binding Title}"/>
+                                                        </StackPanel>
+                                                    </DataTemplate>
+                                                </ItemsControl.ItemTemplate>
+                                                <ItemsControl.Style>
+                                                    <Style TargetType="ItemsControl">
+                                                        <Setter Property="Visibility" Value="Visible"/>
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding Children.Count}" Value="0">
+                                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </ItemsControl.Style>
+                                            </ItemsControl>
+                                            <TextBlock Text="No child ideas yet. Use “Add Child” to break this topic down further."
+                                                       Foreground="#5F6B7C"
+                                                       TextWrapping="Wrap">
+                                                <TextBlock.Style>
+                                                    <Style TargetType="TextBlock">
+                                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding Children.Count}" Value="0">
+                                                                <Setter Property="Visibility" Value="Visible"/>
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </TextBlock.Style>
+                                            </TextBlock>
+                                        </StackPanel>
+                                    </Border>
+                                </Grid>
+                            </DataTemplate>
+                        </ContentControl.ContentTemplate>
+                    </ContentControl>
+                </Grid>
+            </Border>
+        </Grid>
+    </Grid>
+</UserControl>

--- a/Views/MindMapView.xaml.cs
+++ b/Views/MindMapView.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows.Controls;
+
+namespace EconToolbox.Desktop.Views
+{
+    public partial class MindMapView : UserControl
+    {
+        public MindMapView()
+        {
+            InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated Mind Map view model with commands for creating, selecting, and organizing brainstorming nodes
- create a Mind Map tab UI with guidance, tree navigation, and detail editing for notes
- wire the new workspace into the main window and export pipeline so mind map ideas appear in the Excel export

## Testing
- `dotnet build` *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c86b915dfc83309075f6241a21de4e