### PR TITLE
Add informational tooltips across all input surfaces

### DIFF
--- a/Behaviors/DataGridColumnDescriptor.cs
+++ b/Behaviors/DataGridColumnDescriptor.cs
@@ -40,6 +40,8 @@ namespace EconToolbox.Desktop.Behaviors
 
         public bool IsHeaderEditable { get; init; }
 
+        public string? ToolTip { get; init; }
+
         public event PropertyChangedEventHandler? PropertyChanged;
 
         protected virtual void OnPropertyChanged(string propertyName)

--- a/Behaviors/DataGridColumnsBehavior.cs
+++ b/Behaviors/DataGridColumnsBehavior.cs
@@ -184,6 +184,8 @@ namespace EconToolbox.Desktop.Behaviors
 
             private static object CreateHeader(DataGridColumnDescriptor descriptor)
             {
+                FrameworkElement headerElement;
+
                 if (descriptor.HeaderContext != null && !string.IsNullOrWhiteSpace(descriptor.HeaderBindingPath))
                 {
                     if (descriptor.IsHeaderEditable)
@@ -195,7 +197,8 @@ namespace EconToolbox.Desktop.Behaviors
                             MinWidth = descriptor.MinWidth ?? 80,
                             HorizontalAlignment = HorizontalAlignment.Stretch,
                             BorderThickness = new Thickness(0),
-                            Background = System.Windows.Media.Brushes.Transparent
+                            Background = System.Windows.Media.Brushes.Transparent,
+                            VerticalAlignment = VerticalAlignment.Center
                         };
 
                         headerBox.SetBinding(TextBox.TextProperty, new Binding(descriptor.HeaderBindingPath)
@@ -204,21 +207,64 @@ namespace EconToolbox.Desktop.Behaviors
                             UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged
                         });
 
-                        return headerBox;
+                        headerElement = headerBox;
                     }
-
-                    var headerText = new TextBlock
+                    else
                     {
-                        DataContext = descriptor.HeaderContext,
-                        Margin = new Thickness(0),
-                        TextTrimming = TextTrimming.CharacterEllipsis
-                    };
+                        var headerText = new TextBlock
+                        {
+                            DataContext = descriptor.HeaderContext,
+                            Margin = new Thickness(0),
+                            TextTrimming = TextTrimming.CharacterEllipsis,
+                            VerticalAlignment = VerticalAlignment.Center
+                        };
 
-                    headerText.SetBinding(TextBlock.TextProperty, new Binding(descriptor.HeaderBindingPath));
-                    return headerText;
+                        headerText.SetBinding(TextBlock.TextProperty, new Binding(descriptor.HeaderBindingPath));
+                        headerElement = headerText;
+                    }
+                }
+                else
+                {
+                    headerElement = new TextBlock
+                    {
+                        Text = descriptor.HeaderText ?? descriptor.BindingPath,
+                        Margin = new Thickness(0),
+                        TextTrimming = TextTrimming.CharacterEllipsis,
+                        VerticalAlignment = VerticalAlignment.Center
+                    };
                 }
 
-                return descriptor.HeaderText ?? descriptor.BindingPath;
+                if (!string.IsNullOrWhiteSpace(descriptor.ToolTip))
+                {
+                    var panel = new StackPanel
+                    {
+                        Orientation = Orientation.Horizontal,
+                        VerticalAlignment = VerticalAlignment.Center
+                    };
+
+                    var icon = new ContentControl
+                    {
+                        ToolTip = descriptor.ToolTip,
+                        VerticalAlignment = VerticalAlignment.Center
+                    };
+
+                    if (Application.Current?.TryFindResource("Content.InfoIcon") is Style iconStyle)
+                    {
+                        icon.Style = iconStyle;
+                    }
+
+                    panel.Children.Add(icon);
+
+                    if (headerElement.Margin.Left < 4)
+                    {
+                        headerElement.Margin = new Thickness(4, headerElement.Margin.Top, headerElement.Margin.Right, headerElement.Margin.Bottom);
+                    }
+
+                    panel.Children.Add(headerElement);
+                    return panel;
+                }
+
+                return headerElement;
             }
         }
     }

--- a/ViewModels/EadViewModel.cs
+++ b/ViewModels/EadViewModel.cs
@@ -263,7 +263,8 @@ namespace EconToolbox.Desktop.ViewModels
             ColumnDefinitions.Add(new DataGridColumnDescriptor(nameof(EadRow.Probability))
             {
                 HeaderText = "Probability",
-                MinWidth = 120
+                MinWidth = 120,
+                ToolTip = "Exceedance probability for the row of damage and stage inputs."
             });
 
             if (UseStage)
@@ -271,7 +272,8 @@ namespace EconToolbox.Desktop.ViewModels
                 ColumnDefinitions.Add(new DataGridColumnDescriptor(nameof(EadRow.Stage))
                 {
                     HeaderText = "Stage",
-                    MinWidth = 120
+                    MinWidth = 120,
+                    ToolTip = "Water surface elevation or stage aligned with the probability."
                 });
             }
 
@@ -282,7 +284,8 @@ namespace EconToolbox.Desktop.ViewModels
                     HeaderContext = DamageColumns[i],
                     HeaderBindingPath = nameof(DamageColumn.Name),
                     IsHeaderEditable = true,
-                    MinWidth = 140
+                    MinWidth = 140,
+                    ToolTip = "Damage amount for this category at the selected probability."
                 });
             }
         }

--- a/Views/AnnualizerView.xaml
+++ b/Views/AnnualizerView.xaml
@@ -132,7 +132,13 @@
                       </TextBox.Style>
                   </TextBox>
 
-                  <TextBlock Grid.Row="5" Text="Base Year" Style="{StaticResource AnnualizerLabelStyle}"/>
+                  <TextBlock Grid.Row="5" Style="{StaticResource AnnualizerLabelStyle}">
+                      <InlineUIContainer BaselineAlignment="Center">
+                          <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                          ToolTip="Reference year that anchors discounting for future costs and benefits."/>
+                      </InlineUIContainer>
+                      <Run Text="Base Year"/>
+                  </TextBlock>
                   <TextBox Grid.Row="6" Text="{Binding BaseYear}">
                       <TextBox.Style>
                           <Style TargetType="TextBox" BasedOn="{StaticResource AnnualizerInputStyle}">
@@ -206,7 +212,13 @@
                       </TextBox.Style>
                   </TextBox>
 
-                  <TextBlock Grid.Row="13" Text="Construction Months" Style="{StaticResource AnnualizerLabelStyle}"/>
+                  <TextBlock Grid.Row="13" Style="{StaticResource AnnualizerLabelStyle}">
+                      <InlineUIContainer BaselineAlignment="Center">
+                          <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                          ToolTip="Total construction duration in months used to accumulate IDC."/>
+                      </InlineUIContainer>
+                      <Run Text="Construction Months"/>
+                  </TextBlock>
                   <TextBox Grid.Row="14" Text="{Binding ConstructionMonths}">
                       <TextBox.Style>
                           <Style TargetType="TextBox" BasedOn="{StaticResource AnnualizerInputStyle}">
@@ -220,7 +232,7 @@
                       </TextBox.Style>
                   </TextBox>
 
-                  <TextBlock Grid.Row="15" Text="IDC Schedule">
+                  <TextBlock Grid.Row="15">
                       <TextBlock.Style>
                           <Style TargetType="TextBlock" BasedOn="{StaticResource AnnualizerLabelStyle}">
                               <Setter Property="Margin" Value="0,24,12,4"/>
@@ -232,6 +244,11 @@
                               </Style.Triggers>
                           </Style>
                       </TextBlock.Style>
+                      <InlineUIContainer BaselineAlignment="Center">
+                          <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                          ToolTip="List construction outlays by month and timing so the tool can compute interest during construction."/>
+                      </InlineUIContainer>
+                      <Run Text="IDC Schedule"/>
                   </TextBlock>
                   <Grid Grid.Row="16">
                       <Grid.Style>
@@ -251,9 +268,32 @@
                       <Border Background="White" BorderBrush="{StaticResource Brush.Border}" BorderThickness="1" CornerRadius="6" Padding="6">
                           <DataGrid ItemsSource="{Binding IdcEntries}" AutoGenerateColumns="False" Margin="0" HeadersVisibility="All">
                               <DataGrid.Columns>
-                                  <DataGridTextColumn Header="Cost" Binding="{Binding Cost}"/>
-                                  <DataGridTextColumn Header="Month" Binding="{Binding Year}"/>
-                                  <DataGridComboBoxColumn Header="Timing" SelectedItemBinding="{Binding Timing}">
+                                  <DataGridTextColumn Binding="{Binding Cost}">
+                                      <DataGridTextColumn.Header>
+                                          <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                              <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                                              ToolTip="Amount of capital spent in the specified month."/>
+                                              <TextBlock Text="Cost" Margin="4,0,0,0" VerticalAlignment="Center"/>
+                                          </StackPanel>
+                                      </DataGridTextColumn.Header>
+                                  </DataGridTextColumn>
+                                  <DataGridTextColumn Binding="{Binding Year}">
+                                      <DataGridTextColumn.Header>
+                                          <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                              <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                                              ToolTip="Construction month when the cost occurs, starting at 1."/>
+                                              <TextBlock Text="Month" Margin="4,0,0,0" VerticalAlignment="Center"/>
+                                          </StackPanel>
+                                      </DataGridTextColumn.Header>
+                                  </DataGridTextColumn>
+                                  <DataGridComboBoxColumn SelectedItemBinding="{Binding Timing}">
+                                      <DataGridComboBoxColumn.Header>
+                                          <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                              <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                                              ToolTip="Select whether the cost hits at the beginning, midpoint, or end of the month."/>
+                                              <TextBlock Text="Timing" Margin="4,0,0,0" VerticalAlignment="Center"/>
+                                          </StackPanel>
+                                      </DataGridComboBoxColumn.Header>
                                       <DataGridComboBoxColumn.ItemsSource>
                                           <x:Array Type="sys:String" xmlns:sys="clr-namespace:System;assembly=mscorlib">
                                               <sys:String>beginning</sys:String>
@@ -276,7 +316,7 @@
                       </StackPanel>
                   </Grid>
 
-                  <TextBlock Grid.Row="17" Text="Future Costs">
+                  <TextBlock Grid.Row="17">
                       <TextBlock.Style>
                           <Style TargetType="TextBlock" BasedOn="{StaticResource AnnualizerLabelStyle}">
                               <Setter Property="Margin" Value="0,24,12,4"/>
@@ -288,6 +328,11 @@
                               </Style.Triggers>
                           </Style>
                       </TextBlock.Style>
+                      <InlineUIContainer BaselineAlignment="Center">
+                          <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                          ToolTip="Add future capital expenses in the year and timing they occur to include their present value."/>
+                      </InlineUIContainer>
+                      <Run Text="Future Costs"/>
                   </TextBlock>
                   <Grid Grid.Row="18">
                       <Grid.Style>
@@ -307,9 +352,32 @@
                       <Border Background="White" BorderBrush="{StaticResource Brush.Border}" BorderThickness="1" CornerRadius="6" Padding="6">
                           <DataGrid ItemsSource="{Binding FutureCosts}" AutoGenerateColumns="False" Margin="0">
                               <DataGrid.Columns>
-                                  <DataGridTextColumn Header="Cost" Binding="{Binding Cost}"/>
-                                  <DataGridTextColumn Header="Year" Binding="{Binding Year}"/>
-                                  <DataGridComboBoxColumn Header="Timing" SelectedItemBinding="{Binding Timing}">
+                                  <DataGridTextColumn Binding="{Binding Cost}">
+                                      <DataGridTextColumn.Header>
+                                          <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                              <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                                              ToolTip="Future cost amount entered in nominal dollars."/>
+                                              <TextBlock Text="Cost" Margin="4,0,0,0" VerticalAlignment="Center"/>
+                                          </StackPanel>
+                                      </DataGridTextColumn.Header>
+                                  </DataGridTextColumn>
+                                  <DataGridTextColumn Binding="{Binding Year}">
+                                      <DataGridTextColumn.Header>
+                                          <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                              <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                                              ToolTip="Calendar year when the future cost will be incurred."/>
+                                              <TextBlock Text="Year" Margin="4,0,0,0" VerticalAlignment="Center"/>
+                                          </StackPanel>
+                                      </DataGridTextColumn.Header>
+                                  </DataGridTextColumn>
+                                  <DataGridComboBoxColumn SelectedItemBinding="{Binding Timing}">
+                                      <DataGridComboBoxColumn.Header>
+                                          <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                              <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                                              ToolTip="Timing within the year to align present value factors."/>
+                                              <TextBlock Text="Timing" Margin="4,0,0,0" VerticalAlignment="Center"/>
+                                          </StackPanel>
+                                      </DataGridComboBoxColumn.Header>
                                       <DataGridComboBoxColumn.ItemsSource>
                                           <x:Array Type="sys:String" xmlns:sys="clr-namespace:System;assembly=mscorlib">
                                               <sys:String>beginning</sys:String>

--- a/Views/EadView.xaml
+++ b/Views/EadView.xaml
@@ -74,10 +74,15 @@
                             <TextBlock Text="Remove Damage Column"/>
                         </StackPanel>
                     </Button>
-                    <CheckBox Content="Include Stage"
-                              IsChecked="{Binding UseStage}"
+                    <CheckBox IsChecked="{Binding UseStage}"
                               VerticalAlignment="Center"
-                              Margin="{StaticResource Margin.Inline}"/>
+                              Margin="{StaticResource Margin.Inline}">
+                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                            <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                            ToolTip="Toggle to add a stage column so you can enter paired stage values."/>
+                            <TextBlock Text="Include Stage" Margin="4,0,0,0" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </CheckBox>
                     <Button Command="{Binding ComputeCommand}" Margin="{StaticResource Margin.Inline}">
                         <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
                             <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Margin="{StaticResource Margin.Inline}"/>

--- a/Views/MindMapView.xaml
+++ b/Views/MindMapView.xaml
@@ -113,9 +113,14 @@
                         <StackPanel Orientation="Horizontal"
                                     Margin="0,10,0,0"
                                     VerticalAlignment="Center">
-                            <TextBlock Text="Zoom"
-                                       VerticalAlignment="Center"
-                                       Foreground="{StaticResource Brush.TextSecondary}"/>
+                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                                ToolTip="Adjust to zoom the canvas in or out."/>
+                                <TextBlock Text="Zoom"
+                                           Margin="4,0,0,0"
+                                           VerticalAlignment="Center"
+                                           Foreground="{StaticResource Brush.TextSecondary}"/>
+                            </StackPanel>
                             <Slider Width="160"
                                     Margin="10,0,0,0"
                                     Minimum="{Binding ZoomLevelMinimum}"
@@ -125,7 +130,8 @@
                                     IsSnapToTickEnabled="False"
                                     SmallChange="0.05"
                                     LargeChange="0.2"
-                                    VerticalAlignment="Center"/>
+                                    VerticalAlignment="Center"
+                                    ToolTip="Drag to change the zoom level of the mind map."/>
                             <TextBlock Text="{Binding ZoomLevel, StringFormat={}{0:P0}}"
                                        Margin="10,0,0,0"
                                        FontWeight="SemiBold"
@@ -358,14 +364,26 @@
                                     </Grid.RowDefinitions>
 
                                     <StackPanel Grid.Row="0" Margin="0,0,0,16">
-                                        <TextBlock Text="Idea Title" FontWeight="SemiBold"/>
+                                        <TextBlock FontWeight="SemiBold">
+                                            <InlineUIContainer BaselineAlignment="Center">
+                                                <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                                                ToolTip="Name this idea or topic as it should appear on the map."/>
+                                            </InlineUIContainer>
+                                            <Run Text="Idea Title"/>
+                                        </TextBlock>
                                         <TextBox Text="{Binding Title, UpdateSourceTrigger=PropertyChanged}"
                                                  Margin="0,6,0,0"
                                                  MinHeight="28"/>
                                     </StackPanel>
 
                                     <StackPanel Grid.Row="1" Margin="0,0,0,16">
-                                        <TextBlock Text="Key Points / Notes" FontWeight="SemiBold"/>
+                                        <TextBlock FontWeight="SemiBold">
+                                            <InlineUIContainer BaselineAlignment="Center">
+                                                <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                                                ToolTip="Capture supporting notes, context, or actions for the selected idea."/>
+                                            </InlineUIContainer>
+                                            <Run Text="Key Points / Notes"/>
+                                        </TextBlock>
                                         <TextBox Text="{Binding Notes, UpdateSourceTrigger=PropertyChanged}"
                                                  Margin="0,6,0,0"
                                                  AcceptsReturn="True"

--- a/Views/UdvView.xaml
+++ b/Views/UdvView.xaml
@@ -46,8 +46,26 @@
                     </Style.Triggers>
                 </Style>
             </StackPanel.Style>
-            <ComboBox ItemsSource="{Binding RecreationTypes}" SelectedItem="{Binding RecreationType}" MinWidth="150" Margin="{StaticResource Margin.Inline}"/>
-            <ComboBox ItemsSource="{Binding ActivityTypes}" SelectedItem="{Binding ActivityType}" MinWidth="200"/>
+            <StackPanel Margin="{StaticResource Margin.Inline}">
+                <TextBlock>
+                    <InlineUIContainer BaselineAlignment="Center">
+                        <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                        ToolTip="Choose the overall recreation classification to filter available activity point tables."/>
+                    </InlineUIContainer>
+                    <Run Text="Recreation Type"/>
+                </TextBlock>
+                <ComboBox ItemsSource="{Binding RecreationTypes}" SelectedItem="{Binding RecreationType}" MinWidth="150"/>
+            </StackPanel>
+            <StackPanel Margin="{StaticResource Margin.Inline}">
+                <TextBlock>
+                    <InlineUIContainer BaselineAlignment="Center">
+                        <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                        ToolTip="Select the specific activity that matches your study to retrieve the proper unit day scale."/>
+                    </InlineUIContainer>
+                    <Run Text="Activity Type"/>
+                </TextBlock>
+                <ComboBox ItemsSource="{Binding ActivityTypes}" SelectedItem="{Binding ActivityType}" MinWidth="200"/>
+            </StackPanel>
         </StackPanel>
         <StackPanel Orientation="Horizontal" Grid.Row="2" Margin="{StaticResource Margin.Stack}">
             <StackPanel.Style>
@@ -63,7 +81,11 @@
                 </Style>
             </StackPanel.Style>
             <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Foreground="{StaticResource Brush.Primary}" Margin="{StaticResource Margin.Inline}" VerticalAlignment="Center"/>
-            <TextBlock Text="Points" VerticalAlignment="Center" Margin="{StaticResource Margin.Inline}"/>
+            <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="{StaticResource Margin.Inline}">
+                <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                ToolTip="Enter the point score from the Unit Day Value table that reflects recreation quality."/>
+                <TextBlock Text="Points" Margin="4,0,0,0" VerticalAlignment="Center"/>
+            </StackPanel>
             <TextBox Text="{Binding Points}" Width="60" Margin="{StaticResource Margin.InlineMedium}"/>
             <TextBlock Text="Unit Day Value" VerticalAlignment="Center" Margin="{StaticResource Margin.Inline}"/>
             <TextBlock Text="{Binding UnitDayValue, StringFormat={}{0:F2}}" VerticalAlignment="Center" FontWeight="SemiBold"/>
@@ -83,9 +105,17 @@
                 </Style>
             </StackPanel.Style>
             <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Foreground="{StaticResource Brush.Primary}" Margin="{StaticResource Margin.Inline}" VerticalAlignment="Center"/>
-            <TextBlock Text="Annual User Days" VerticalAlignment="Center" Margin="{StaticResource Margin.Inline}"/>
+            <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="{StaticResource Margin.Inline}">
+                <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                ToolTip="Provide the total projected recreation user days per year for the study area."/>
+                <TextBlock Text="Annual User Days" Margin="4,0,0,0" VerticalAlignment="Center"/>
+            </StackPanel>
             <TextBox Text="{Binding UserDays}" Width="80" Margin="{StaticResource Margin.InlineMedium}"/>
-            <TextBlock Text="Visitation" VerticalAlignment="Center" Margin="{StaticResource Margin.Inline}"/>
+            <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="{StaticResource Margin.Inline}">
+                <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                ToolTip="Fraction of total user days attributable to the plan or alternative being valued."/>
+                <TextBlock Text="Visitation" Margin="4,0,0,0" VerticalAlignment="Center"/>
+            </StackPanel>
             <TextBox Text="{Binding Visitation}" Width="60" Margin="{StaticResource Margin.InlineMedium}"/>
             <Button Command="{Binding ComputeCommand}">
                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">

--- a/Views/UpdatedCostView.xaml
+++ b/Views/UpdatedCostView.xaml
@@ -119,9 +119,21 @@
                         <ColumnDefinition Width="Auto"/>
                         <ColumnDefinition Width="*"/>
                     </Grid.ColumnDefinitions>
-                    <TextBlock Text="Total Usable Storage" Margin="0,0,5,5"/>
+                    <TextBlock Margin="0,0,5,5">
+                        <InlineUIContainer BaselineAlignment="Center">
+                            <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                            ToolTip="Enter the system's total usable storage before any plan allocation."/>
+                        </InlineUIContainer>
+                        <Run Text="Total Usable Storage"/>
+                    </TextBlock>
                     <TextBox Text="{Binding TotalStorage}" Grid.Column="1" Margin="0,0,0,5"/>
-                    <TextBlock Text="Storage Recommendation" Grid.Row="1" Margin="0,0,5,5"/>
+                    <TextBlock Grid.Row="1" Margin="0,0,5,5">
+                        <InlineUIContainer BaselineAlignment="Center">
+                            <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                            ToolTip="Recommended portion of the joint storage allocated to this alternative."/>
+                        </InlineUIContainer>
+                        <Run Text="Storage Recommendation"/>
+                    </TextBlock>
                     <TextBox Text="{Binding StorageRecommendation}" Grid.Row="1" Grid.Column="1" Margin="0,0,0,5"/>
                     <Button Command="{Binding ComputeStorageCommand}" Grid.Row="2" Grid.ColumnSpan="2" Margin="0,5,0,5">
                         <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
@@ -168,9 +180,21 @@
                         <ColumnDefinition Width="Auto"/>
                         <ColumnDefinition Width="*"/>
                     </Grid.ColumnDefinitions>
-                    <TextBlock Text="Joint Operations Cost" Margin="0,0,5,5"/>
+                    <TextBlock Margin="0,0,5,5">
+                        <InlineUIContainer BaselineAlignment="Center">
+                            <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                            ToolTip="Annual system-wide joint operations expense before scaling."/>
+                        </InlineUIContainer>
+                        <Run Text="Joint Operations Cost"/>
+                    </TextBlock>
                     <TextBox Text="{Binding JointOperationsCost}" Grid.Column="1" Margin="0,0,0,5"/>
-                    <TextBlock Text="Joint Maintenance Cost" Grid.Row="1" Margin="0,0,5,5"/>
+                    <TextBlock Grid.Row="1" Margin="0,0,5,5">
+                        <InlineUIContainer BaselineAlignment="Center">
+                            <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                            ToolTip="Annual joint maintenance expense for the entire system."/>
+                        </InlineUIContainer>
+                        <Run Text="Joint Maintenance Cost"/>
+                    </TextBlock>
                     <TextBox Text="{Binding JointMaintenanceCost}" Grid.Row="1" Grid.Column="1" Margin="0,0,0,5"/>
                     <Button Grid.Row="2" Grid.ColumnSpan="2" Margin="0,5,0,5" Command="{Binding ComputeJointCommand}">
                         <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
@@ -208,9 +232,33 @@
                 </Border>
                 <DataGrid ItemsSource="{Binding UpdatedCostItems}" AutoGenerateColumns="False" Height="160" Margin="0,10,0,5" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto">
                     <DataGrid.Columns>
-                        <DataGridTextColumn Header="Category" Binding="{Binding Category}"/>
-                        <DataGridTextColumn Header="Actual Cost" Binding="{Binding ActualCost}"/>
-                        <DataGridTextColumn Header="Update Factor" Binding="{Binding UpdateFactor}"/>
+                        <DataGridTextColumn Binding="{Binding Category}">
+                            <DataGridTextColumn.Header>
+                                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                    <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                                    ToolTip="Name or description of the cost item being escalated."/>
+                                    <TextBlock Text="Category" Margin="4,0,0,0" VerticalAlignment="Center"/>
+                                </StackPanel>
+                            </DataGridTextColumn.Header>
+                        </DataGridTextColumn>
+                        <DataGridTextColumn Binding="{Binding ActualCost}">
+                            <DataGridTextColumn.Header>
+                                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                    <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                                    ToolTip="Original cost expressed in the historical price level."/>
+                                    <TextBlock Text="Actual Cost" Margin="4,0,0,0" VerticalAlignment="Center"/>
+                                </StackPanel>
+                            </DataGridTextColumn.Header>
+                        </DataGridTextColumn>
+                        <DataGridTextColumn Binding="{Binding UpdateFactor}">
+                            <DataGridTextColumn.Header>
+                                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                    <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                                    ToolTip="Escalation factor (e.g., CWCCI ratio) applied to the actual cost."/>
+                                    <TextBlock Text="Update Factor" Margin="4,0,0,0" VerticalAlignment="Center"/>
+                                </StackPanel>
+                            </DataGridTextColumn.Header>
+                        </DataGridTextColumn>
                         <DataGridTextColumn Header="Updated Cost" Binding="{Binding UpdatedCost}" IsReadOnly="True"/>
                     </DataGrid.Columns>
                 </DataGrid>
@@ -263,19 +311,67 @@
                         <ColumnDefinition Width="Auto"/>
                         <ColumnDefinition Width="*"/>
                     </Grid.ColumnDefinitions>
-                    <TextBlock Text="Federal Discount Rate (%)" Margin="0,0,5,5"/>
+                    <TextBlock Margin="0,0,5,5">
+                        <InlineUIContainer BaselineAlignment="Center">
+                            <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                            ToolTip="Real federal discount rate applied to future RR&amp;R and mitigation costs."/>
+                        </InlineUIContainer>
+                        <Run Text="Federal Discount Rate (%)"/>
+                    </TextBlock>
                     <TextBox Text="{Binding RrrRate}" Grid.Column="1" Margin="0,0,0,5"/>
-                    <TextBlock Text="Analysis Years" Grid.Row="1" Margin="0,0,5,5"/>
+                    <TextBlock Grid.Row="1" Margin="0,0,5,5">
+                        <InlineUIContainer BaselineAlignment="Center">
+                            <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                            ToolTip="Number of years used when discounting recurring RR&amp;R and mitigation items."/>
+                        </InlineUIContainer>
+                        <Run Text="Analysis Years"/>
+                    </TextBlock>
                     <TextBox Text="{Binding RrrPeriods}" Grid.Row="1" Grid.Column="1" Margin="0,0,0,5"/>
-                    <TextBlock Text="CWCCI" Grid.Row="2" Margin="0,0,5,5"/>
+                    <TextBlock Grid.Row="2" Margin="0,0,5,5">
+                        <InlineUIContainer BaselineAlignment="Center">
+                            <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                            ToolTip="Civil Works Construction Cost Index factor applied after discounting."/>
+                        </InlineUIContainer>
+                        <Run Text="CWCCI"/>
+                    </TextBlock>
                     <TextBox Text="{Binding RrrCwcci}" Grid.Row="2" Grid.Column="1" Margin="0,0,0,5"/>
-                    <TextBlock Text="Base Year" Grid.Row="3" Margin="0,0,5,5"/>
+                    <TextBlock Grid.Row="3" Margin="0,0,5,5">
+                        <InlineUIContainer BaselineAlignment="Center">
+                            <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                            ToolTip="Reference year to which all RR&amp;R and mitigation costs are discounted."/>
+                        </InlineUIContainer>
+                        <Run Text="Base Year"/>
+                    </TextBlock>
                     <TextBox Text="{Binding RrrBaseYear}" Grid.Row="3" Grid.Column="1" Margin="0,0,0,5"/>
                     <DataGrid ItemsSource="{Binding RrrCostItems}" AutoGenerateColumns="False" Grid.Row="4" Grid.ColumnSpan="2" Height="150" Margin="0,0,0,5" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto">
                         <DataGrid.Columns>
-                            <DataGridTextColumn Header="Item" Binding="{Binding Item}"/>
-                            <DataGridTextColumn Header="Future Cost" Binding="{Binding FutureCost}"/>
-                            <DataGridTextColumn Header="Year" Binding="{Binding Year}"/>
+                            <DataGridTextColumn Binding="{Binding Item}">
+                                <DataGridTextColumn.Header>
+                                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                        <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                                        ToolTip="Name of the repair, replacement, rehabilitation, or mitigation activity."/>
+                                        <TextBlock Text="Item" Margin="4,0,0,0" VerticalAlignment="Center"/>
+                                    </StackPanel>
+                                </DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding FutureCost}">
+                                <DataGridTextColumn.Header>
+                                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                        <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                                        ToolTip="Cost of the activity stated in the year it occurs."/>
+                                        <TextBlock Text="Future Cost" Margin="4,0,0,0" VerticalAlignment="Center"/>
+                                    </StackPanel>
+                                </DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding Year}">
+                                <DataGridTextColumn.Header>
+                                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                        <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                                        ToolTip="Calendar year when the activity is scheduled."/>
+                                        <TextBlock Text="Year" Margin="4,0,0,0" VerticalAlignment="Center"/>
+                                    </StackPanel>
+                                </DataGridTextColumn.Header>
+                            </DataGridTextColumn>
                             <DataGridTextColumn Header="PV Factor" Binding="{Binding PvFactor}" IsReadOnly="True"/>
                             <DataGridTextColumn Header="Present Value" Binding="{Binding PresentValue}" IsReadOnly="True"/>
                         </DataGrid.Columns>
@@ -330,13 +426,37 @@
                         <ColumnDefinition Width="Auto"/>
                         <ColumnDefinition Width="*"/>
                     </Grid.ColumnDefinitions>
-                    <TextBlock Text="Discount Rate 1 (%)" Margin="0,0,5,5"/>
+                    <TextBlock Margin="0,0,5,5">
+                        <InlineUIContainer BaselineAlignment="Center">
+                            <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                            ToolTip="Discount rate used for the first annualization scenario."/>
+                        </InlineUIContainer>
+                        <Run Text="Discount Rate 1 (%)"/>
+                    </TextBlock>
                     <TextBox Text="{Binding DiscountRate1}" Grid.Column="1" Margin="0,0,0,5"/>
-                    <TextBlock Text="Analysis Period 1" Grid.Row="1" Margin="0,0,5,5"/>
+                    <TextBlock Grid.Row="1" Margin="0,0,5,5">
+                        <InlineUIContainer BaselineAlignment="Center">
+                            <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                            ToolTip="Number of years in the first capital recovery scenario."/>
+                        </InlineUIContainer>
+                        <Run Text="Analysis Period 1"/>
+                    </TextBlock>
                     <TextBox Text="{Binding AnalysisPeriod1}" Grid.Row="1" Grid.Column="1" Margin="0,0,0,5"/>
-                    <TextBlock Text="Discount Rate 2 (%)" Grid.Row="2" Margin="0,0,5,5"/>
+                    <TextBlock Grid.Row="2" Margin="0,0,5,5">
+                        <InlineUIContainer BaselineAlignment="Center">
+                            <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                            ToolTip="Discount rate for the second comparison scenario."/>
+                        </InlineUIContainer>
+                        <Run Text="Discount Rate 2 (%)"/>
+                    </TextBlock>
                     <TextBox Text="{Binding DiscountRate2}" Grid.Row="2" Grid.Column="1" Margin="0,0,0,5"/>
-                    <TextBlock Text="Analysis Period 2" Grid.Row="3" Margin="0,0,5,5"/>
+                    <TextBlock Grid.Row="3" Margin="0,0,5,5">
+                        <InlineUIContainer BaselineAlignment="Center">
+                            <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                            ToolTip="Years covered by the second capital recovery scenario."/>
+                        </InlineUIContainer>
+                        <Run Text="Analysis Period 2"/>
+                    </TextBlock>
                     <TextBox Text="{Binding AnalysisPeriod2}" Grid.Row="3" Grid.Column="1" Margin="0,0,0,5"/>
                     <Button Grid.Row="4" Grid.ColumnSpan="2" Margin="0,5,0,5" Command="{Binding ComputeTotalCommand}">
                         <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">

--- a/Views/WaterDemandView.xaml
+++ b/Views/WaterDemandView.xaml
@@ -60,8 +60,24 @@
                                 <Border Grid.Row="0" Background="White" CornerRadius="4" Padding="5" Margin="0,0,0,5">
                                     <DataGrid ItemsSource="{Binding DataContext.HistoricalData, ElementName=Root}" AutoGenerateColumns="False" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" ScrollViewer.VerticalScrollBarVisibility="Auto" ScrollViewer.HorizontalScrollBarVisibility="Auto">
                                         <DataGrid.Columns>
-                                            <DataGridTextColumn Header="Year" Binding="{Binding Year}"/>
-                                            <DataGridTextColumn Header="Demand per Capita" Binding="{Binding Demand}"/>
+                                            <DataGridTextColumn Binding="{Binding Year}">
+                                                <DataGridTextColumn.Header>
+                                                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                                        <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                                                        ToolTip="Historical observation year for the demand record."/>
+                                                        <TextBlock Text="Year" Margin="4,0,0,0" VerticalAlignment="Center"/>
+                                                    </StackPanel>
+                                                </DataGridTextColumn.Header>
+                                            </DataGridTextColumn>
+                                            <DataGridTextColumn Binding="{Binding Demand}">
+                                                <DataGridTextColumn.Header>
+                                                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                                        <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                                                        ToolTip="Recorded water demand per capita for the listed year."/>
+                                                        <TextBlock Text="Demand per Capita" Margin="4,0,0,0" VerticalAlignment="Center"/>
+                                                    </StackPanel>
+                                                </DataGridTextColumn.Header>
+                                            </DataGridTextColumn>
                                         </DataGrid.Columns>
                                     </DataGrid>
                                 </Border>
@@ -90,45 +106,105 @@
                                         </Style>
                                     </Grid.Resources>
 
-                                    <TextBlock Text="Forecast Years" Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                                    <TextBlock Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0">
+                                        <InlineUIContainer BaselineAlignment="Center">
+                                            <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                                            ToolTip="Number of years to extend the demand projection."/>
+                                        </InlineUIContainer>
+                                        <Run Text="Forecast Years"/>
+                                    </TextBlock>
                                     <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding DataContext.ForecastYears, ElementName=Root}"/>
                                     <TextBlock Text="years" Grid.Row="0" Grid.Column="2" VerticalAlignment="Center"/>
 
-                                    <TextBlock Text="Base Year" Grid.Row="1" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                                    <TextBlock Grid.Row="1" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0">
+                                        <InlineUIContainer BaselineAlignment="Center">
+                                            <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                                            ToolTip="Year that anchors the historical data and forecast."/>
+                                        </InlineUIContainer>
+                                        <Run Text="Base Year"/>
+                                    </TextBlock>
                                     <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding BaseYear}"/>
 
-                                    <TextBlock Text="Base Population" Grid.Row="2" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                                    <TextBlock Grid.Row="2" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0">
+                                        <InlineUIContainer BaselineAlignment="Center">
+                                            <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                                            ToolTip="Population served in the base year."/>
+                                        </InlineUIContainer>
+                                        <Run Text="Base Population"/>
+                                    </TextBlock>
                                     <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding BasePopulation}"/>
                                     <TextBlock Text="people" Grid.Row="2" Grid.Column="2" VerticalAlignment="Center"/>
 
-                                    <TextBlock Text="Base Per Capita" Grid.Row="3" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                                    <TextBlock Grid.Row="3" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0">
+                                        <InlineUIContainer BaselineAlignment="Center">
+                                            <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                                            ToolTip="Current per capita water demand for the base year."/>
+                                        </InlineUIContainer>
+                                        <Run Text="Base Per Capita"/>
+                                    </TextBlock>
                                     <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding BasePerCapitaDemand}"/>
                                     <TextBlock Text="gallons/person/day" Grid.Row="3" Grid.Column="2" VerticalAlignment="Center"/>
 
-                                    <TextBlock Text="Population Growth %" Grid.Row="4" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                                    <TextBlock Grid.Row="4" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0">
+                                        <InlineUIContainer BaselineAlignment="Center">
+                                            <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                                            ToolTip="Expected annual population growth rate for the service area."/>
+                                        </InlineUIContainer>
+                                        <Run Text="Population Growth %"/>
+                                    </TextBlock>
                                     <TextBox Grid.Row="4" Grid.Column="1" Text="{Binding PopulationGrowthRate}"/>
                                     <TextBlock Text="%" Grid.Row="4" Grid.Column="2" VerticalAlignment="Center"/>
 
-                                    <TextBlock Text="Per Capita Change %" Grid.Row="5" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                                    <TextBlock Grid.Row="5" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0">
+                                        <InlineUIContainer BaselineAlignment="Center">
+                                            <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                                            ToolTip="Annual percentage change expected in per capita demand."/>
+                                        </InlineUIContainer>
+                                        <Run Text="Per Capita Change %"/>
+                                    </TextBlock>
                                     <TextBox Grid.Row="5" Grid.Column="1" Text="{Binding PerCapitaDemandChangeRate}"/>
                                     <TextBlock Text="%" Grid.Row="5" Grid.Column="2" VerticalAlignment="Center"/>
 
                                     <DataGrid Grid.Row="6" Grid.ColumnSpan="3" ItemsSource="{Binding Sectors}" AutoGenerateColumns="False" CanUserAddRows="False" HeadersVisibility="Column" Margin="0,5,0,5">
                                         <DataGrid.Columns>
                                             <DataGridTextColumn Header="Sector" Binding="{Binding Name}" IsReadOnly="True"/>
-                                            <DataGridTextColumn Header="Current %" Binding="{Binding CurrentPercent, Mode=TwoWay}"/>
-                                            <DataGridTextColumn Header="Future %" Binding="{Binding FuturePercent, Mode=TwoWay}"/>
+                                            <DataGridTextColumn Binding="{Binding CurrentPercent, Mode=TwoWay}">
+                                                <DataGridTextColumn.Header>
+                                                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                                        <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                                                        ToolTip="Current share of total demand attributed to the sector."/>
+                                                        <TextBlock Text="Current %" Margin="4,0,0,0" VerticalAlignment="Center"/>
+                                                    </StackPanel>
+                                                </DataGridTextColumn.Header>
+                                            </DataGridTextColumn>
+                                            <DataGridTextColumn Binding="{Binding FuturePercent, Mode=TwoWay}">
+                                                <DataGridTextColumn.Header>
+                                                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                                        <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                                                        ToolTip="Projected future share of total demand for the sector."/>
+                                                        <TextBlock Text="Future %" Margin="4,0,0,0" VerticalAlignment="Center"/>
+                                                    </StackPanel>
+                                                </DataGridTextColumn.Header>
+                                            </DataGridTextColumn>
                                         </DataGrid.Columns>
                                     </DataGrid>
 
                                     <Expander Grid.Row="7" Grid.ColumnSpan="3" Header="Advanced Adjustments" Margin="0,5,0,5">
                                         <StackPanel Orientation="Vertical">
                                             <StackPanel Orientation="Horizontal">
-                                                <TextBlock Text="Improvements %" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                                                <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="0,0,5,0">
+                                                    <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                                                    ToolTip="Percent reduction in demand from planned system improvements."/>
+                                                    <TextBlock Text="Improvements %" Margin="4,0,0,0" VerticalAlignment="Center"/>
+                                                </StackPanel>
                                                 <TextBox Text="{Binding SystemImprovementsPercent}"/>
                                             </StackPanel>
                                             <StackPanel Orientation="Horizontal">
-                                                <TextBlock Text="Losses %" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                                                <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="0,0,5,0">
+                                                    <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                                                    ToolTip="Percent of demand lost to system leakage or other losses."/>
+                                                    <TextBlock Text="Losses %" Margin="4,0,0,0" VerticalAlignment="Center"/>
+                                                </StackPanel>
                                                 <TextBox Text="{Binding SystemLossesPercent}"/>
                                             </StackPanel>
                                         </StackPanel>


### PR DESCRIPTION
## Summary
- extend the reusable data grid column descriptor to support info-icon headers with tooltips
- add contextual tooltips to every input control and editable grid column across the app views
- apply the new tooltip headers to dynamic EAD columns and each data entry table

## Testing
- dotnet build EconToolbox.Desktop.sln *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc82b6af188330b620d422a5e3c3c1