### PR TITLE
Toggle calculate button visibility

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -23,6 +23,7 @@
 
     <Window.Resources>
         <ResourceDictionary>
+            <BooleanToVisibilityConverter x:Key="BoolToVisibilityConverter"/>
             <DataTemplate x:Key="HeroWideTemplate">
                 <Grid Margin="0"
                       HorizontalAlignment="Stretch">
@@ -107,7 +108,9 @@
                     <Button x:Name="CalculateButton"
                             Command="{Binding CalculateCommand}"
                             Margin="{StaticResource Margin.Inline}"
-                            HorizontalAlignment="Stretch">
+                            HorizontalAlignment="Stretch"
+                            Visibility="{Binding IsCalculateVisible, Converter={StaticResource BoolToVisibilityConverter}}"
+                            IsEnabled="{Binding IsCalculateVisible}">
                         <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
                             <TextBlock FontFamily="Segoe MDL2 Assets"
                                        Text=""
@@ -132,7 +135,9 @@
 
             <DataTemplate x:Key="ActionsNarrowTemplate">
                 <StackPanel>
-                    <Button Command="{Binding CalculateCommand}">
+                    <Button Command="{Binding CalculateCommand}"
+                            Visibility="{Binding IsCalculateVisible, Converter={StaticResource BoolToVisibilityConverter}}"
+                            IsEnabled="{Binding IsCalculateVisible}">
                         <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
                             <TextBlock FontFamily="Segoe MDL2 Assets"
                                        Text=""

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -16,40 +16,54 @@ namespace EconToolbox.Desktop.ViewModels
         public int SelectedIndex
         {
             get => _selectedIndex;
-            set { _selectedIndex = value; OnPropertyChanged(); }
+            set
+            {
+                if (_selectedIndex == value) return;
+                _selectedIndex = value;
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(IsCalculateVisible));
+            }
         }
 
         public ICommand CalculateCommand { get; }
         public ICommand ExportCommand { get; }
 
+        public bool IsCalculateVisible => SelectedComputeCommand?.CanExecute(null) == true;
+
         public MainViewModel()
         {
             CalculateCommand = new RelayCommand(Calculate);
             ExportCommand = new RelayCommand(Export);
+
+            SubscribeToComputeCommand(Ead.ComputeCommand);
+            SubscribeToComputeCommand(UpdatedCost.ComputeCommand);
+            SubscribeToComputeCommand(Annualizer.ComputeCommand);
+            SubscribeToComputeCommand(WaterDemand.ComputeCommand);
+            SubscribeToComputeCommand(Udv.ComputeCommand);
         }
 
         private void Calculate()
         {
-            switch (SelectedIndex)
+            var command = SelectedComputeCommand;
+            if (command?.CanExecute(null) == true)
             {
-                case 0:
-                    if (Ead.ComputeCommand.CanExecute(null)) Ead.ComputeCommand.Execute(null);
-                    break;
-                case 1:
-                    if (UpdatedCost.ComputeCommand.CanExecute(null)) UpdatedCost.ComputeCommand.Execute(null);
-                    break;
-                case 2:
-                    if (Annualizer.ComputeCommand.CanExecute(null)) Annualizer.ComputeCommand.Execute(null);
-                    break;
-                case 3:
-                    if (WaterDemand.ComputeCommand.CanExecute(null)) WaterDemand.ComputeCommand.Execute(null);
-                    break;
-                case 4:
-                    if (Udv.ComputeCommand.CanExecute(null)) Udv.ComputeCommand.Execute(null);
-                    break;
-                case 5:
-                    break;
+                command.Execute(null);
             }
+        }
+
+        private ICommand? SelectedComputeCommand => SelectedIndex switch
+        {
+            0 => Ead.ComputeCommand,
+            1 => UpdatedCost.ComputeCommand,
+            2 => Annualizer.ComputeCommand,
+            3 => WaterDemand.ComputeCommand,
+            4 => Udv.ComputeCommand,
+            _ => null
+        };
+
+        private void SubscribeToComputeCommand(ICommand command)
+        {
+            command.CanExecuteChanged += (_, _) => OnPropertyChanged(nameof(IsCalculateVisible));
         }
 
         private void Export()


### PR DESCRIPTION
## Summary
- add an `IsCalculateVisible` property to `MainViewModel` that reflects the active tab's runnable compute command
- reuse the selected compute command when executing calculate and update the visibility when compute commands change state
- hide and disable the Calculate buttons in the wide and narrow action templates when no compute command is available

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cc65b834b88330aade7a450800479b