### PR TITLE
Improve tooltip visibility and fix scroll wheel handling

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -10,7 +10,13 @@
         MinHeight="600"
         ResizeMode="CanResize"
         SnapsToDevicePixels="True"
-        UseLayoutRounding="True">
+        UseLayoutRounding="True"
+        ToolTipService.InitialShowDelay="200"
+        ToolTipService.ShowDuration="20000"
+        ToolTipService.BetweenShowDelay="200"
+        ToolTipService.Placement="Mouse"
+        ToolTipService.HorizontalOffset="12"
+        ToolTipService.VerticalOffset="12">
     <Window.DataContext>
         <vm:MainViewModel/>
     </Window.DataContext>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Media3D;
@@ -37,8 +38,20 @@ namespace EconToolbox.Desktop
             var current = source;
             while (current != null && current != root)
             {
-                if (current is ScrollViewer)
+                if (current is ScrollViewer nested)
                 {
+                    if (ReferenceEquals(nested, root))
+                    {
+                        break;
+                    }
+
+                    var templatedParent = nested.TemplatedParent;
+                    if (templatedParent is TextBoxBase || templatedParent is PasswordBox)
+                    {
+                        current = GetParent(nested);
+                        continue;
+                    }
+
                     return true;
                 }
 

--- a/Themes/Design.xaml
+++ b/Themes/Design.xaml
@@ -122,5 +122,36 @@
         <Setter Property="VerticalScrollBarVisibility" Value="Auto"/>
     </Style>
 
+    <Style TargetType="ToolTip">
+        <Setter Property="Placement" Value="Mouse"/>
+        <Setter Property="HorizontalOffset" Value="12"/>
+        <Setter Property="VerticalOffset" Value="12"/>
+        <Setter Property="Background" Value="{StaticResource Brush.Primary}"/>
+        <Setter Property="Foreground" Value="White"/>
+        <Setter Property="Padding" Value="12,8"/>
+        <Setter Property="FontSize" Value="13"/>
+        <Setter Property="MaxWidth" Value="360"/>
+        <Setter Property="HasDropShadow" Value="True"/>
+        <Setter Property="TextElement.FontFamily" Value="Segoe UI"/>
+        <Setter Property="TextElement.FontSize" Value="13"/>
+        <Setter Property="TextElement.Foreground" Value="White"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="ToolTip">
+                    <Border Background="{TemplateBinding Background}"
+                            CornerRadius="8"
+                            BorderBrush="#1C4E68"
+                            BorderThickness="1"
+                            Padding="{TemplateBinding Padding}"
+                            SnapsToDevicePixels="True">
+                        <ContentPresenter Margin="0"
+                                          RecognizesAccessKey="True"
+                                          TextBlock.TextWrapping="Wrap"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
     <converters:WidthToLayoutModeConverter x:Key="WidthToLayoutModeConverter" Threshold="800"/>
 </ResourceDictionary>


### PR DESCRIPTION
## Summary
- configure window-level tooltip behavior so hints appear near the cursor with minimal delay
- add a themed tooltip style for consistent coloring, padding, and readability across the app
- update the scroll-wheel routing helper to ignore template scroll viewers so pages scroll while hovering inputs

## Testing
- Attempted `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c8840eeb5c8330b95711a846cd0e08