### PR TITLE
Add tooltip icons for inputs and align UDV explainer styling

### DIFF
--- a/Themes/Design.xaml
+++ b/Themes/Design.xaml
@@ -176,5 +176,32 @@
         </Setter>
     </Style>
 
+    <Style x:Key="Content.InfoIcon" TargetType="ContentControl">
+        <Setter Property="Focusable" Value="False"/>
+        <Setter Property="Width" Value="20"/>
+        <Setter Property="Height" Value="20"/>
+        <Setter Property="Margin" Value="{StaticResource Margin.Inline}"/>
+        <Setter Property="Cursor" Value="Help"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="ContentControl">
+                    <Border Background="{StaticResource Brush.Primary}"
+                            CornerRadius="10"
+                            Width="{TemplateBinding Width}"
+                            Height="{TemplateBinding Height}"
+                            HorizontalAlignment="Center"
+                            VerticalAlignment="Center">
+                        <TextBlock Text="?"
+                                   Foreground="White"
+                                   FontWeight="SemiBold"
+                                   HorizontalAlignment="Center"
+                                   VerticalAlignment="Center"
+                                   FontSize="12"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
     <converters:WidthToLayoutModeConverter x:Key="WidthToLayoutModeConverter" Threshold="800"/>
 </ResourceDictionary>

--- a/Views/AnnualizerView.xaml
+++ b/Views/AnnualizerView.xaml
@@ -92,8 +92,14 @@
                       </StackPanel>
                   </Border>
 
-                  <TextBlock Grid.Row="1" Text="First Cost" Style="{StaticResource AnnualizerLabelStyle}"/>
-                  <TextBox Grid.Row="2" Text="{Binding FirstCost}" ToolTip="Initial project cost.">
+                  <TextBlock Grid.Row="1" Style="{StaticResource AnnualizerLabelStyle}">
+                      <InlineUIContainer BaselineAlignment="Center">
+                          <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                          ToolTip="Initial project cost."/>
+                      </InlineUIContainer>
+                      <Run Text="First Cost"/>
+                  </TextBlock>
+                  <TextBox Grid.Row="2" Text="{Binding FirstCost}">
                       <TextBox.Style>
                           <Style TargetType="TextBox" BasedOn="{StaticResource AnnualizerInputStyle}">
                               <Style.Triggers>
@@ -106,8 +112,14 @@
                       </TextBox.Style>
                   </TextBox>
 
-                  <TextBlock Grid.Row="3" Text="Rate (%)" Style="{StaticResource AnnualizerLabelStyle}"/>
-                  <TextBox Grid.Row="4" Text="{Binding Rate}" ToolTip="Discount rate in percent.">
+                  <TextBlock Grid.Row="3" Style="{StaticResource AnnualizerLabelStyle}">
+                      <InlineUIContainer BaselineAlignment="Center">
+                          <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                          ToolTip="Discount rate in percent."/>
+                      </InlineUIContainer>
+                      <Run Text="Rate (%)"/>
+                  </TextBlock>
+                  <TextBox Grid.Row="4" Text="{Binding Rate}">
                       <TextBox.Style>
                           <Style TargetType="TextBox" BasedOn="{StaticResource AnnualizerInputStyle}">
                               <Style.Triggers>
@@ -134,8 +146,14 @@
                       </TextBox.Style>
                   </TextBox>
 
-                  <TextBlock Grid.Row="7" Text="Analysis Period" Style="{StaticResource AnnualizerLabelStyle}"/>
-                  <TextBox Grid.Row="8" Text="{Binding AnalysisPeriod}" ToolTip="Number of periods for capital recovery.">
+                  <TextBlock Grid.Row="7" Style="{StaticResource AnnualizerLabelStyle}">
+                      <InlineUIContainer BaselineAlignment="Center">
+                          <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                          ToolTip="Number of periods for capital recovery."/>
+                      </InlineUIContainer>
+                      <Run Text="Analysis Period"/>
+                  </TextBlock>
+                  <TextBox Grid.Row="8" Text="{Binding AnalysisPeriod}">
                       <TextBox.Style>
                           <Style TargetType="TextBox" BasedOn="{StaticResource AnnualizerInputStyle}">
                               <Style.Triggers>
@@ -148,8 +166,14 @@
                       </TextBox.Style>
                   </TextBox>
 
-                  <TextBlock Grid.Row="9" Text="Annual O&amp;M" Style="{StaticResource AnnualizerLabelStyle}"/>
-                  <TextBox Grid.Row="10" Text="{Binding AnnualOm}" ToolTip="Annual operations and maintenance cost.">
+                  <TextBlock Grid.Row="9" Style="{StaticResource AnnualizerLabelStyle}">
+                      <InlineUIContainer BaselineAlignment="Center">
+                          <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                          ToolTip="Annual operations and maintenance cost."/>
+                      </InlineUIContainer>
+                      <Run Text="Annual O&amp;M"/>
+                  </TextBlock>
+                  <TextBox Grid.Row="10" Text="{Binding AnnualOm}">
                       <TextBox.Style>
                           <Style TargetType="TextBox" BasedOn="{StaticResource AnnualizerInputStyle}">
                               <Style.Triggers>
@@ -162,8 +186,14 @@
                       </TextBox.Style>
                   </TextBox>
 
-                  <TextBlock Grid.Row="11" Text="Annual Benefits" Style="{StaticResource AnnualizerLabelStyle}"/>
-                  <TextBox Grid.Row="12" Text="{Binding AnnualBenefits}" ToolTip="Expected annual benefits.">
+                  <TextBlock Grid.Row="11" Style="{StaticResource AnnualizerLabelStyle}">
+                      <InlineUIContainer BaselineAlignment="Center">
+                          <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                          ToolTip="Expected annual benefits."/>
+                      </InlineUIContainer>
+                      <Run Text="Annual Benefits"/>
+                  </TextBlock>
+                  <TextBox Grid.Row="12" Text="{Binding AnnualBenefits}">
                       <TextBox.Style>
                           <Style TargetType="TextBox" BasedOn="{StaticResource AnnualizerInputStyle}">
                               <Style.Triggers>

--- a/Views/UdvView.xaml
+++ b/Views/UdvView.xaml
@@ -13,7 +13,7 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
-        <Border Grid.Row="0" Background="#FFF4F7" BorderBrush="#E8A6B8" BorderThickness="1" CornerRadius="10" Padding="12" Margin="{StaticResource Margin.Stack}">
+        <Border Grid.Row="0" Style="{StaticResource Border.Explainer}">
             <StackPanel>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <Viewbox Width="28" Height="28" Margin="{StaticResource Margin.Inline}">


### PR DESCRIPTION
## Summary
- add a reusable tooltip icon style to surface circled question mark glyphs
- show the info icon next to annualizer input labels and move the tooltips onto the icon
- switch the UDV overview border to the shared explainer style so it matches other tabs

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cc7e062ed083308fb5f04564d15bd9