### PR TITLE
Add Excel dashboard summary and refine scroll interactions

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -22,7 +22,7 @@ namespace EconToolbox.Desktop
                 return;
             }
 
-            if (IsInsideNestedScrollViewer(e.OriginalSource as DependencyObject, scrollViewer))
+            if (ShouldHandleInNestedScrollViewer(e.OriginalSource as DependencyObject, scrollViewer, e.Delta))
             {
                 return;
             }
@@ -33,7 +33,7 @@ namespace EconToolbox.Desktop
             e.Handled = true;
         }
 
-        private static bool IsInsideNestedScrollViewer(DependencyObject? source, ScrollViewer root)
+        private static bool ShouldHandleInNestedScrollViewer(DependencyObject? source, ScrollViewer root, double delta)
         {
             var current = source;
             while (current != null && current != root)
@@ -52,7 +52,24 @@ namespace EconToolbox.Desktop
                         continue;
                     }
 
-                    return true;
+                    bool hasScrollableContent = nested.ScrollableHeight > 0 || nested.ComputedVerticalScrollBarVisibility == Visibility.Visible;
+                    if (!hasScrollableContent)
+                    {
+                        current = GetParent(nested);
+                        continue;
+                    }
+
+                    bool scrollingUp = delta > 0;
+                    bool canScrollUp = nested.VerticalOffset > 0;
+                    bool canScrollDown = nested.VerticalOffset < nested.ScrollableHeight;
+
+                    if ((scrollingUp && canScrollUp) || (!scrollingUp && canScrollDown))
+                    {
+                        return true;
+                    }
+
+                    current = GetParent(nested);
+                    continue;
                 }
 
                 current = GetParent(current);


### PR DESCRIPTION
## Summary
- add a comprehensive Dashboard worksheet to the export with formatted tables and four custom chart images
- introduce helper routines to build the dashboard and render new bar, line, and recreation charts
- update main window scrolling to respect nested viewers only when they can scroll, preventing idle scroll capture

## Testing
- `dotnet build` *(fails: command not found in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c98f3dea7883309a711bb73fdd5c13