### PR TITLE
Reorganize hero guidance and actions layout

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -74,27 +74,72 @@
                                    Style="{StaticResource Text.Body}"
                                    Foreground="White"
                                    Margin="{StaticResource Margin.Stack}"/>
-                        <TextBlock Text="To prepare your inputs:"
-                                   FontWeight="SemiBold"
-                                   Foreground="White"
-                                   Margin="{StaticResource Margin.Stack}"/>
-                        <ItemsControl ItemsSource="{Binding SelectedModule.InputSteps}"
-                                      Margin="{StaticResource Margin.StackSmall}">
-                            <ItemsControl.ItemTemplate>
-                                <DataTemplate>
-                                    <StackPanel Orientation="Horizontal" Margin="0,2">
-                                        <TextBlock Text="•"
-                                                   Foreground="White"
-                                                   FontSize="16"
-                                                   Margin="0,0,6,0"/>
-                                        <TextBlock Text="{Binding}"
-                                                   Style="{StaticResource Text.Body}"
-                                                   Foreground="White"
-                                                   TextWrapping="Wrap"/>
-                                    </StackPanel>
-                                </DataTemplate>
-                            </ItemsControl.ItemTemplate>
-                        </ItemsControl>
+                        <Grid Margin="{StaticResource Margin.Stack}">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" MinWidth="260"/>
+                                <ColumnDefinition Width="*" MinWidth="260"/>
+                            </Grid.ColumnDefinitions>
+                            <StackPanel Grid.Column="0"
+                                        Margin="0,0,16,0">
+                                <TextBlock Text="To prepare your inputs:"
+                                           FontWeight="SemiBold"
+                                           Foreground="White"
+                                           Margin="0,0,0,6"/>
+                                <ItemsControl ItemsSource="{Binding SelectedModule.InputSteps}">
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate>
+                                            <StackPanel Orientation="Horizontal" Margin="0,2">
+                                                <TextBlock Text="•"
+                                                           Foreground="White"
+                                                           FontSize="16"
+                                                           Margin="0,0,6,0"/>
+                                                <TextBlock Text="{Binding}"
+                                                           TextWrapping="Wrap"
+                                                           Foreground="White"
+                                                           FontSize="14"/>
+                                            </StackPanel>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
+                            </StackPanel>
+                            <StackPanel Grid.Column="1"
+                                        Margin="16,0,0,0">
+                                <TextBlock Text="What the outputs show"
+                                           FontWeight="SemiBold"
+                                           Foreground="White"
+                                           Margin="0,0,0,6"/>
+                                <ItemsControl ItemsSource="{Binding SelectedModule.OutputHighlights}">
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate>
+                                            <StackPanel Orientation="Horizontal" Margin="0,2">
+                                                <TextBlock Text="•"
+                                                           Foreground="{StaticResource Brush.Accent}"
+                                                           FontSize="16"
+                                                           Margin="0,0,6,0"/>
+                                                <TextBlock Text="{Binding}"
+                                                           TextWrapping="Wrap"
+                                                           Foreground="White"
+                                                           FontSize="14"/>
+                                            </StackPanel>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
+                            </StackPanel>
+                        </Grid>
+                        <Border Background="#3312212F"
+                                CornerRadius="10"
+                                Padding="12"
+                                Margin="{StaticResource Margin.Stack}">
+                            <StackPanel>
+                                <TextBlock Text="Real-world example"
+                                           FontWeight="SemiBold"
+                                           Foreground="White"/>
+                                <TextBlock Text="{Binding SelectedModule.Example}"
+                                           TextWrapping="Wrap"
+                                           Foreground="White"
+                                           Margin="0,6,0,0"/>
+                            </StackPanel>
+                        </Border>
                     </StackPanel>
                 </Grid>
             </DataTemplate>
@@ -147,7 +192,6 @@
                                                FontSize="16"
                                                Margin="0,0,6,0"/>
                                     <TextBlock Text="{Binding}"
-                                               Style="{StaticResource Text.Body}"
                                                Foreground="White"
                                                TextWrapping="Wrap"
                                                Width="240"/>
@@ -155,78 +199,14 @@
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
-                </StackPanel>
-            </DataTemplate>
-
-            <DataTemplate x:Key="ActionsWideTemplate">
-                <Grid HorizontalAlignment="Stretch"
-                      Margin="0,0,0,8">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*"/>
-                        <ColumnDefinition Width="Auto"/>
-                    </Grid.ColumnDefinitions>
-                    <StackPanel Grid.Column="0"
-                                Margin="{StaticResource Margin.StackLarge}">
-                        <TextBlock Text="What the outputs show"
-                                   FontWeight="SemiBold"
-                                   Foreground="{StaticResource Brush.Primary}"/>
-                        <ItemsControl ItemsSource="{Binding SelectedModule.OutputHighlights}"
-                                      Margin="{StaticResource Margin.StackSmall}">
-                            <ItemsControl.ItemTemplate>
-                                <DataTemplate>
-                                    <StackPanel Orientation="Horizontal" Margin="0,2">
-                                        <TextBlock Text="•"
-                                                   Foreground="{StaticResource Brush.Accent}"
-                                                   FontSize="16"
-                                                   Margin="0,0,6,0"/>
-                                        <TextBlock Text="{Binding}"
-                                                   Style="{StaticResource Text.Body}"
-                                                   TextWrapping="Wrap"
-                                                   Width="320"/>
-                                    </StackPanel>
-                                </DataTemplate>
-                            </ItemsControl.ItemTemplate>
-                        </ItemsControl>
-                    </StackPanel>
-                    <StackPanel Grid.Column="1"
-                                Orientation="Horizontal"
-                                HorizontalAlignment="Right"
-                                Margin="{StaticResource Margin.Stack}">
-                        <Button x:Name="CalculateButton"
-                                Command="{Binding CalculateCommand}"
-                                Margin="{StaticResource Margin.Inline}"
-                                Visibility="{Binding IsCalculateVisible, Converter={StaticResource BoolToVisibilityConverter}}"
-                                IsEnabled="{Binding IsCalculateVisible}">
-                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-                                <TextBlock FontFamily="Segoe MDL2 Assets"
-                                           Text=""
-                                           Margin="{StaticResource Margin.Inline}"
-                                           FontSize="16"/>
-                                <TextBlock Text="Calculate"/>
-                            </StackPanel>
-                        </Button>
-                        <Button Command="{Binding ExportCommand}"
-                                Margin="{StaticResource Margin.Inline}">
-                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-                                <TextBlock FontFamily="Segoe MDL2 Assets"
-                                           Text=""
-                                           Margin="{StaticResource Margin.Inline}"
-                                           FontSize="16"/>
-                                <TextBlock Text="Export"/>
-                            </StackPanel>
-                        </Button>
-                    </StackPanel>
-                </Grid>
-            </DataTemplate>
-
-            <DataTemplate x:Key="ActionsNarrowTemplate">
-                <StackPanel>
                     <TextBlock Text="What the outputs show"
                                FontWeight="SemiBold"
-                               Foreground="{StaticResource Brush.Primary}"
+                               Foreground="White"
+                               TextAlignment="Center"
                                Margin="{StaticResource Margin.Stack}"/>
                     <ItemsControl ItemsSource="{Binding SelectedModule.OutputHighlights}"
-                                  Margin="{StaticResource Margin.StackSmall}">
+                                  Margin="{StaticResource Margin.StackSmall}"
+                                  HorizontalAlignment="Center">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
                                 <StackPanel Orientation="Horizontal" Margin="0,2">
@@ -235,32 +215,104 @@
                                                FontSize="16"
                                                Margin="0,0,6,0"/>
                                     <TextBlock Text="{Binding}"
-                                               Style="{StaticResource Text.Body}"
-                                               TextWrapping="Wrap"/>
+                                               Foreground="White"
+                                               TextWrapping="Wrap"
+                                               Width="240"/>
                                 </StackPanel>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
-                    <Button Command="{Binding CalculateCommand}"
-                            Margin="{StaticResource Margin.Inline}"
+                    <Border Background="#3312212F"
+                            CornerRadius="10"
+                            Padding="12"
+                            Margin="{StaticResource Margin.Stack}">
+                        <StackPanel>
+                            <TextBlock Text="Real-world example"
+                                       FontWeight="SemiBold"
+                                       Foreground="White"
+                                       TextAlignment="Center"/>
+                            <TextBlock Text="{Binding SelectedModule.Example}"
+                                       TextWrapping="Wrap"
+                                       Foreground="White"
+                                       Margin="0,6,0,0"
+                                       TextAlignment="Center"/>
+                        </StackPanel>
+                    </Border>
+                </StackPanel>
+            </DataTemplate>
+
+            <DataTemplate x:Key="ActionsWideTemplate">
+                <Grid HorizontalAlignment="Stretch">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <Button x:Name="CalculateButton"
+                            Grid.Column="0"
+                            Command="{Binding CalculateCommand}"
+                            Margin="0,0,12,0"
+                            Height="64"
                             Visibility="{Binding IsCalculateVisible, Converter={StaticResource BoolToVisibilityConverter}}"
                             IsEnabled="{Binding IsCalculateVisible}">
-                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                        <StackPanel Orientation="Horizontal"
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Center">
                             <TextBlock FontFamily="Segoe MDL2 Assets"
-                                       Text=""
-                                       Margin="{StaticResource Margin.Inline}"
+                                       Text="&#xE8EF;"
+                                       Margin="0,0,8,0"
+                                       FontSize="20"/>
+                            <TextBlock Text="Calculate"
                                        FontSize="16"/>
-                            <TextBlock Text="Calculate"/>
+                        </StackPanel>
+                    </Button>
+                    <Button Grid.Column="1"
+                            Command="{Binding ExportCommand}"
+                            Margin="0"
+                            Height="64">
+                        <StackPanel Orientation="Horizontal"
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Center">
+                            <TextBlock FontFamily="Segoe MDL2 Assets"
+                                       Text="&#xEDE1;"
+                                       Margin="0,0,8,0"
+                                       FontSize="20"/>
+                            <TextBlock Text="Export"
+                                       FontSize="16"/>
+                        </StackPanel>
+                    </Button>
+                </Grid>
+            </DataTemplate>
+
+            <DataTemplate x:Key="ActionsNarrowTemplate">
+                <StackPanel>
+                    <Button Command="{Binding CalculateCommand}"
+                            Margin="0,0,0,12"
+                            Height="56"
+                            Visibility="{Binding IsCalculateVisible, Converter={StaticResource BoolToVisibilityConverter}}"
+                            IsEnabled="{Binding IsCalculateVisible}">
+                        <StackPanel Orientation="Horizontal"
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Center">
+                            <TextBlock FontFamily="Segoe MDL2 Assets"
+                                       Text="&#xE8EF;"
+                                       Margin="0,0,8,0"
+                                       FontSize="20"/>
+                            <TextBlock Text="Calculate"
+                                       FontSize="16"/>
                         </StackPanel>
                     </Button>
                     <Button Command="{Binding ExportCommand}"
-                            Margin="{StaticResource Margin.Inline}">
-                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                            Margin="0"
+                            Height="56">
+                        <StackPanel Orientation="Horizontal"
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Center">
                             <TextBlock FontFamily="Segoe MDL2 Assets"
-                                       Text=""
-                                       Margin="{StaticResource Margin.Inline}"
+                                       Text="&#xEDE1;"
+                                       Margin="0,0,8,0"
+                                       FontSize="20"/>
+                            <TextBlock Text="Export"
                                        FontSize="16"/>
-                            <TextBlock Text="Export"/>
                         </StackPanel>
                     </Button>
                 </StackPanel>

--- a/Themes/Design.xaml
+++ b/Themes/Design.xaml
@@ -153,8 +153,8 @@
         <Setter Property="Foreground" Value="White"/>
         <Setter Property="Padding" Value="12,8"/>
         <Setter Property="FontSize" Value="13"/>
-        <Setter Property="MaxWidth" Value="360"/>
-        <Setter Property="TextBlock.TextWrapping" Value="Wrap"/>
+        <Setter Property="MaxWidth" Value="420"/>
+        <Setter Property="TextBlock.TextWrapping" Value="WrapWithOverflow"/>
         <Setter Property="HasDropShadow" Value="True"/>
         <Setter Property="TextElement.FontFamily" Value="Segoe UI"/>
         <Setter Property="TextElement.FontSize" Value="13"/>
@@ -178,15 +178,15 @@
 
     <Style x:Key="Content.InfoIcon" TargetType="ContentControl">
         <Setter Property="Focusable" Value="False"/>
-        <Setter Property="Width" Value="20"/>
-        <Setter Property="Height" Value="20"/>
+        <Setter Property="Width" Value="16"/>
+        <Setter Property="Height" Value="16"/>
         <Setter Property="Margin" Value="{StaticResource Margin.Inline}"/>
         <Setter Property="Cursor" Value="Help"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="ContentControl">
                     <Border Background="{StaticResource Brush.Primary}"
-                            CornerRadius="10"
+                            CornerRadius="8"
                             Width="{TemplateBinding Width}"
                             Height="{TemplateBinding Height}"
                             HorizontalAlignment="Center"
@@ -196,7 +196,7 @@
                                    FontWeight="SemiBold"
                                    HorizontalAlignment="Center"
                                    VerticalAlignment="Center"
-                                   FontSize="12"/>
+                                   FontSize="10"/>
                     </Border>
                 </ControlTemplate>
             </Setter.Value>

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -60,6 +60,7 @@ namespace EconToolbox.Desktop.ViewModels
                         "Draws frequency-damage and stage-damage curves so you can visually QA the shape of the inputs.",
                         "Exports the full grid, summary text, and charts to Excel for documentation."
                     },
+                    "Example: The Cedar River levee district pairs 0.5, 0.1, and 0.01 annual exceedance probabilities with $250K, $1.2M, and $6.8M structure damage estimates captured in its 2019 flood study.",
                     Ead,
                     Ead.ComputeCommand),
                 new ModuleDefinition(
@@ -77,6 +78,7 @@ namespace EconToolbox.Desktop.ViewModels
                         "Summarizes updated capital, annualized RR&R, and total annual cost comparisons across scenarios.",
                         "Provides an export-ready workbook covering every sub-tab for auditability."
                     },
+                    "Example: Modernizing the North Bay joint-use reservoir assigns 70% of its 850 acre-feet to the recommended diversion plan while escalating $2.3M of 2010 construction costs to FY24 dollars.",
                     UpdatedCost,
                     UpdatedCost.ComputeCommand),
                 new ModuleDefinition(
@@ -94,6 +96,7 @@ namespace EconToolbox.Desktop.ViewModels
                         "Generates schedules for future costs and IDC contributions for traceability.",
                         "Exports a concise summary table and supporting detail to Excel."
                     },
+                    "Example: Annualizing a $45M pump station replacement uses a 3.5% discount rate over 50 years, includes $250K in annual O&M, and captures a $1.1M mid-life rehab cost occurring in year 25.",
                     Annualizer,
                     Annualizer.ComputeCommand),
                 new ModuleDefinition(
@@ -111,6 +114,7 @@ namespace EconToolbox.Desktop.ViewModels
                         "Displays comparison charts and tables to highlight divergence across scenarios.",
                         "Allows exporting to Excel with data tables and visualizations for stakeholder review."
                     },
+                    "Example: Forecasting demand for a city of 180,000 residents that used 120 gallons per capita in 2023 while expecting 1.5% annual population growth and system improvements cutting losses by 8%.",
                     WaterDemand,
                     WaterDemand.ComputeCommand),
                 new ModuleDefinition(
@@ -128,6 +132,7 @@ namespace EconToolbox.Desktop.ViewModels
                         "Highlights how quality point adjustments influence the composite value.",
                         "Supports exporting the evaluation for integration into economic reports."
                     },
+                    "Example: Evaluating the Riverwalk trail system anticipates 42,000 annual user days split between day hiking and cycling with average facility quality scores of 27 points.",
                     Udv,
                     Udv.ComputeCommand),
                 new ModuleDefinition(
@@ -145,6 +150,7 @@ namespace EconToolbox.Desktop.ViewModels
                         "Supports quick export alongside other modules for project documentation.",
                         "Provides an always-on workspace to summarize qualitative findings."
                     },
+                    "Example: Mapping insights from a coastal storm resilience workshop organizes nodes for risk drivers, mitigation concepts, funding leads, and assigned follow-up tasks.",
                     MindMap,
                     null)
             };

--- a/ViewModels/ModuleDefinition.cs
+++ b/ViewModels/ModuleDefinition.cs
@@ -12,6 +12,7 @@ namespace EconToolbox.Desktop.ViewModels
             string description,
             IEnumerable<string> inputSteps,
             IEnumerable<string> outputHighlights,
+            string example,
             BaseViewModel contentViewModel,
             ICommand? computeCommand)
         {
@@ -19,6 +20,7 @@ namespace EconToolbox.Desktop.ViewModels
             Description = description;
             InputSteps = new ReadOnlyCollection<string>(inputSteps.ToList());
             OutputHighlights = new ReadOnlyCollection<string>(outputHighlights.ToList());
+            Example = example;
             ContentViewModel = contentViewModel;
             ComputeCommand = computeCommand;
         }
@@ -30,6 +32,8 @@ namespace EconToolbox.Desktop.ViewModels
         public IReadOnlyList<string> InputSteps { get; }
 
         public IReadOnlyList<string> OutputHighlights { get; }
+
+        public string Example { get; }
 
         public BaseViewModel ContentViewModel { get; }
 


### PR DESCRIPTION
## Summary
- Move each module's output highlights into the hero section alongside input guidance, add a real-world example callout, and adapt the layout for wide and narrow breakpoints
- Resize the bottom action area so the calculate/export buttons fill the footer and swap in calculator/export glyphs for clearer affordances
- Shrink the help tooltip icon style, expand tooltip wrapping support, and extend module metadata to supply real-world examples

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc87e5735483309948dbf523d8e4f0