### PR TITLE
Update explainer icons and align palettes

### DIFF
--- a/Themes/Design.xaml
+++ b/Themes/Design.xaml
@@ -19,6 +19,10 @@
     <SolidColorBrush x:Key="Brush.Border" Color="{StaticResource Color.Border}"/>
     <SolidColorBrush x:Key="Brush.TextPrimary" Color="{StaticResource Color.TextPrimary}"/>
     <SolidColorBrush x:Key="Brush.TextSecondary" Color="{StaticResource Color.TextSecondary}"/>
+    <Color x:Key="Color.HighlightBackground">#E6F2F8</Color>
+    <Color x:Key="Color.HighlightBorder">#AFCDE0</Color>
+    <SolidColorBrush x:Key="Brush.HighlightBackground" Color="{StaticResource Color.HighlightBackground}"/>
+    <SolidColorBrush x:Key="Brush.HighlightBorder" Color="{StaticResource Color.HighlightBorder}"/>
 
     <!-- Spacing tokens -->
     <sys:Double x:Key="Space.XS">4</sys:Double>
@@ -40,6 +44,24 @@
     <Thickness x:Key="Margin.TopLarge">0,16,0,0</Thickness>
     <Thickness x:Key="Margin.TopXSmall">0,4,0,0</Thickness>
     <Thickness x:Key="Margin.None">0</Thickness>
+
+    <Style x:Key="Border.Explainer" TargetType="Border">
+        <Setter Property="Background" Value="{StaticResource Brush.HighlightBackground}"/>
+        <Setter Property="BorderBrush" Value="{StaticResource Brush.HighlightBorder}"/>
+        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="CornerRadius" Value="10"/>
+        <Setter Property="Padding" Value="{StaticResource Padding.Content}"/>
+        <Setter Property="Margin" Value="{StaticResource Margin.StackLarge}"/>
+    </Style>
+
+    <Style x:Key="Border.ResultInfo" TargetType="Border">
+        <Setter Property="Background" Value="{StaticResource Brush.Surface}"/>
+        <Setter Property="BorderBrush" Value="{StaticResource Brush.Border}"/>
+        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="CornerRadius" Value="8"/>
+        <Setter Property="Padding" Value="{StaticResource Padding.Content}"/>
+        <Setter Property="Margin" Value="{StaticResource Margin.StackLarge}"/>
+    </Style>
 
     <!-- Type ramp -->
     <Style x:Key="Text.Caption" TargetType="TextBlock">

--- a/Views/AnnualizerView.xaml
+++ b/Views/AnnualizerView.xaml
@@ -69,16 +69,19 @@
                   </Grid.Resources>
 
                   <Border Grid.Row="0" Grid.ColumnSpan="2"
-                          Background="#E8F4FB"
-                          BorderBrush="{StaticResource Brush.Primary}"
-                          BorderThickness="1"
-                          CornerRadius="8"
-                          Padding="{StaticResource Padding.Card}"
-                          Margin="{StaticResource Margin.StackLarge}">
+                          Style="{StaticResource Border.Explainer}"
+                          Padding="{StaticResource Padding.Card}">
                       <StackPanel>
                           <StackPanel Orientation="Horizontal" Margin="{StaticResource Margin.Stack}">
-                              <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="20" Foreground="{StaticResource Brush.SurfaceAlt}" Margin="{StaticResource Margin.Inline}"/>
-                              <TextBlock Text="Cost Annualization Workflow" FontWeight="Bold" FontSize="16" Foreground="{StaticResource Brush.Primary}"/>
+                              <TextBlock FontFamily="Segoe MDL2 Assets"
+                                         Text=""
+                                         FontSize="22"
+                                         Foreground="{StaticResource Brush.Primary}"
+                                         Margin="{StaticResource Margin.Inline}"/>
+                              <TextBlock Text="Cost Annualization Workflow"
+                                         FontWeight="Bold"
+                                         FontSize="16"
+                                         Foreground="{StaticResource Brush.Primary}"/>
                           </StackPanel>
                           <TextBlock TextWrapping="Wrap">
                               1. Document upfront investments, financing assumptions, and the analysis period.
@@ -311,75 +314,60 @@
                               </Style.Triggers>
                           </Style>
                       </UniformGrid.Style>
-                      <Border Background="White" CornerRadius="6" Padding="{StaticResource Padding.Content}" BorderBrush="{StaticResource Brush.Border}" BorderThickness="1" Margin="{StaticResource Margin.Stack}">
-                          <Grid>
-                              <Grid.ColumnDefinitions>
-                                  <ColumnDefinition Width="Auto"/>
-                                  <ColumnDefinition Width="Auto"/>
-                                  <ColumnDefinition Width="*"/>
-                              </Grid.ColumnDefinitions>
-                              <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="18" Foreground="{StaticResource Brush.Primary}" Margin="{StaticResource Margin.Inline}" VerticalAlignment="Center"/>
-                              <TextBlock Grid.Column="1" FontWeight="Bold" Text="{Binding Idc, StringFormat=IDC: {0:C2}}" VerticalAlignment="Center"/>
-                              <TextBlock Grid.Column="2" TextWrapping="Wrap" Margin="{StaticResource Margin.InlineMedium}" Foreground="{StaticResource Brush.TextSecondary}">
+                      <Border Style="{StaticResource Border.ResultInfo}" Margin="{StaticResource Margin.Stack}">
+                          <StackPanel>
+                              <TextBlock FontWeight="Bold"
+                                         Text="{Binding Idc, StringFormat=IDC: {0:C2}}"/>
+                              <TextBlock TextWrapping="Wrap"
+                                         Margin="{StaticResource Margin.TopSmall}"
+                                         Foreground="{StaticResource Brush.TextSecondary}">
                                   Interest during construction accumulates from the IDC schedule using your month, timing, and rate inputs. Higher rates or longer construction windows increase this value.
                               </TextBlock>
-                          </Grid>
+                          </StackPanel>
                       </Border>
-                      <Border Background="White" CornerRadius="6" Padding="{StaticResource Padding.Content}" BorderBrush="{StaticResource Brush.Border}" BorderThickness="1" Margin="{StaticResource Margin.Stack}">
-                          <Grid>
-                              <Grid.ColumnDefinitions>
-                                  <ColumnDefinition Width="Auto"/>
-                                  <ColumnDefinition Width="Auto"/>
-                                  <ColumnDefinition Width="*"/>
-                              </Grid.ColumnDefinitions>
-                              <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="18" Foreground="{StaticResource Brush.Primary}" Margin="{StaticResource Margin.Inline}" VerticalAlignment="Center"/>
-                              <TextBlock Grid.Column="1" FontWeight="Bold" Text="{Binding TotalInvestment, StringFormat=Total Investment: {0:C2}}" VerticalAlignment="Center"/>
-                              <TextBlock Grid.Column="2" TextWrapping="Wrap" Margin="{StaticResource Margin.InlineMedium}" Foreground="{StaticResource Brush.TextSecondary}">
+                      <Border Style="{StaticResource Border.ResultInfo}" Margin="{StaticResource Margin.Stack}">
+                          <StackPanel>
+                              <TextBlock FontWeight="Bold"
+                                         Text="{Binding TotalInvestment, StringFormat=Total Investment: {0:C2}}"/>
+                              <TextBlock TextWrapping="Wrap"
+                                         Margin="{StaticResource Margin.TopSmall}"
+                                         Foreground="{StaticResource Brush.TextSecondary}">
                                   Total investment combines First Cost, IDC, and the present value of Future Costs. Adding more future expenses or higher IDC immediately raises this figure.
                               </TextBlock>
-                          </Grid>
+                          </StackPanel>
                       </Border>
-                      <Border Background="White" CornerRadius="6" Padding="{StaticResource Padding.Content}" BorderBrush="{StaticResource Brush.Border}" BorderThickness="1" Margin="{StaticResource Margin.Stack}">
-                          <Grid>
-                              <Grid.ColumnDefinitions>
-                                  <ColumnDefinition Width="Auto"/>
-                                  <ColumnDefinition Width="Auto"/>
-                                  <ColumnDefinition Width="*"/>
-                              </Grid.ColumnDefinitions>
-                              <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="18" Foreground="{StaticResource Brush.Primary}" Margin="{StaticResource Margin.Inline}" VerticalAlignment="Center"/>
-                              <TextBlock Grid.Column="1" FontWeight="Bold" Text="{Binding Crf, StringFormat=CRF: {0:F4}}" VerticalAlignment="Center"/>
-                              <TextBlock Grid.Column="2" TextWrapping="Wrap" Margin="{StaticResource Margin.InlineMedium}" Foreground="{StaticResource Brush.TextSecondary}">
+                      <Border Style="{StaticResource Border.ResultInfo}" Margin="{StaticResource Margin.Stack}">
+                          <StackPanel>
+                              <TextBlock FontWeight="Bold"
+                                         Text="{Binding Crf, StringFormat=CRF: {0:F4}}"/>
+                              <TextBlock TextWrapping="Wrap"
+                                         Margin="{StaticResource Margin.TopSmall}"
+                                         Foreground="{StaticResource Brush.TextSecondary}">
                                   The capital recovery factor converts present investment into an equivalent annual cost. It is entirely driven by your discount rate and analysis period selections.
                               </TextBlock>
-                          </Grid>
+                          </StackPanel>
                       </Border>
-                      <Border Background="White" CornerRadius="6" Padding="{StaticResource Padding.Content}" BorderBrush="{StaticResource Brush.Border}" BorderThickness="1" Margin="{StaticResource Margin.Stack}">
-                          <Grid>
-                              <Grid.ColumnDefinitions>
-                                  <ColumnDefinition Width="Auto"/>
-                                  <ColumnDefinition Width="Auto"/>
-                                  <ColumnDefinition Width="*"/>
-                              </Grid.ColumnDefinitions>
-                              <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="18" Foreground="{StaticResource Brush.Primary}" Margin="{StaticResource Margin.Inline}" VerticalAlignment="Center"/>
-                              <TextBlock Grid.Column="1" FontWeight="Bold" Text="{Binding AnnualCost, StringFormat=Annual Cost: {0:C2}}" VerticalAlignment="Center"/>
-                              <TextBlock Grid.Column="2" TextWrapping="Wrap" Margin="{StaticResource Margin.InlineMedium}" Foreground="{StaticResource Brush.TextSecondary}">
+                      <Border Style="{StaticResource Border.ResultInfo}" Margin="{StaticResource Margin.Stack}">
+                          <StackPanel>
+                              <TextBlock FontWeight="Bold"
+                                         Text="{Binding AnnualCost, StringFormat=Annual Cost: {0:C2}}"/>
+                              <TextBlock TextWrapping="Wrap"
+                                         Margin="{StaticResource Margin.TopSmall}"
+                                         Foreground="{StaticResource Brush.TextSecondary}">
                                   Annual cost reflects how the total investment and your O&amp;M inputs translate into yearly expenses. Increasing either component will raise this annualized value.
                               </TextBlock>
-                          </Grid>
+                          </StackPanel>
                       </Border>
-                      <Border Background="White" CornerRadius="6" Padding="{StaticResource Padding.Content}" BorderBrush="{StaticResource Brush.Border}" BorderThickness="1">
-                          <Grid>
-                              <Grid.ColumnDefinitions>
-                                  <ColumnDefinition Width="Auto"/>
-                                  <ColumnDefinition Width="Auto"/>
-                                  <ColumnDefinition Width="*"/>
-                              </Grid.ColumnDefinitions>
-                              <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="18" Foreground="{StaticResource Brush.Primary}" Margin="{StaticResource Margin.Inline}" VerticalAlignment="Center"/>
-                              <TextBlock Grid.Column="1" FontWeight="Bold" Text="{Binding Bcr, StringFormat=BCR: {0:F2}}" VerticalAlignment="Center"/>
-                              <TextBlock Grid.Column="2" TextWrapping="Wrap" Margin="{StaticResource Margin.InlineMedium}" Foreground="{StaticResource Brush.TextSecondary}">
+                      <Border Style="{StaticResource Border.ResultInfo}" Margin="{StaticResource Margin.Stack}">
+                          <StackPanel>
+                              <TextBlock FontWeight="Bold"
+                                         Text="{Binding Bcr, StringFormat=BCR: {0:F2}}"/>
+                              <TextBlock TextWrapping="Wrap"
+                                         Margin="{StaticResource Margin.TopSmall}"
+                                         Foreground="{StaticResource Brush.TextSecondary}">
                                   Benefit-cost ratio compares annual benefits against annual costs. Greater benefits or lower annual costs will push the BCR upward, signaling a stronger economic case.
                               </TextBlock>
-                          </Grid>
+                          </StackPanel>
                       </Border>
                   </UniformGrid>
               </Grid>

--- a/Views/EadView.xaml
+++ b/Views/EadView.xaml
@@ -19,16 +19,11 @@
                 </Grid.RowDefinitions>
 
                 <Border Grid.Row="0"
-                        Background="#FFF2FBFF"
-                        BorderBrush="{StaticResource Brush.Primary}"
-                        BorderThickness="1"
-                        CornerRadius="8"
-                        Padding="{StaticResource Padding.Content}"
-                        Margin="{StaticResource Margin.StackLarge}">
+                        Style="{StaticResource Border.Explainer}">
                     <StackPanel>
                         <StackPanel Orientation="Horizontal" Margin="{StaticResource Margin.Stack}">
                             <TextBlock FontFamily="Segoe MDL2 Assets"
-                                       Text=""
+                                       Text=""
                                        FontSize="20"
                                        Foreground="{StaticResource Brush.Primary}"
                                        Margin="{StaticResource Margin.Inline}"/>
@@ -197,17 +192,12 @@
                 </ItemsControl>
 
                 <Border Grid.Row="4"
-                        Background="#FFF8FD"
-                        BorderBrush="#E0CAE7"
-                        BorderThickness="1"
-                        CornerRadius="8"
-                        Padding="{StaticResource Padding.Content}"
-                        Margin="{StaticResource Margin.StackLarge}">
+                        Style="{StaticResource Border.ResultInfo}">
                     <StackPanel>
-                        <StackPanel Orientation="Horizontal" Margin="{StaticResource Margin.Stack}" VerticalAlignment="Center">
-                            <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="18" Foreground="#8A4BAF" Margin="{StaticResource Margin.Inline}"/>
-                            <TextBlock Text="Result Interpretation" FontWeight="Bold" Foreground="#8A4BAF"/>
-                        </StackPanel>
+                        <TextBlock Text="Result Interpretation"
+                                   FontWeight="Bold"
+                                   Foreground="{StaticResource Brush.Primary}"
+                                   Margin="{StaticResource Margin.Stack}"/>
                         <TextBlock Style="{StaticResource Text.Body}">
                             Each Expected Annual Damage value averages the damage column across the entire probability curve you supplied. Higher damages at frequent events raise the EAD most dramatically. The plotted curves update with every calculation, helping you confirm the shape of the probability and stage relationships before exporting your Excel summary.
                         </TextBlock>

--- a/Views/MindMapView.xaml
+++ b/Views/MindMapView.xaml
@@ -25,17 +25,57 @@
         </Grid.RowDefinitions>
 
         <Border Grid.Row="0"
-                Background="#EEF6FF"
-                BorderBrush="#AACDF1"
-                BorderThickness="1"
-                CornerRadius="10"
-                Padding="16"
-                Margin="0,0,0,16">
+                Style="{StaticResource Border.Explainer}"
+                Margin="0,0,0,16"
+                Padding="{StaticResource Padding.Card}">
             <StackPanel>
-                <TextBlock Text="Mind Map Planner"
-                           FontSize="18"
-                           FontWeight="Bold"
-                           Foreground="#1F6AB0"/>
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                    <Viewbox Width="32" Height="32" Margin="0,0,10,0">
+                        <Canvas Width="32" Height="32">
+                            <Path Stroke="{StaticResource Brush.Primary}"
+                                  StrokeThickness="2.4"
+                                  StrokeLineJoin="Round"
+                                  StrokeStartLineCap="Round"
+                                  StrokeEndLineCap="Round">
+                                <Path.Data>
+                                    <GeometryGroup>
+                                        <PathGeometry>
+                                            <PathFigure StartPoint="12,8" IsClosed="False">
+                                                <BezierSegment Point1="6,10" Point2="6,16" Point3="12,18"/>
+                                                <BezierSegment Point1="6,20" Point2="6,26" Point3="12,28"/>
+                                            </PathFigure>
+                                        </PathGeometry>
+                                        <PathGeometry>
+                                            <PathFigure StartPoint="20,8" IsClosed="False">
+                                                <BezierSegment Point1="26,10" Point2="26,16" Point3="20,18"/>
+                                                <BezierSegment Point1="26,20" Point2="26,26" Point3="20,28"/>
+                                            </PathFigure>
+                                        </PathGeometry>
+                                        <PathGeometry>
+                                            <PathFigure StartPoint="12,12" IsClosed="False">
+                                                <BezierSegment Point1="16,10" Point2="18,10" Point3="20,12"/>
+                                            </PathFigure>
+                                        </PathGeometry>
+                                        <PathGeometry>
+                                            <PathFigure StartPoint="12,16" IsClosed="False">
+                                                <BezierSegment Point1="16,14" Point2="18,14" Point3="20,16"/>
+                                            </PathFigure>
+                                        </PathGeometry>
+                                        <PathGeometry>
+                                            <PathFigure StartPoint="12,20" IsClosed="False">
+                                                <BezierSegment Point1="16,18" Point2="18,18" Point3="20,20"/>
+                                            </PathFigure>
+                                        </PathGeometry>
+                                    </GeometryGroup>
+                                </Path.Data>
+                            </Path>
+                        </Canvas>
+                    </Viewbox>
+                    <TextBlock Text="Mind Map Planner"
+                               FontSize="18"
+                               FontWeight="Bold"
+                               Foreground="{StaticResource Brush.Primary}"/>
+                </StackPanel>
                 <TextBlock Margin="0,6,0,0"
                            TextWrapping="Wrap">
                     Right-click anywhere on the canvas to create new root, child, or sibling ideas. Drag the icons to
@@ -51,11 +91,11 @@
             </Grid.ColumnDefinitions>
 
             <Border Grid.Column="0"
-                    Background="White"
+                    Background="{StaticResource Brush.Surface}"
                     CornerRadius="12"
                     Padding="18"
                     Margin="0,0,12,0"
-                    BorderBrush="#E2E8F0"
+                    BorderBrush="{StaticResource Brush.Border}"
                     BorderThickness="1">
                 <Grid>
                     <Grid.RowDefinitions>
@@ -68,14 +108,14 @@
                                    FontSize="16"
                                    FontWeight="SemiBold"/>
                         <TextBlock Margin="0,4,0,0"
-                                   Foreground="#5B6C86"
+                                   Foreground="{StaticResource Brush.TextSecondary}"
                                    Text="Right-click to add ideas, and drag icons to re-arrange your thinking."/>
                         <StackPanel Orientation="Horizontal"
                                     Margin="0,10,0,0"
                                     VerticalAlignment="Center">
                             <TextBlock Text="Zoom"
                                        VerticalAlignment="Center"
-                                       Foreground="#475569"/>
+                                       Foreground="{StaticResource Brush.TextSecondary}"/>
                             <Slider Width="160"
                                     Margin="10,0,0,0"
                                     Minimum="{Binding ZoomLevelMinimum}"
@@ -90,7 +130,7 @@
                                        Margin="10,0,0,0"
                                        FontWeight="SemiBold"
                                        VerticalAlignment="Center"
-                                       Foreground="#1F6AB0"/>
+                                       Foreground="{StaticResource Brush.Primary}"/>
                         </StackPanel>
                     </StackPanel>
 
@@ -208,12 +248,12 @@
                                                            FontWeight="SemiBold"
                                                            FontSize="14"
                                                            TextAlignment="Center"
-                                                           Foreground="#1E3A5F"
+                                                           Foreground="{StaticResource Brush.Primary}"
                                                            TextWrapping="Wrap"/>
                                                 <TextBlock Text="{Binding Notes}"
                                                            Margin="0,6,0,0"
                                                            FontSize="12"
-                                                           Foreground="#64748B"
+                                                           Foreground="{StaticResource Brush.TextSecondary}"
                                                            TextAlignment="Center"
                                                            TextTrimming="CharacterEllipsis"
                                                            TextWrapping="Wrap"
@@ -229,10 +269,10 @@
             </Border>
 
             <Border Grid.Column="1"
-                    Background="White"
+                    Background="{StaticResource Brush.Surface}"
                     CornerRadius="12"
                     Padding="20"
-                    BorderBrush="#E2E8F0"
+                    BorderBrush="{StaticResource Brush.Border}"
                     BorderThickness="1">
                 <Grid>
                     <Grid.RowDefinitions>
@@ -247,13 +287,13 @@
                                    FontWeight="SemiBold"/>
                         <TextBlock Margin="0,4,0,12"
                                    TextWrapping="Wrap"
-                                   Foreground="#5F6B7C"
+                                   Foreground="{StaticResource Brush.TextSecondary}"
                                    Text="Select an icon from the canvas to capture notes, context, and next steps."/>
                     </StackPanel>
 
                     <Border Grid.Row="1"
-                            Background="#F4F7FB"
-                            BorderBrush="#DFE7F5"
+                            Background="{StaticResource Brush.HighlightBackground}"
+                            BorderBrush="{StaticResource Brush.HighlightBorder}"
                             BorderThickness="1"
                             CornerRadius="8"
                             Padding="10"
@@ -261,7 +301,7 @@
                         <TextBlock Text="{Binding SelectedPath}"
                                    FontSize="14"
                                    FontWeight="SemiBold"
-                                   Foreground="#274265"
+                                   Foreground="{StaticResource Brush.Primary}"
                                    TextWrapping="Wrap">
                             <TextBlock.Style>
                                 <Style TargetType="TextBlock">
@@ -280,7 +320,7 @@
                                Text="Right-click on the canvas to add your first idea."
                                VerticalAlignment="Center"
                                HorizontalAlignment="Center"
-                               Foreground="#6B7280"
+                               Foreground="{StaticResource Brush.TextSecondary}"
                                FontSize="14"
                                TextWrapping="Wrap"
                                TextAlignment="Center">
@@ -335,8 +375,8 @@
                                     </StackPanel>
 
                                     <Border Grid.Row="2"
-                                            Background="#F8FAFC"
-                                            BorderBrush="#E2E8F0"
+                                            Background="{StaticResource Brush.SurfaceAlt}"
+                                            BorderBrush="{StaticResource Brush.Border}"
                                             BorderThickness="1"
                                             CornerRadius="6"
                                             Padding="12">
@@ -351,7 +391,7 @@
                                                             <TextBlock Text="•"
                                                                        FontSize="16"
                                                                        Margin="0,0,6,0"
-                                                                       Foreground="#2D6A8E"/>
+                                                                       Foreground="{StaticResource Brush.Primary}"/>
                                                             <TextBlock Text="{Binding Title}"/>
                                                         </StackPanel>
                                                     </DataTemplate>
@@ -368,7 +408,7 @@
                                                 </ItemsControl.Style>
                                             </ItemsControl>
                                             <TextBlock Text="No child ideas yet. Use the context menu to break this topic down further."
-                                                       Foreground="#5F6B7C"
+                                                       Foreground="{StaticResource Brush.TextSecondary}"
                                                        TextWrapping="Wrap">
                                                 <TextBlock.Style>
                                                     <Style TargetType="TextBlock">

--- a/Views/UpdatedCostView.xaml
+++ b/Views/UpdatedCostView.xaml
@@ -8,7 +8,9 @@
              UseLayoutRounding="True">
     <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto" Padding="{StaticResource Padding.Card}">
         <StackPanel>
-        <Border Margin="10,0,10,10" Background="#EEF6F8" BorderBrush="{StaticResource Brush.Primary}" BorderThickness="1" CornerRadius="10" Padding="16">
+        <Border Margin="10,0,10,10"
+                Style="{StaticResource Border.Explainer}"
+                Padding="{StaticResource Padding.Card}">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto"/>
@@ -20,7 +22,26 @@
                     <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
                 <StackPanel Orientation="Horizontal" Grid.Column="0" VerticalAlignment="Top">
-                    <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="24" Foreground="{StaticResource Brush.Primary}" Margin="0,0,10,0"/>
+                    <Viewbox Width="32" Height="32" Margin="0,0,10,0">
+                        <Canvas Width="32" Height="32">
+                            <Rectangle Width="24"
+                                       Height="16"
+                                       RadiusX="2"
+                                       RadiusY="2"
+                                       Fill="{StaticResource Brush.Primary}"
+                                       Canvas.Left="4"
+                                       Canvas.Top="8"/>
+                            <Rectangle Width="4" Height="12" Fill="{StaticResource Brush.Surface}" Opacity="0.6" Canvas.Left="6" Canvas.Top="10"/>
+                            <Rectangle Width="4" Height="12" Fill="{StaticResource Brush.Surface}" Opacity="0.6" Canvas.Left="14" Canvas.Top="10"/>
+                            <Rectangle Width="4" Height="12" Fill="{StaticResource Brush.Surface}" Opacity="0.6" Canvas.Left="22" Canvas.Top="10"/>
+                            <Path Data="M4,24 C7,22 9,22 12,24 C15,26 17,26 20,24 C23,22 25,22 28,24"
+                                  Stroke="{StaticResource Brush.Accent}"
+                                  StrokeThickness="2"
+                                  StrokeStartLineCap="Round"
+                                  StrokeEndLineCap="Round"
+                                  Fill="Transparent"/>
+                        </Canvas>
+                    </Viewbox>
                 </StackPanel>
                 <StackPanel Grid.Column="1">
                     <StackPanel.Style>
@@ -70,11 +91,17 @@
         <TabControl Margin="10,0,10,10" HorizontalContentAlignment="Stretch">
         <TabItem Header="Storage Cost">
             <StackPanel Margin="10">
-                <Border Background="#FFF7F0" BorderBrush="#F2C089" BorderThickness="1" CornerRadius="8" Padding="12" Margin="0,0,0,10">
+                <Border Style="{StaticResource Border.Explainer}" Margin="0,0,0,12">
                     <StackPanel>
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                            <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="18" Foreground="#B96A00" Margin="0,0,8,0"/>
-                            <TextBlock Text="Storage Guidance" FontWeight="Bold" Foreground="#B96A00"/>
+                            <TextBlock FontFamily="Segoe MDL2 Assets"
+                                       Text=""
+                                       FontSize="18"
+                                       Foreground="{StaticResource Brush.Primary}"
+                                       Margin="0,0,8,0"/>
+                            <TextBlock Text="Storage Guidance"
+                                       FontWeight="Bold"
+                                       Foreground="{StaticResource Brush.Primary}"/>
                         </StackPanel>
                         <TextBlock TextWrapping="Wrap" Margin="0,6,0,0">
                             Record the full system storage and the recommended storage allocation for your study. The compute action scales other sections by this proportion, so double-check the recommendation before proceeding.
@@ -104,7 +131,7 @@
                     </Button>
                     <TextBlock Text="{Binding Percent, StringFormat=P: {0:F5}}" Grid.Row="3" Grid.ColumnSpan="2" ToolTip="Percent = Storage Recommendation / Total Usable Storage"/>
                 </Grid>
-                <Border Background="#FFF3E2" BorderBrush="#F2C089" BorderThickness="1" CornerRadius="8" Padding="12">
+                <Border Style="{StaticResource Border.ResultInfo}" Margin="0">
                     <TextBlock TextWrapping="Wrap">
                         The resulting P value shows how much of the joint facilities support your recommendation. Increasing the recommendation or decreasing total storage raises the percentage and, consequently, the share of downstream costs assigned to this project.
                     </TextBlock>
@@ -113,11 +140,17 @@
         </TabItem>
         <TabItem Header="Joint Costs O&amp;M">
             <StackPanel Margin="10">
-                <Border Background="#EEF9F1" BorderBrush="#8BC999" BorderThickness="1" CornerRadius="8" Padding="12" Margin="0,0,0,10">
+                <Border Style="{StaticResource Border.Explainer}" Margin="0,0,0,12">
                     <StackPanel>
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                            <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="18" Foreground="#2F855A" Margin="0,0,8,0"/>
-                            <TextBlock Text="Joint O&amp;M Entry" FontWeight="Bold" Foreground="#2F855A"/>
+                            <TextBlock FontFamily="Segoe MDL2 Assets"
+                                       Text=""
+                                       FontSize="18"
+                                       Foreground="{StaticResource Brush.Primary}"
+                                       Margin="0,0,8,0"/>
+                            <TextBlock Text="Joint O&amp;M Entry"
+                                       FontWeight="Bold"
+                                       Foreground="{StaticResource Brush.Primary}"/>
                         </StackPanel>
                         <TextBlock TextWrapping="Wrap" Margin="0,6,0,0">
                             Enter the system-wide joint operating and maintenance costs on an annual basis. The compute step keeps a running total that is later scaled by the storage percentage.
@@ -147,7 +180,7 @@
                     </Button>
                     <TextBlock Text="{Binding TotalJointOm, StringFormat=Total Joint O&amp;M: {0:C2}}" Grid.Row="3" Grid.ColumnSpan="2" ToolTip="Total Joint O&amp;M = Joint Operations Cost + Joint Maintenance Cost"/>
                 </Grid>
-                <Border Background="#E5F4EA" BorderBrush="#8BC999" BorderThickness="1" CornerRadius="8" Padding="12">
+                <Border Style="{StaticResource Border.ResultInfo}" Margin="0">
                     <TextBlock TextWrapping="Wrap">
                         This total represents the joint-system expenses before scaling. When the storage percentage increases, more of this amount will be allocated to the recommended plan in the Total Annual Cost tab.
                     </TextBlock>
@@ -156,11 +189,17 @@
         </TabItem>
         <TabItem Header="Updated Storage Cost">
             <StackPanel Margin="10">
-                <Border Background="#F1F4FF" BorderBrush="#A2B4F5" BorderThickness="1" CornerRadius="8" Padding="12" Margin="0,0,0,10">
+                <Border Style="{StaticResource Border.Explainer}" Margin="0,0,0,12">
                     <StackPanel>
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                            <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="18" Foreground="#3A55B5" Margin="0,0,8,0"/>
-                            <TextBlock Text="Update Legacy Costs" FontWeight="Bold" Foreground="#3A55B5"/>
+                            <TextBlock FontFamily="Segoe MDL2 Assets"
+                                       Text=""
+                                       FontSize="18"
+                                       Foreground="{StaticResource Brush.Primary}"
+                                       Margin="0,0,8,0"/>
+                            <TextBlock Text="Update Legacy Costs"
+                                       FontWeight="Bold"
+                                       Foreground="{StaticResource Brush.Primary}"/>
                         </StackPanel>
                         <TextBlock TextWrapping="Wrap" Margin="0,6,0,0">
                             Replace historical construction costs with current values by pairing each category with the proper update factor. Keep the categories clear so the export remains audit friendly.
@@ -181,7 +220,7 @@
                         <TextBlock Text="Compute"/>
                     </StackPanel>
                 </Button>
-                <Border Background="#E7ECFF" BorderBrush="#A2B4F5" BorderThickness="1" CornerRadius="8" Padding="12">
+                <Border Style="{StaticResource Border.ResultInfo}" Margin="0">
                     <StackPanel>
                         <TextBlock Text="{Binding TotalUpdatedCost, StringFormat=Total Updated Cost: {0:C2}}" FontWeight="Bold"/>
                         <TextBlock TextWrapping="Wrap" Margin="0,6,0,0">
@@ -193,11 +232,17 @@
         </TabItem>
         <TabItem Header="RR&amp;R and Mitigation">
             <StackPanel Margin="10">
-                <Border Background="#F6F0FF" BorderBrush="#C3A4F6" BorderThickness="1" CornerRadius="8" Padding="12" Margin="0,0,0,10">
+                <Border Style="{StaticResource Border.Explainer}" Margin="0,0,0,12">
                     <StackPanel>
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                            <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="18" Foreground="#6B35B2" Margin="0,0,8,0"/>
-                            <TextBlock Text="RR&amp;R / Mitigation Planner" FontWeight="Bold" Foreground="#6B35B2"/>
+                            <TextBlock FontFamily="Segoe MDL2 Assets"
+                                       Text=""
+                                       FontSize="18"
+                                       Foreground="{StaticResource Brush.Primary}"
+                                       Margin="0,0,8,0"/>
+                            <TextBlock Text="RR&amp;R / Mitigation Planner"
+                                       FontWeight="Bold"
+                                       Foreground="{StaticResource Brush.Primary}"/>
                         </StackPanel>
                         <TextBlock TextWrapping="Wrap" Margin="0,6,0,0">
                             Capture future repair, replacement, rehabilitation, and mitigation costs. Use the grid to list each activity, the year it occurs, and its cost in that year dollars. The tool discounts everything back to the base year before applying the CWCCI.
@@ -246,7 +291,7 @@
                         <TextBlock Text="{Binding RrrAnnualized, StringFormat=Annualized: {0:C2}}" ToolTip="Annualized = Updated Cost × CRF" FontWeight="Bold"/>
                     </StackPanel>
                 </Grid>
-                <Border Background="#F1E8FF" BorderBrush="#C3A4F6" BorderThickness="1" CornerRadius="8" Padding="12">
+                <Border Style="{StaticResource Border.ResultInfo}" Margin="0">
                     <TextBlock TextWrapping="Wrap">
                         Present Value aggregates each scheduled cost using the discount rate and base year. The Updated Cost multiplies that total by CWCCI, and the Annualized figure then applies your capital recovery factor. Larger future costs, slower discounting, or higher CWCCI will elevate every downstream total.
                     </TextBlock>
@@ -255,11 +300,17 @@
         </TabItem>
         <TabItem Header="Total Annual Cost">
             <StackPanel Margin="10">
-                <Border Background="#E9F3FF" BorderBrush="#8DB6E3" BorderThickness="1" CornerRadius="8" Padding="12" Margin="0,0,0,10">
+                <Border Style="{StaticResource Border.Explainer}" Margin="0,0,0,12">
                     <StackPanel>
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                            <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="18" Foreground="#1F6AB0" Margin="0,0,8,0"/>
-                            <TextBlock Text="Compare Annual Cost Scenarios" FontWeight="Bold" Foreground="#1F6AB0"/>
+                            <TextBlock FontFamily="Segoe MDL2 Assets"
+                                       Text=""
+                                       FontSize="18"
+                                       Foreground="{StaticResource Brush.Primary}"
+                                       Margin="0,0,8,0"/>
+                            <TextBlock Text="Compare Annual Cost Scenarios"
+                                       FontWeight="Bold"
+                                       Foreground="{StaticResource Brush.Primary}"/>
                         </StackPanel>
                         <TextBlock TextWrapping="Wrap" Margin="0,6,0,0">
                             Define up to two capital recovery scenarios. Each uses its own discount rate and analysis period to annualize the updated costs, then layers on scaled joint O&amp;M and RR&amp;R/mitigation values.
@@ -319,7 +370,7 @@
                         </GroupBox>
                     </Grid>
                 </Grid>
-                <Border Background="#DBECFF" BorderBrush="#8DB6E3" BorderThickness="1" CornerRadius="8" Padding="12">
+                <Border Style="{StaticResource Border.ResultInfo}" Margin="0">
                     <TextBlock TextWrapping="Wrap">
                         Cost 1 and Cost 2 let you compare alternative discounting assumptions. Lower discount rates or longer analysis periods increase the capital recovery factor and therefore annualized storage costs. Because joint O&amp;M and RR&amp;R values scale with the storage percentage, any change you make on earlier tabs will ripple into both scenarios here.
                     </TextBlock>


### PR DESCRIPTION
## Summary
- add shared highlight brushes and border styles for explainer and results cards to create a consistent color palette
- refresh explainer icons across EAD, annualizer, updated cost, and mind map tabs (including a custom dam and brain illustration)
- clean up tab layouts so result cards share the same styling and cost annualization results drop their icons while spacing text for readability

## Testing
- `dotnet build` *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb04f75ef48330917eccccbf781570