### PR TITLE
Add zoom controls and flow connectors to mind map

### DIFF
--- a/ViewModels/MindMapConnectionViewModel.cs
+++ b/ViewModels/MindMapConnectionViewModel.cs
@@ -1,5 +1,7 @@
 using System;
 using System.ComponentModel;
+using System.Windows;
+using System.Windows.Media;
 
 namespace EconToolbox.Desktop.ViewModels
 {
@@ -19,10 +21,25 @@ namespace EconToolbox.Desktop.ViewModels
         public MindMapNodeViewModel Source { get; }
         public MindMapNodeViewModel Target { get; }
 
+        private PointCollection _connectorPoints = new();
+
         public double StartX => Source.X + Source.VisualWidth / 2;
         public double StartY => Source.Y + Source.VisualHeight / 2;
         public double EndX => Target.X + Target.VisualWidth / 2;
         public double EndY => Target.Y + Target.VisualHeight / 2;
+
+        public PointCollection ConnectorPoints
+        {
+            get => _connectorPoints;
+            private set
+            {
+                if (!Equals(_connectorPoints, value))
+                {
+                    _connectorPoints = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
 
         public void Dispose()
         {
@@ -47,6 +64,44 @@ namespace EconToolbox.Desktop.ViewModels
             OnPropertyChanged(nameof(StartY));
             OnPropertyChanged(nameof(EndX));
             OnPropertyChanged(nameof(EndY));
+            ConnectorPoints = CreateConnectorPoints();
+        }
+
+        private PointCollection CreateConnectorPoints()
+        {
+            var sourceRight = Source.X + Source.VisualWidth;
+            var sourceLeft = Source.X;
+            var sourceMidY = Source.Y + Source.VisualHeight / 2;
+
+            var targetLeft = Target.X;
+            var targetRight = Target.X + Target.VisualWidth;
+            var targetMidY = Target.Y + Target.VisualHeight / 2;
+
+            bool targetToRight = targetLeft >= sourceRight;
+
+            double startX = targetToRight ? sourceRight : sourceLeft;
+            double endX = targetToRight ? targetLeft : targetRight;
+
+            var start = new Point(startX, sourceMidY);
+            var end = new Point(endX, targetMidY);
+
+            double midX;
+            if (Math.Abs(start.X - end.X) < 0.1)
+            {
+                midX = start.X;
+            }
+            else
+            {
+                midX = (start.X + end.X) / 2;
+            }
+
+            return new PointCollection
+            {
+                start,
+                new Point(midX, start.Y),
+                new Point(midX, end.Y),
+                end
+            };
         }
     }
 }

--- a/ViewModels/MindMapViewModel.cs
+++ b/ViewModels/MindMapViewModel.cs
@@ -16,6 +16,9 @@ namespace EconToolbox.Desktop.ViewModels
         private readonly List<MindMapNodeViewModel> _pathSubscriptions = new();
         private bool _suppressSelectionSync;
         private int _nodeCounter = 1;
+        private const double MinZoomLevel = 0.4;
+        private const double MaxZoomLevel = 1.6;
+        private double _zoomLevel = 1.0;
 
         public ObservableCollection<MindMapNodeViewModel> Nodes { get; } = new();
         public ObservableCollection<MindMapNodeViewModel> CanvasNodes { get; } = new();
@@ -58,6 +61,23 @@ namespace EconToolbox.Desktop.ViewModels
         public string SelectedPath => SelectedNode == null
             ? string.Empty
             : string.Join("  ›  ", SelectedNode.GetPath().Select(n => n.Title));
+
+        public double ZoomLevel
+        {
+            get => _zoomLevel;
+            set
+            {
+                var clamped = Math.Clamp(value, MinZoomLevel, MaxZoomLevel);
+                if (Math.Abs(_zoomLevel - clamped) > 0.001)
+                {
+                    _zoomLevel = clamped;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public double ZoomLevelMinimum => MinZoomLevel;
+        public double ZoomLevelMaximum => MaxZoomLevel;
 
         public ICommand AddRootNodeCommand { get; }
         public ICommand AddChildNodeCommand => _addChildCommand;

--- a/Views/MindMapView.xaml
+++ b/Views/MindMapView.xaml
@@ -7,12 +7,14 @@
              SnapsToDevicePixels="True"
              UseLayoutRounding="True">
     <UserControl.Resources>
-        <Style x:Key="ConnectionLineStyle" TargetType="Line">
+        <Style x:Key="ConnectionLineStyle" TargetType="Polyline">
             <Setter Property="Stroke" Value="#92A8D4"/>
             <Setter Property="StrokeThickness" Value="2.4"/>
             <Setter Property="StrokeStartLineCap" Value="Round"/>
             <Setter Property="StrokeEndLineCap" Value="Round"/>
+            <Setter Property="StrokeLineJoin" Value="Round"/>
             <Setter Property="Opacity" Value="0.9"/>
+            <Setter Property="Fill" Value="Transparent"/>
         </Style>
     </UserControl.Resources>
 
@@ -68,6 +70,28 @@
                         <TextBlock Margin="0,4,0,0"
                                    Foreground="#5B6C86"
                                    Text="Right-click to add ideas, and drag icons to re-arrange your thinking."/>
+                        <StackPanel Orientation="Horizontal"
+                                    Margin="0,10,0,0"
+                                    VerticalAlignment="Center">
+                            <TextBlock Text="Zoom"
+                                       VerticalAlignment="Center"
+                                       Foreground="#475569"/>
+                            <Slider Width="160"
+                                    Margin="10,0,0,0"
+                                    Minimum="{Binding ZoomLevelMinimum}"
+                                    Maximum="{Binding ZoomLevelMaximum}"
+                                    Value="{Binding ZoomLevel, Mode=TwoWay}"
+                                    TickFrequency="0.1"
+                                    IsSnapToTickEnabled="False"
+                                    SmallChange="0.05"
+                                    LargeChange="0.2"
+                                    VerticalAlignment="Center"/>
+                            <TextBlock Text="{Binding ZoomLevel, StringFormat={}{0:P0}}"
+                                       Margin="10,0,0,0"
+                                       FontWeight="SemiBold"
+                                       VerticalAlignment="Center"
+                                       Foreground="#1F6AB0"/>
+                        </StackPanel>
                     </StackPanel>
 
                     <ScrollViewer Grid.Row="1"
@@ -75,8 +99,12 @@
                                   HorizontalScrollBarVisibility="Auto"
                                   VerticalScrollBarVisibility="Auto">
                         <Grid>
+                            <Grid.LayoutTransform>
+                                <ScaleTransform ScaleX="{Binding ZoomLevel}" ScaleY="{Binding ZoomLevel}"/>
+                            </Grid.LayoutTransform>
                             <ItemsControl ItemsSource="{Binding Connections}"
-                                          IsHitTestVisible="False">
+                                          IsHitTestVisible="False"
+                                          Panel.ZIndex="0">
                                 <ItemsControl.ItemsPanel>
                                     <ItemsPanelTemplate>
                                         <Canvas Width="{Binding CanvasWidth}"
@@ -85,11 +113,8 @@
                                 </ItemsControl.ItemsPanel>
                                 <ItemsControl.ItemTemplate>
                                     <DataTemplate DataType="{x:Type vm:MindMapConnectionViewModel}">
-                                        <Line Style="{StaticResource ConnectionLineStyle}"
-                                              X1="{Binding StartX}"
-                                              Y1="{Binding StartY}"
-                                              X2="{Binding EndX}"
-                                              Y2="{Binding EndY}"/>
+                                        <Polyline Style="{StaticResource ConnectionLineStyle}"
+                                                  Points="{Binding ConnectorPoints}"/>
                                     </DataTemplate>
                                 </ItemsControl.ItemTemplate>
                             </ItemsControl>
@@ -97,7 +122,8 @@
                             <ItemsControl x:Name="NodeItemsControl"
                                           ItemsSource="{Binding CanvasNodes}"
                                           Loaded="OnNodesLoaded"
-                                          PreviewMouseRightButtonDown="OnCanvasRightButtonDown">
+                                          PreviewMouseRightButtonDown="OnCanvasRightButtonDown"
+                                          Panel.ZIndex="1">
                                 <ItemsControl.ItemsPanel>
                                     <ItemsPanelTemplate>
                                         <Canvas Width="{Binding CanvasWidth}"

--- a/Views/MindMapView.xaml.cs
+++ b/Views/MindMapView.xaml.cs
@@ -22,6 +22,26 @@ namespace EconToolbox.Desktop.Views
 
         private MindMapViewModel? ViewModel => DataContext as MindMapViewModel;
 
+        private double GetZoomFactor()
+        {
+            var zoom = ViewModel?.ZoomLevel ?? 1.0;
+            return zoom <= 0 ? 1.0 : zoom;
+        }
+
+        private Point NormalizeToCanvas(Point point)
+        {
+            var zoom = GetZoomFactor();
+            if (Math.Abs(zoom - 1.0) < 0.0001)
+                return point;
+
+            return new Point(point.X / zoom, point.Y / zoom);
+        }
+
+        private Point GetCanvasPosition(MouseEventArgs e, IInputElement reference)
+        {
+            return NormalizeToCanvas(e.GetPosition(reference));
+        }
+
         private void OnNodesLoaded(object sender, RoutedEventArgs e)
         {
             if (sender is ItemsControl itemsControl)
@@ -57,7 +77,7 @@ namespace EconToolbox.Desktop.Views
         private void OnCanvasRightButtonDown(object sender, MouseButtonEventArgs e)
         {
             var reference = (IInputElement?)_nodeCanvas ?? (IInputElement)sender;
-            _lastCanvasContextPosition = e.GetPosition(reference);
+            _lastCanvasContextPosition = GetCanvasPosition(e, reference);
         }
 
         private void OnCanvasContextMenuOpened(object sender, RoutedEventArgs e)
@@ -104,7 +124,7 @@ namespace EconToolbox.Desktop.Views
                 ViewModel.SelectedNode = node;
 
             var reference = (IInputElement?)_nodeCanvas ?? element;
-            var position = e.GetPosition(reference);
+            var position = GetCanvasPosition(e, reference);
             _dragOffset = new Point(position.X - node.X, position.Y - node.Y);
 
             _draggingNode = node;
@@ -128,7 +148,7 @@ namespace EconToolbox.Desktop.Views
             }
 
             var reference = (IInputElement?)_nodeCanvas ?? _draggingElement;
-            var position = e.GetPosition(reference);
+            var position = GetCanvasPosition(e, reference);
             var newX = position.X - _dragOffset.X;
             var newY = position.Y - _dragOffset.Y;
 
@@ -162,7 +182,7 @@ namespace EconToolbox.Desktop.Views
                     ViewModel.SelectedNode = node;
 
                 var reference = (IInputElement?)_nodeCanvas ?? element;
-                _lastCanvasContextPosition = e.GetPosition(reference);
+                _lastCanvasContextPosition = GetCanvasPosition(e, reference);
             }
         }
 


### PR DESCRIPTION
## Summary
- replace straight line connectors with flow-style polylines that link parents and children
- expose a zoom level on the mind map view model and surface a slider/scale transform in the view
- normalize pointer interactions so dragging and context positioning behave correctly at different zoom levels

## Testing
- `dotnet build` *(fails: `dotnet` command is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68c87d32a78c83309a0f9faa6fc30936