### PR TITLE
Fix MindMapView canvas lookup for WPF

### DIFF
--- a/Views/MindMapView.xaml.cs
+++ b/Views/MindMapView.xaml.cs
@@ -2,6 +2,7 @@ using System;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using System.Windows.Media;
 using EconToolbox.Desktop.ViewModels;
 
 namespace EconToolbox.Desktop.Views
@@ -25,8 +26,32 @@ namespace EconToolbox.Desktop.Views
         {
             if (sender is ItemsControl itemsControl)
             {
-                _nodeCanvas = itemsControl.ItemsPanelRoot as Canvas;
+                _nodeCanvas = FindItemsPanelCanvas(itemsControl);
             }
+        }
+
+        private static Canvas? FindItemsPanelCanvas(ItemsControl itemsControl)
+        {
+            // In WPF, ItemsControl does not expose the instantiated items panel directly.
+            // We traverse the visual tree to locate the Canvas defined in the ItemsPanel template.
+            return FindVisualChild<Canvas>(itemsControl);
+        }
+
+        private static T? FindVisualChild<T>(DependencyObject parent) where T : DependencyObject
+        {
+            for (int i = 0; i < VisualTreeHelper.GetChildrenCount(parent); i++)
+            {
+                var child = VisualTreeHelper.GetChild(parent, i);
+
+                if (child is T typedChild)
+                    return typedChild;
+
+                var descendant = FindVisualChild<T>(child);
+                if (descendant != null)
+                    return descendant;
+            }
+
+            return null;
         }
 
         private void OnCanvasRightButtonDown(object sender, MouseButtonEventArgs e)


### PR DESCRIPTION
## Summary
- locate the mind map canvas panel by walking the visual tree instead of relying on ItemsPanelRoot
- add helper method to find the instantiated Canvas within the ItemsControl

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68c879e788288330a07159840ed6609a