### PR TITLE
Refine module navigation and modernize EAD grid

### DIFF
--- a/Behaviors/DataGridColumnDescriptor.cs
+++ b/Behaviors/DataGridColumnDescriptor.cs
@@ -1,0 +1,50 @@
+using System.ComponentModel;
+
+namespace EconToolbox.Desktop.Behaviors
+{
+    public class DataGridColumnDescriptor : INotifyPropertyChanged
+    {
+        private string? _headerText;
+
+        public DataGridColumnDescriptor(string bindingPath)
+        {
+            BindingPath = bindingPath;
+        }
+
+        public string BindingPath { get; }
+
+        public string? HeaderText
+        {
+            get => _headerText;
+            set
+            {
+                if (_headerText == value)
+                {
+                    return;
+                }
+
+                _headerText = value;
+                OnPropertyChanged(nameof(HeaderText));
+            }
+        }
+
+        public bool IsReadOnly { get; init; }
+
+        public double? Width { get; init; }
+
+        public double? MinWidth { get; init; }
+
+        public object? HeaderContext { get; init; }
+
+        public string? HeaderBindingPath { get; init; }
+
+        public bool IsHeaderEditable { get; init; }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        protected virtual void OnPropertyChanged(string propertyName)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+}

--- a/Behaviors/DataGridColumnsBehavior.cs
+++ b/Behaviors/DataGridColumnsBehavior.cs
@@ -1,0 +1,225 @@
+using System.Collections;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+
+namespace EconToolbox.Desktop.Behaviors
+{
+    public static class DataGridColumnsBehavior
+    {
+        public static readonly DependencyProperty ColumnsSourceProperty = DependencyProperty.RegisterAttached(
+            "ColumnsSource",
+            typeof(IEnumerable),
+            typeof(DataGridColumnsBehavior),
+            new PropertyMetadata(null, OnColumnsSourceChanged));
+
+        private static readonly DependencyProperty ColumnsBindingProperty = DependencyProperty.RegisterAttached(
+            "ColumnsBinding",
+            typeof(ColumnsBinding),
+            typeof(DataGridColumnsBehavior),
+            new PropertyMetadata(null));
+
+        public static IEnumerable? GetColumnsSource(DependencyObject obj) => (IEnumerable?)obj.GetValue(ColumnsSourceProperty);
+
+        public static void SetColumnsSource(DependencyObject obj, IEnumerable? value) => obj.SetValue(ColumnsSourceProperty, value);
+
+        private static void OnColumnsSourceChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is not DataGrid dataGrid)
+            {
+                return;
+            }
+
+            if (GetColumnsBinding(dataGrid) is ColumnsBinding oldBinding)
+            {
+                oldBinding.Detach();
+            }
+
+            if (e.NewValue is IEnumerable newSource)
+            {
+                var binding = new ColumnsBinding(dataGrid, newSource);
+                SetColumnsBinding(dataGrid, binding);
+            }
+            else
+            {
+                dataGrid.Columns.Clear();
+                SetColumnsBinding(dataGrid, null);
+            }
+        }
+
+        private static ColumnsBinding? GetColumnsBinding(DependencyObject obj)
+            => (ColumnsBinding?)obj.GetValue(ColumnsBindingProperty);
+
+        private static void SetColumnsBinding(DependencyObject obj, ColumnsBinding? value)
+            => obj.SetValue(ColumnsBindingProperty, value);
+
+        private sealed class ColumnsBinding
+        {
+            private readonly DataGrid _dataGrid;
+            private readonly IEnumerable _source;
+
+            public ColumnsBinding(DataGrid dataGrid, IEnumerable source)
+            {
+                _dataGrid = dataGrid;
+                _source = source;
+
+                if (source is INotifyCollectionChanged notify)
+                {
+                    notify.CollectionChanged += OnCollectionChanged;
+                }
+
+                foreach (var descriptor in source.OfType<INotifyPropertyChanged>())
+                {
+                    descriptor.PropertyChanged += OnDescriptorPropertyChanged;
+                }
+
+                RebuildColumns();
+            }
+
+            private void OnCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+            {
+                if (sender is INotifyCollectionChanged notify)
+                {
+                    if (e.OldItems != null)
+                    {
+                        foreach (var item in e.OldItems.OfType<INotifyPropertyChanged>())
+                        {
+                            item.PropertyChanged -= OnDescriptorPropertyChanged;
+                        }
+                    }
+
+                    if (e.NewItems != null)
+                    {
+                        foreach (var item in e.NewItems.OfType<INotifyPropertyChanged>())
+                        {
+                            item.PropertyChanged += OnDescriptorPropertyChanged;
+                        }
+                    }
+                }
+
+                RebuildColumns();
+            }
+
+            private void OnDescriptorPropertyChanged(object? sender, PropertyChangedEventArgs e)
+            {
+                if (e.PropertyName == nameof(DataGridColumnDescriptor.HeaderText))
+                {
+                    UpdateHeaders();
+                }
+            }
+
+            public void Detach()
+            {
+                if (_source is INotifyCollectionChanged notify)
+                {
+                    notify.CollectionChanged -= OnCollectionChanged;
+                }
+
+                foreach (var descriptor in _source.OfType<INotifyPropertyChanged>())
+                {
+                    descriptor.PropertyChanged -= OnDescriptorPropertyChanged;
+                }
+
+                _dataGrid.Columns.Clear();
+            }
+
+            private void RebuildColumns()
+            {
+                _dataGrid.Columns.Clear();
+
+                foreach (var descriptor in _source.OfType<DataGridColumnDescriptor>())
+                {
+                    _dataGrid.Columns.Add(CreateColumn(descriptor));
+                }
+            }
+
+            private void UpdateHeaders()
+            {
+                int index = 0;
+                foreach (var descriptor in _source.OfType<DataGridColumnDescriptor>())
+                {
+                    if (index < _dataGrid.Columns.Count)
+                    {
+                        _dataGrid.Columns[index].Header = CreateHeader(descriptor);
+                    }
+
+                    index++;
+                }
+            }
+
+            private static DataGridColumn CreateColumn(DataGridColumnDescriptor descriptor)
+            {
+                var binding = new Binding(descriptor.BindingPath)
+                {
+                    Mode = descriptor.IsReadOnly ? BindingMode.OneWay : BindingMode.TwoWay,
+                    UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged,
+                    ValidatesOnDataErrors = true,
+                    ValidatesOnExceptions = true
+                };
+
+                var column = new DataGridTextColumn
+                {
+                    Binding = binding,
+                    IsReadOnly = descriptor.IsReadOnly,
+                    SortMemberPath = descriptor.BindingPath
+                };
+
+                if (descriptor.Width.HasValue)
+                {
+                    column.Width = new DataGridLength(descriptor.Width.Value);
+                }
+
+                if (descriptor.MinWidth.HasValue)
+                {
+                    column.MinWidth = descriptor.MinWidth.Value;
+                }
+
+                column.Header = CreateHeader(descriptor);
+
+                return column;
+            }
+
+            private static object CreateHeader(DataGridColumnDescriptor descriptor)
+            {
+                if (descriptor.HeaderContext != null && !string.IsNullOrWhiteSpace(descriptor.HeaderBindingPath))
+                {
+                    if (descriptor.IsHeaderEditable)
+                    {
+                        var headerBox = new TextBox
+                        {
+                            DataContext = descriptor.HeaderContext,
+                            Padding = new Thickness(4, 2, 4, 2),
+                            MinWidth = descriptor.MinWidth ?? 80,
+                            HorizontalAlignment = HorizontalAlignment.Stretch,
+                            BorderThickness = new Thickness(0),
+                            Background = System.Windows.Media.Brushes.Transparent
+                        };
+
+                        headerBox.SetBinding(TextBox.TextProperty, new Binding(descriptor.HeaderBindingPath)
+                        {
+                            Mode = BindingMode.TwoWay,
+                            UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged
+                        });
+
+                        return headerBox;
+                    }
+
+                    var headerText = new TextBlock
+                    {
+                        DataContext = descriptor.HeaderContext,
+                        Margin = new Thickness(0),
+                        TextTrimming = TextTrimming.CharacterEllipsis
+                    };
+
+                    headerText.SetBinding(TextBlock.TextProperty, new Binding(descriptor.HeaderBindingPath));
+                    return headerText;
+                }
+
+                return descriptor.HeaderText ?? descriptor.BindingPath;
+            }
+        }
+    }
+}

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -24,15 +24,33 @@
     <Window.Resources>
         <ResourceDictionary>
             <BooleanToVisibilityConverter x:Key="BoolToVisibilityConverter"/>
+            <DataTemplate DataType="{x:Type vm:EadViewModel}">
+                <views:EadView/>
+            </DataTemplate>
+            <DataTemplate DataType="{x:Type vm:UpdatedCostViewModel}">
+                <views:UpdatedCostView/>
+            </DataTemplate>
+            <DataTemplate DataType="{x:Type vm:AnnualizerViewModel}">
+                <views:AnnualizerView/>
+            </DataTemplate>
+            <DataTemplate DataType="{x:Type vm:WaterDemandViewModel}">
+                <views:WaterDemandView/>
+            </DataTemplate>
+            <DataTemplate DataType="{x:Type vm:UdvViewModel}">
+                <views:UdvView/>
+            </DataTemplate>
+            <DataTemplate DataType="{x:Type vm:MindMapViewModel}">
+                <views:MindMapView/>
+            </DataTemplate>
             <DataTemplate x:Key="HeroWideTemplate">
                 <Grid Margin="0"
                       HorizontalAlignment="Stretch">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="*" MinWidth="300"/>
+                        <ColumnDefinition Width="*" MinWidth="320"/>
                     </Grid.ColumnDefinitions>
                     <Canvas Width="120"
-                            Height="80"
+                            Height="90"
                             Margin="{StaticResource Margin.InlineLarge}">
                         <Path Data="M10,70 L30,45 L55,55 L85,20"
                               Stroke="White"
@@ -44,23 +62,39 @@
                         <Ellipse Width="10" Height="10" Fill="{StaticResource Brush.Accent}" Canvas.Left="51" Canvas.Top="50"/>
                         <Ellipse Width="12" Height="12" Fill="White" Canvas.Left="79" Canvas.Top="14"/>
                     </Canvas>
-                    <StackPanel Grid.Column="1">
-                        <StackPanel Orientation="Horizontal" Margin="{StaticResource Margin.Stack}">
-                            <TextBlock FontFamily="Segoe MDL2 Assets"
-                                       Text=""
-                                       FontSize="30"
-                                       Foreground="White"
-                                       Margin="{StaticResource Margin.Inline}"/>
-                            <TextBlock Text="Economic Toolbox"
-                                       Style="{StaticResource Text.Title}"/>
-                        </StackPanel>
-                        <TextBlock Style="{StaticResource Text.Body}"
+                    <StackPanel Grid.Column="1"
+                                Margin="{StaticResource Margin.StackLarge}">
+                        <TextBlock Text="Economic Toolbox"
                                    Foreground="White"
-                                   Margin="{StaticResource Margin.Stack}">
-                            Review each tab to build a complete project narrative. Enter inputs carefully, press Calculate when
-                            available, and use Export to capture your work. Context-sensitive tips below explain what each result
-                            means and how your assumptions drive it.
-                        </TextBlock>
+                                   FontWeight="SemiBold"
+                                   FontSize="14"/>
+                        <TextBlock Text="{Binding SelectedModule.Title}"
+                                   Style="{StaticResource Text.Title}"/>
+                        <TextBlock Text="{Binding SelectedModule.Description}"
+                                   Style="{StaticResource Text.Body}"
+                                   Foreground="White"
+                                   Margin="{StaticResource Margin.Stack}"/>
+                        <TextBlock Text="To prepare your inputs:"
+                                   FontWeight="SemiBold"
+                                   Foreground="White"
+                                   Margin="{StaticResource Margin.Stack}"/>
+                        <ItemsControl ItemsSource="{Binding SelectedModule.InputSteps}"
+                                      Margin="{StaticResource Margin.StackSmall}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <StackPanel Orientation="Horizontal" Margin="0,2">
+                                        <TextBlock Text="•"
+                                                   Foreground="White"
+                                                   FontSize="16"
+                                                   Margin="0,0,6,0"/>
+                                        <TextBlock Text="{Binding}"
+                                                   Style="{StaticResource Text.Body}"
+                                                   Foreground="White"
+                                                   TextWrapping="Wrap"/>
+                                    </StackPanel>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
                     </StackPanel>
                 </Grid>
             </DataTemplate>
@@ -85,57 +119,130 @@
                     <StackPanel Margin="{StaticResource Margin.Stack}"
                                 HorizontalAlignment="Center">
                         <TextBlock Text="Economic Toolbox"
-                                   Style="{StaticResource Text.Title}"/>
+                                   Foreground="White"
+                                   FontWeight="SemiBold"
+                                   FontSize="14"/>
+                        <TextBlock Text="{Binding SelectedModule.Title}"
+                                   Style="{StaticResource Text.Title}"
+                                   TextAlignment="Center"/>
                     </StackPanel>
                     <TextBlock Style="{StaticResource Text.Body}"
                                Foreground="White"
                                TextAlignment="Center"
-                               Margin="{StaticResource Margin.Stack}">
-                        Review each tab to build a complete project narrative. Enter inputs carefully, press Calculate when
-                        available, and use Export to capture your work. Context-sensitive tips below explain what each result means
-                        and how your assumptions drive it.
-                    </TextBlock>
+                               Margin="{StaticResource Margin.Stack}"
+                               Text="{Binding SelectedModule.Description}"/>
+                    <TextBlock Text="To prepare your inputs:"
+                               FontWeight="SemiBold"
+                               Foreground="White"
+                               TextAlignment="Center"
+                               Margin="{StaticResource Margin.Stack}"/>
+                    <ItemsControl ItemsSource="{Binding SelectedModule.InputSteps}"
+                                  Margin="{StaticResource Margin.StackSmall}"
+                                  HorizontalAlignment="Center">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel Orientation="Horizontal" Margin="0,2">
+                                    <TextBlock Text="•"
+                                               Foreground="White"
+                                               FontSize="16"
+                                               Margin="0,0,6,0"/>
+                                    <TextBlock Text="{Binding}"
+                                               Style="{StaticResource Text.Body}"
+                                               Foreground="White"
+                                               TextWrapping="Wrap"
+                                               Width="240"/>
+                                </StackPanel>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
                 </StackPanel>
             </DataTemplate>
 
             <DataTemplate x:Key="ActionsWideTemplate">
-                <Grid HorizontalAlignment="Right"
-                      Grid.IsSharedSizeScope="True">
+                <Grid HorizontalAlignment="Stretch"
+                      Margin="0,0,0,8">
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="Auto" SharedSizeGroup="ActionButtons"/>
-                        <ColumnDefinition Width="Auto" SharedSizeGroup="ActionButtons"/>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
                     </Grid.ColumnDefinitions>
-                    <Button x:Name="CalculateButton"
-                            Command="{Binding CalculateCommand}"
-                            Margin="{StaticResource Margin.Inline}"
-                            HorizontalAlignment="Stretch"
-                            Visibility="{Binding IsCalculateVisible, Converter={StaticResource BoolToVisibilityConverter}}"
-                            IsEnabled="{Binding IsCalculateVisible}">
-                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-                            <TextBlock FontFamily="Segoe MDL2 Assets"
-                                       Text=""
-                                       Margin="{StaticResource Margin.Inline}"
-                                       FontSize="16"/>
-                            <TextBlock Text="Calculate"/>
-                        </StackPanel>
-                    </Button>
-                    <Button Grid.Column="1"
-                            Command="{Binding ExportCommand}"
-                            HorizontalAlignment="Stretch">
-                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-                            <TextBlock FontFamily="Segoe MDL2 Assets"
-                                       Text=""
-                                       Margin="{StaticResource Margin.Inline}"
-                                       FontSize="16"/>
-                            <TextBlock Text="Export"/>
-                        </StackPanel>
-                    </Button>
+                    <StackPanel Grid.Column="0"
+                                Margin="{StaticResource Margin.StackLarge}">
+                        <TextBlock Text="What the outputs show"
+                                   FontWeight="SemiBold"
+                                   Foreground="{StaticResource Brush.Primary}"/>
+                        <ItemsControl ItemsSource="{Binding SelectedModule.OutputHighlights}"
+                                      Margin="{StaticResource Margin.StackSmall}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <StackPanel Orientation="Horizontal" Margin="0,2">
+                                        <TextBlock Text="•"
+                                                   Foreground="{StaticResource Brush.Accent}"
+                                                   FontSize="16"
+                                                   Margin="0,0,6,0"/>
+                                        <TextBlock Text="{Binding}"
+                                                   Style="{StaticResource Text.Body}"
+                                                   TextWrapping="Wrap"
+                                                   Width="320"/>
+                                    </StackPanel>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </StackPanel>
+                    <StackPanel Grid.Column="1"
+                                Orientation="Horizontal"
+                                HorizontalAlignment="Right"
+                                Margin="{StaticResource Margin.Stack}">
+                        <Button x:Name="CalculateButton"
+                                Command="{Binding CalculateCommand}"
+                                Margin="{StaticResource Margin.Inline}"
+                                Visibility="{Binding IsCalculateVisible, Converter={StaticResource BoolToVisibilityConverter}}"
+                                IsEnabled="{Binding IsCalculateVisible}">
+                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                                <TextBlock FontFamily="Segoe MDL2 Assets"
+                                           Text=""
+                                           Margin="{StaticResource Margin.Inline}"
+                                           FontSize="16"/>
+                                <TextBlock Text="Calculate"/>
+                            </StackPanel>
+                        </Button>
+                        <Button Command="{Binding ExportCommand}"
+                                Margin="{StaticResource Margin.Inline}">
+                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                                <TextBlock FontFamily="Segoe MDL2 Assets"
+                                           Text=""
+                                           Margin="{StaticResource Margin.Inline}"
+                                           FontSize="16"/>
+                                <TextBlock Text="Export"/>
+                            </StackPanel>
+                        </Button>
+                    </StackPanel>
                 </Grid>
             </DataTemplate>
 
             <DataTemplate x:Key="ActionsNarrowTemplate">
                 <StackPanel>
+                    <TextBlock Text="What the outputs show"
+                               FontWeight="SemiBold"
+                               Foreground="{StaticResource Brush.Primary}"
+                               Margin="{StaticResource Margin.Stack}"/>
+                    <ItemsControl ItemsSource="{Binding SelectedModule.OutputHighlights}"
+                                  Margin="{StaticResource Margin.StackSmall}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel Orientation="Horizontal" Margin="0,2">
+                                    <TextBlock Text="•"
+                                               Foreground="{StaticResource Brush.Accent}"
+                                               FontSize="16"
+                                               Margin="0,0,6,0"/>
+                                    <TextBlock Text="{Binding}"
+                                               Style="{StaticResource Text.Body}"
+                                               TextWrapping="Wrap"/>
+                                </StackPanel>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
                     <Button Command="{Binding CalculateCommand}"
+                            Margin="{StaticResource Margin.Inline}"
                             Visibility="{Binding IsCalculateVisible, Converter={StaticResource BoolToVisibilityConverter}}"
                             IsEnabled="{Binding IsCalculateVisible}">
                         <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
@@ -146,7 +253,8 @@
                             <TextBlock Text="Calculate"/>
                         </StackPanel>
                     </Button>
-                    <Button Command="{Binding ExportCommand}">
+                    <Button Command="{Binding ExportCommand}"
+                            Margin="{StaticResource Margin.Inline}">
                         <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
                             <TextBlock FontFamily="Segoe MDL2 Assets"
                                        Text=""
@@ -196,7 +304,9 @@
                           HorizontalScrollBarVisibility="Disabled"
                           VerticalScrollBarVisibility="Auto"
                           PreviewMouseWheel="MainScrollViewer_PreviewMouseWheel">
-                <TabControl SelectedIndex="{Binding SelectedIndex}" Background="{StaticResource Brush.Surface}">
+                <TabControl ItemsSource="{Binding Modules}"
+                            SelectedIndex="{Binding SelectedIndex}"
+                            Background="{StaticResource Brush.Surface}">
                     <TabControl.Resources>
                         <Style TargetType="TabItem">
                             <Setter Property="Margin" Value="{StaticResource Margin.TopSmall}"/>
@@ -205,43 +315,17 @@
                             <Setter Property="FontSize" Value="14"/>
                         </Style>
                     </TabControl.Resources>
-
-                    <TabItem DataContext="{Binding Ead}">
-                        <TabItem.Header>
-                            <TextBlock Text="EAD" TextAlignment="Center"/>
-                        </TabItem.Header>
-                        <views:EadView Margin="{StaticResource Margin.Container}"/>
-                    </TabItem>
-                    <TabItem DataContext="{Binding UpdatedCost}">
-                        <TabItem.Header>
-                            <TextBlock Text="Updated Cost of Storage" TextAlignment="Center"/>
-                        </TabItem.Header>
-                        <views:UpdatedCostView Margin="{StaticResource Margin.Container}"/>
-                    </TabItem>
-                    <TabItem DataContext="{Binding Annualizer}">
-                        <TabItem.Header>
-                            <TextBlock Text="Cost Annualization" TextAlignment="Center"/>
-                        </TabItem.Header>
-                        <views:AnnualizerView Margin="{StaticResource Margin.Container}"/>
-                    </TabItem>
-                    <TabItem DataContext="{Binding WaterDemand}">
-                        <TabItem.Header>
-                            <TextBlock Text="Water Demand" TextAlignment="Center"/>
-                        </TabItem.Header>
-                        <views:WaterDemandView Margin="{StaticResource Margin.Container}"/>
-                    </TabItem>
-                    <TabItem DataContext="{Binding Udv}">
-                        <TabItem.Header>
-                            <TextBlock Text="Unit Day Value" TextAlignment="Center"/>
-                        </TabItem.Header>
-                        <views:UdvView Margin="{StaticResource Margin.Container}"/>
-                    </TabItem>
-                    <TabItem DataContext="{Binding MindMap}">
-                        <TabItem.Header>
-                            <TextBlock Text="Mind Map" TextAlignment="Center"/>
-                        </TabItem.Header>
-                        <views:MindMapView Margin="{StaticResource Margin.Container}"/>
-                    </TabItem>
+                    <TabControl.ItemTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding Title}" TextAlignment="Center"/>
+                        </DataTemplate>
+                    </TabControl.ItemTemplate>
+                    <TabControl.ContentTemplate>
+                        <DataTemplate>
+                            <ContentControl Content="{Binding ContentViewModel}"
+                                            Margin="{StaticResource Margin.Container}"/>
+                        </DataTemplate>
+                    </TabControl.ContentTemplate>
                 </TabControl>
             </ScrollViewer>
         </Border>

--- a/Services/ExcelExporter.cs
+++ b/Services/ExcelExporter.cs
@@ -176,7 +176,7 @@ namespace EconToolbox.Desktop.Services
             if (ead.UseStage)
                 eadSheet.Cell(1, col++).Value = "Stage";
             int dcCount = ead.DamageColumns.Count;
-            foreach (var name in ead.DamageColumns)
+            foreach (var name in ead.DamageColumns.Select(c => c.Name))
                 eadSheet.Cell(1, col++).Value = name;
             int rowIdx = 2;
             foreach (var r in ead.Rows)
@@ -466,7 +466,7 @@ namespace EconToolbox.Desktop.Services
             AddAnnualizerComparisonChart(ws, annualizer.AnnualBenefits, annualizer.AnnualCost, annualizer.Bcr, capitalStart, 5);
 
             double? primaryEadValue = null;
-            string primaryDamageColumn = ead.DamageColumns.Count > 0 ? ead.DamageColumns[0] : "Damage";
+            string primaryDamageColumn = ead.DamageColumns.Count > 0 ? ead.DamageColumns[0].Name : "Damage";
             var eadRows = new List<(string Label, object Value, string? Format, string? Comment, bool Highlight)>
             {
                 ("Rows Evaluated", ead.Rows.Count, "0", "Number of probability-damage pairs included.", false),
@@ -482,7 +482,7 @@ namespace EconToolbox.Desktop.Services
                     double eadValue = EadModel.Compute(probabilities, damages);
                     if (i == 0)
                         primaryEadValue = eadValue;
-                    eadRows.Add(($"{ead.DamageColumns[i]} EAD", eadValue, "$#,##0.00", "Expected annual damage for this damage column.", i == 0));
+                    eadRows.Add(($"{ead.DamageColumns[i].Name} EAD", eadValue, "$#,##0.00", "Expected annual damage for this damage column.", i == 0));
                 }
                 eadRows.Add(("Summary", string.Join(" | ", ead.Results), null, "Combined textual output from the calculator.", false));
             }

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -1,8 +1,9 @@
+using System.Collections.Generic;
 using System.Windows.Input;
 using EconToolbox.Desktop.Services;
 
 namespace EconToolbox.Desktop.ViewModels
-{ 
+{
     public class MainViewModel : BaseViewModel
     {
         public EadViewModel Ead { get; } = new();
@@ -11,6 +12,8 @@ namespace EconToolbox.Desktop.ViewModels
         public UdvViewModel Udv { get; } = new();
         public WaterDemandViewModel WaterDemand { get; } = new();
         public MindMapViewModel MindMap { get; } = new();
+
+        public IReadOnlyList<ModuleDefinition> Modules { get; }
 
         private int _selectedIndex;
         public int SelectedIndex
@@ -22,47 +25,152 @@ namespace EconToolbox.Desktop.ViewModels
                 _selectedIndex = value;
                 OnPropertyChanged();
                 OnPropertyChanged(nameof(IsCalculateVisible));
+                OnPropertyChanged(nameof(SelectedModule));
             }
         }
 
         public ICommand CalculateCommand { get; }
         public ICommand ExportCommand { get; }
 
-        public bool IsCalculateVisible => SelectedComputeCommand?.CanExecute(null) == true;
+        public ModuleDefinition? SelectedModule => SelectedIndex >= 0 && SelectedIndex < Modules.Count
+            ? Modules[SelectedIndex]
+            : null;
+
+        public bool IsCalculateVisible => SelectedModule?.ComputeCommand?.CanExecute(null) == true;
 
         public MainViewModel()
         {
             CalculateCommand = new RelayCommand(Calculate);
             ExportCommand = new RelayCommand(Export);
 
-            SubscribeToComputeCommand(Ead.ComputeCommand);
-            SubscribeToComputeCommand(UpdatedCost.ComputeCommand);
-            SubscribeToComputeCommand(Annualizer.ComputeCommand);
-            SubscribeToComputeCommand(WaterDemand.ComputeCommand);
-            SubscribeToComputeCommand(Udv.ComputeCommand);
+            Modules = new List<ModuleDefinition>
+            {
+                new ModuleDefinition(
+                    "Expected Annual Damage (EAD)",
+                    "Quantify how frequently damages occur by pairing exceedance probabilities with damage estimates.",
+                    new[]
+                    {
+                        "List probabilities between 0 and 1 in descending order so the curve integrates correctly.",
+                        "Optionally add stage values that align with the same probabilities when stage-damage insight is needed.",
+                        "Add, rename, and populate damage columns to represent scenarios, assets, or plans being compared."
+                    },
+                    new[]
+                    {
+                        "Computes the expected annual damage for every damage column using trapezoidal integration.",
+                        "Draws frequency-damage and stage-damage curves so you can visually QA the shape of the inputs.",
+                        "Exports the full grid, summary text, and charts to Excel for documentation."
+                    },
+                    Ead,
+                    Ead.ComputeCommand),
+                new ModuleDefinition(
+                    "Updated Cost of Storage",
+                    "Update historical costs and allocate joint expenses based on storage recommendations.",
+                    new[]
+                    {
+                        "Confirm the total usable storage and the recommendation for your plan to establish the allocation percent.",
+                        "Enter annual joint O&M totals and refresh historical cost line items with appropriate indices.",
+                        "Capture RR&R/mitigation details and scenario-specific capital recovery factors before computing totals."
+                    },
+                    new[]
+                    {
+                        "Reports the storage allocation percentage applied to joint costs and RR&R values.",
+                        "Summarizes updated capital, annualized RR&R, and total annual cost comparisons across scenarios.",
+                        "Provides an export-ready workbook covering every sub-tab for auditability."
+                    },
+                    UpdatedCost,
+                    UpdatedCost.ComputeCommand),
+                new ModuleDefinition(
+                    "Cost Annualization",
+                    "Translate capital outlays and future costs into comparable annual values.",
+                    new[]
+                    {
+                        "Enter first cost, discount rate, analysis period, and base year that frame the recovery analysis.",
+                        "Populate the IDC schedule and any future cost entries in the year they will occur.",
+                        "Document annual O&M and expected annual benefits to complete the annualization picture."
+                    },
+                    new[]
+                    {
+                        "Calculates IDC, total investment, capital recovery factor, annual cost, and benefit-cost ratio.",
+                        "Generates schedules for future costs and IDC contributions for traceability.",
+                        "Exports a concise summary table and supporting detail to Excel."
+                    },
+                    Annualizer,
+                    Annualizer.ComputeCommand),
+                new ModuleDefinition(
+                    "Water Demand Forecasting",
+                    "Project future water demand scenarios from historical data and planning assumptions.",
+                    new[]
+                    {
+                        "Load historical demand records so baseline year and trend information can auto-populate.",
+                        "Select a scenario, adjust sector shares, and fine-tune system improvements or losses.",
+                        "Set growth assumptions (population and per-capita demand) and choose the forecast horizon."
+                    },
+                    new[]
+                    {
+                        "Produces annual demand projections for each scenario with context on growth drivers.",
+                        "Displays comparison charts and tables to highlight divergence across scenarios.",
+                        "Allows exporting to Excel with data tables and visualizations for stakeholder review."
+                    },
+                    WaterDemand,
+                    WaterDemand.ComputeCommand),
+                new ModuleDefinition(
+                    "Unit Day Value",
+                    "Calibrate recreational benefits and visitation patterns to compute annual unit day values.",
+                    new[]
+                    {
+                        "Describe the project setting, visitation characteristics, and facility quality inputs.",
+                        "Populate demand projections and adjust quality points for each recreation type.",
+                        "Review visitation splits and ensure weighting reflects expected usage."
+                    },
+                    new[]
+                    {
+                        "Calculates weighted unit day values and total annual recreational benefits.",
+                        "Highlights how quality point adjustments influence the composite value.",
+                        "Supports exporting the evaluation for integration into economic reports."
+                    },
+                    Udv,
+                    Udv.ComputeCommand),
+                new ModuleDefinition(
+                    "Mind Map Workspace",
+                    "Capture qualitative insights, organize themes, and track next steps collaboratively.",
+                    new[]
+                    {
+                        "Start with the seeded central idea or add a new root topic to frame your analysis.",
+                        "Use the toolbar to add child and sibling nodes, recording notes and owners as you go.",
+                        "Arrange nodes on the canvas and adjust zoom to communicate the story effectively."
+                    },
+                    new[]
+                    {
+                        "Maintains a navigable mind map with connection lines and breadcrumb paths.",
+                        "Supports quick export alongside other modules for project documentation.",
+                        "Provides an always-on workspace to summarize qualitative findings."
+                    },
+                    MindMap,
+                    null)
+            };
+
+            foreach (var module in Modules)
+            {
+                SubscribeToComputeCommand(module.ComputeCommand);
+            }
         }
 
         private void Calculate()
         {
-            var command = SelectedComputeCommand;
+            var command = SelectedModule?.ComputeCommand;
             if (command?.CanExecute(null) == true)
             {
                 command.Execute(null);
             }
         }
 
-        private ICommand? SelectedComputeCommand => SelectedIndex switch
+        private void SubscribeToComputeCommand(ICommand? command)
         {
-            0 => Ead.ComputeCommand,
-            1 => UpdatedCost.ComputeCommand,
-            2 => Annualizer.ComputeCommand,
-            3 => WaterDemand.ComputeCommand,
-            4 => Udv.ComputeCommand,
-            _ => null
-        };
+            if (command == null)
+            {
+                return;
+            }
 
-        private void SubscribeToComputeCommand(ICommand command)
-        {
             command.CanExecuteChanged += (_, _) => OnPropertyChanged(nameof(IsCalculateVisible));
         }
 

--- a/ViewModels/ModuleDefinition.cs
+++ b/ViewModels/ModuleDefinition.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Windows.Input;
+
+namespace EconToolbox.Desktop.ViewModels
+{
+    public class ModuleDefinition
+    {
+        public ModuleDefinition(
+            string title,
+            string description,
+            IEnumerable<string> inputSteps,
+            IEnumerable<string> outputHighlights,
+            BaseViewModel contentViewModel,
+            ICommand? computeCommand)
+        {
+            Title = title;
+            Description = description;
+            InputSteps = new ReadOnlyCollection<string>(inputSteps.ToList());
+            OutputHighlights = new ReadOnlyCollection<string>(outputHighlights.ToList());
+            ContentViewModel = contentViewModel;
+            ComputeCommand = computeCommand;
+        }
+
+        public string Title { get; }
+
+        public string Description { get; }
+
+        public IReadOnlyList<string> InputSteps { get; }
+
+        public IReadOnlyList<string> OutputHighlights { get; }
+
+        public BaseViewModel ContentViewModel { get; }
+
+        public ICommand? ComputeCommand { get; }
+    }
+}

--- a/Views/EadView.xaml
+++ b/Views/EadView.xaml
@@ -1,6 +1,7 @@
 <UserControl x:Class="EconToolbox.Desktop.Views.EadView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:behaviors="clr-namespace:EconToolbox.Desktop.Behaviors"
              xmlns:sys="clr-namespace:System;assembly=mscorlib"
              SnapsToDevicePixels="True"
              UseLayoutRounding="True">
@@ -121,12 +122,12 @@
                                 </Style.Triggers>
                             </Style>
                         </Border.Style>
-                        <DataGrid x:Name="EadDataGrid"
-                                  ItemsSource="{Binding Rows}"
+                        <DataGrid ItemsSource="{Binding Rows}"
                                   AutoGenerateColumns="False"
                                   CanUserAddRows="True"
                                   CanUserDeleteRows="True"
-                                  ScrollViewer.HorizontalScrollBarVisibility="Auto"/>
+                                  ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                                  behaviors:DataGridColumnsBehavior.ColumnsSource="{Binding ColumnDefinitions}"/>
                     </Border>
 
                     <Border Background="{StaticResource Brush.Surface}"

--- a/Views/EadView.xaml.cs
+++ b/Views/EadView.xaml.cs
@@ -1,9 +1,4 @@
-using System.Collections.Specialized;
-using System.ComponentModel;
-using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using EconToolbox.Desktop.ViewModels;
 
 namespace EconToolbox.Desktop.Views
 {
@@ -12,67 +7,6 @@ namespace EconToolbox.Desktop.Views
         public EadView()
         {
             InitializeComponent();
-            DataContextChanged += OnDataContextChanged;
-        }
-
-        private void OnDataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
-        {
-            if (e.OldValue is EadViewModel oldVm)
-            {
-                oldVm.DamageColumns.CollectionChanged -= DamageColumns_CollectionChanged;
-                oldVm.PropertyChanged -= Vm_PropertyChanged;
-            }
-            if (e.NewValue is EadViewModel vm)
-            {
-                vm.DamageColumns.CollectionChanged += DamageColumns_CollectionChanged;
-                vm.PropertyChanged += Vm_PropertyChanged;
-                RebuildColumns(vm);
-            }
-        }
-
-        private void DamageColumns_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
-        {
-            if (DataContext is EadViewModel vm)
-                RebuildColumns(vm);
-        }
-
-        private void Vm_PropertyChanged(object? sender, PropertyChangedEventArgs e)
-        {
-            if (e.PropertyName == nameof(EadViewModel.UseStage) && DataContext is EadViewModel vm)
-                RebuildColumns(vm);
-        }
-
-        private void RebuildColumns(EadViewModel vm)
-        {
-            EadDataGrid.Columns.Clear();
-            EadDataGrid.Columns.Add(new DataGridTextColumn
-            {
-                Header = "Probability",
-                Binding = new Binding("Probability")
-            });
-            if (vm.UseStage)
-            {
-                EadDataGrid.Columns.Add(new DataGridTextColumn
-                {
-                    Header = "Stage",
-                    Binding = new Binding("Stage")
-                });
-            }
-            for (int i = 0; i < vm.DamageColumns.Count; i++)
-            {
-                var headerBox = new TextBox { MinWidth = 80 };
-                BindingOperations.SetBinding(headerBox, TextBox.TextProperty, new Binding($"DamageColumns[{i}]")
-                {
-                    Source = vm,
-                    Mode = BindingMode.TwoWay,
-                    UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged
-                });
-                EadDataGrid.Columns.Add(new DataGridTextColumn
-                {
-                    Header = headerBox,
-                    Binding = new Binding($"Damages[{i}]")
-                });
-            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- drive the tabbed experience from a module definition list so hero and footer guidance reflect the active calculator
- replace the EAD data grid code-behind with a reusable column descriptor behavior to respect the MVVM pattern
- surface input instructions and output highlights directly in the main window while keeping module exports available

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cc76e2e5d8833091e54b782b8729bf