### PR TITLE
Add missing Margin.StackSmall resource

### DIFF
--- a/Themes/Design.xaml
+++ b/Themes/Design.xaml
@@ -35,6 +35,7 @@
     <Thickness x:Key="Padding.Section">20</Thickness>
     <Thickness x:Key="Padding.Content">12</Thickness>
     <Thickness x:Key="Margin.Container">16</Thickness>
+    <Thickness x:Key="Margin.StackSmall">0,0,0,4</Thickness>
     <Thickness x:Key="Margin.Stack">0,0,0,8</Thickness>
     <Thickness x:Key="Margin.StackLarge">0,0,0,16</Thickness>
     <Thickness x:Key="Margin.Inline">0,0,8,0</Thickness>


### PR DESCRIPTION
## Summary
- define the missing Margin.StackSmall thickness token in the shared design resource dictionary
- allow views referencing Margin.StackSmall to resolve correctly at runtime

## Testing
- `dotnet build` *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc7a9d64288330ab68e7a3be3f744c