### PR TITLE
Set application icon

### DIFF
--- a/EconToolbox.Desktop.csproj
+++ b/EconToolbox.Desktop.csproj
@@ -5,7 +5,11 @@
     <UseWPF>true</UseWPF>
     <Nullable>enable</Nullable>
     <ApplicationManifest>app.manifest</ApplicationManifest>
+    <ApplicationIcon>Pixstle.ico</ApplicationIcon>
   </PropertyGroup>
+  <ItemGroup>
+    <Resource Include="Pixstle.ico" />
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ClosedXML" Version="0.104.0" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- configure the WPF project to use the Pixstle.ico asset as the application icon
- include the icon file as a project resource so it is embedded in the build output

## Testing
- `dotnet build` *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc815442b08330a782c10e2f6e1b03