### PR TITLE
Target .NET 8 for desktop project

### DIFF
--- a/EconToolbox.Desktop.csproj
+++ b/EconToolbox.Desktop.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <Nullable>enable</Nullable>
     <ApplicationManifest>app.manifest</ApplicationManifest>


### PR DESCRIPTION
## Summary
- retarget the desktop project to .NET 8 so it is buildable with the available SDK

## Testing
- attempted `dotnet build EconToolbox.Desktop.csproj /property:GenerateFullPaths=true /p:Configuration=Debug /p:Platform="AnyCPU" /consoleloggerparameters:NoSummary` *(fails: `dotnet` CLI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb02d07b688330b95d56046fe4abd4