### PR TITLE
Fix tooltip wrapping style

### DIFF
--- a/Themes/Design.xaml
+++ b/Themes/Design.xaml
@@ -131,6 +131,7 @@
         <Setter Property="Padding" Value="12,8"/>
         <Setter Property="FontSize" Value="13"/>
         <Setter Property="MaxWidth" Value="360"/>
+        <Setter Property="TextBlock.TextWrapping" Value="Wrap"/>
         <Setter Property="HasDropShadow" Value="True"/>
         <Setter Property="TextElement.FontFamily" Value="Segoe UI"/>
         <Setter Property="TextElement.FontSize" Value="13"/>
@@ -145,8 +146,7 @@
                             Padding="{TemplateBinding Padding}"
                             SnapsToDevicePixels="True">
                         <ContentPresenter Margin="0"
-                                          RecognizesAccessKey="True"
-                                          TextBlock.TextWrapping="Wrap"/>
+                                          RecognizesAccessKey="True"/>
                     </Border>
                 </ControlTemplate>
             </Setter.Value>


### PR DESCRIPTION
## Summary
- ensure tooltip text wrapping is configured via a style setter instead of an invalid ContentPresenter property

## Testing
- `dotnet build EconToolbox.Desktop.csproj /property:GenerateFullPaths=true /p:Configuration=Debug /p:Platform="AnyCPU" /consoleloggerparameters:NoSummary` *(fails: `dotnet` CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c88bd01a4c8330931533b5c4bda98e