### PR TITLE
Finalize interface refinements and new modules

### DIFF
--- a/Converters/DayToPixelConverter.cs
+++ b/Converters/DayToPixelConverter.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace EconToolbox.Desktop.Converters
+{
+    public class DayToPixelConverter : IValueConverter
+    {
+        public double Scale { get; set; } = 18.0;
+
+        public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            if (value == null)
+                return 0;
+
+            if (double.TryParse(value.ToString(), NumberStyles.Any, CultureInfo.InvariantCulture, out var numeric))
+            {
+                return numeric * Scale;
+            }
+
+            if (value is TimeSpan span)
+            {
+                return span.TotalDays * Scale;
+            }
+
+            return 0;
+        }
+
+        public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => Binding.DoNothing;
+    }
+}

--- a/Converters/OffsetConverter.cs
+++ b/Converters/OffsetConverter.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace EconToolbox.Desktop.Converters
+{
+    public class OffsetConverter : IValueConverter
+    {
+        public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            if (value is double d)
+            {
+                double offset = 0;
+                if (parameter != null && double.TryParse(parameter.ToString(), NumberStyles.Any, CultureInfo.InvariantCulture, out var parsed))
+                {
+                    offset = parsed;
+                }
+                return d - offset;
+            }
+
+            return value;
+        }
+
+        public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => Binding.DoNothing;
+    }
+}

--- a/Converters/PercentToOpacityConverter.cs
+++ b/Converters/PercentToOpacityConverter.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace EconToolbox.Desktop.Converters
+{
+    public class PercentToOpacityConverter : IValueConverter
+    {
+        public double MinimumOpacity { get; set; } = 0.35;
+        public double MaximumOpacity { get; set; } = 1.0;
+
+        public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            if (value == null)
+                return MinimumOpacity;
+
+            if (double.TryParse(value.ToString(), NumberStyles.Any, CultureInfo.InvariantCulture, out var percent))
+            {
+                percent = Math.Clamp(percent / 100.0, 0, 1);
+                return MinimumOpacity + (MaximumOpacity - MinimumOpacity) * percent;
+            }
+
+            return MaximumOpacity;
+        }
+
+        public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => Binding.DoNothing;
+    }
+}

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -42,6 +42,12 @@
             <DataTemplate DataType="{x:Type vm:MindMapViewModel}">
                 <views:MindMapView/>
             </DataTemplate>
+            <DataTemplate DataType="{x:Type vm:GanttViewModel}">
+                <views:GanttView/>
+            </DataTemplate>
+            <DataTemplate DataType="{x:Type vm:DrawingViewModel}">
+                <views:DrawingView/>
+            </DataTemplate>
             <DataTemplate x:Key="HeroWideTemplate">
                 <Grid Margin="0"
                       HorizontalAlignment="Stretch">
@@ -49,19 +55,20 @@
                         <ColumnDefinition Width="Auto"/>
                         <ColumnDefinition Width="*" MinWidth="320"/>
                     </Grid.ColumnDefinitions>
-                    <Canvas Width="120"
+                    <Border Width="120"
                             Height="90"
+                            Background="#1F3C52"
+                            CornerRadius="12"
                             Margin="{StaticResource Margin.InlineLarge}">
-                        <Path Data="M10,70 L30,45 L55,55 L85,20"
-                              Stroke="White"
-                              StrokeThickness="4"
-                              StrokeEndLineCap="Round"
-                              StrokeStartLineCap="Round"/>
-                        <Ellipse Width="10" Height="10" Fill="{StaticResource Brush.Accent}" Canvas.Left="6" Canvas.Top="65"/>
-                        <Ellipse Width="10" Height="10" Fill="{StaticResource Brush.Accent}" Canvas.Left="26" Canvas.Top="40"/>
-                        <Ellipse Width="10" Height="10" Fill="{StaticResource Brush.Accent}" Canvas.Left="51" Canvas.Top="50"/>
-                        <Ellipse Width="12" Height="12" Fill="White" Canvas.Left="79" Canvas.Top="14"/>
-                    </Canvas>
+                        <Border.Effect>
+                            <DropShadowEffect BlurRadius="12"
+                                              ShadowDepth="0"
+                                              Opacity="0.35"/>
+                        </Border.Effect>
+                        <Image Source="pack://application:,,,/Pixstle.ico"
+                               Stretch="Uniform"
+                               Margin="10"/>
+                    </Border>
                     <StackPanel Grid.Column="1"
                                 Margin="{StaticResource Margin.StackLarge}">
                         <TextBlock Text="Economic Toolbox"
@@ -147,20 +154,21 @@
             <DataTemplate x:Key="HeroNarrowTemplate">
                 <StackPanel Margin="0"
                             HorizontalAlignment="Stretch">
-                    <Canvas Width="100"
+                    <Border Width="100"
                             Height="70"
                             HorizontalAlignment="Center"
+                            Background="#1F3C52"
+                            CornerRadius="12"
                             Margin="{StaticResource Margin.Stack}">
-                        <Path Data="M10,60 L25,35 L45,45 L70,15"
-                              Stroke="White"
-                              StrokeThickness="4"
-                              StrokeEndLineCap="Round"
-                              StrokeStartLineCap="Round"/>
-                        <Ellipse Width="10" Height="10" Fill="{StaticResource Brush.Accent}" Canvas.Left="6" Canvas.Top="55"/>
-                        <Ellipse Width="10" Height="10" Fill="{StaticResource Brush.Accent}" Canvas.Left="24" Canvas.Top="30"/>
-                        <Ellipse Width="10" Height="10" Fill="{StaticResource Brush.Accent}" Canvas.Left="44" Canvas.Top="40"/>
-                        <Ellipse Width="12" Height="12" Fill="White" Canvas.Left="68" Canvas.Top="10"/>
-                    </Canvas>
+                        <Border.Effect>
+                            <DropShadowEffect BlurRadius="10"
+                                              ShadowDepth="0"
+                                              Opacity="0.35"/>
+                        </Border.Effect>
+                        <Image Source="pack://application:,,,/Pixstle.ico"
+                               Stretch="Uniform"
+                               Margin="8"/>
+                    </Border>
                     <StackPanel Margin="{StaticResource Margin.Stack}"
                                 HorizontalAlignment="Center">
                         <TextBlock Text="Economic Toolbox"
@@ -261,7 +269,7 @@
                                        Text="&#xE8EF;"
                                        Margin="0,0,8,0"
                                        FontSize="20"/>
-                            <TextBlock Text="Calculate"
+                            <TextBlock Text="{Binding PrimaryActionLabel}"
                                        FontSize="16"/>
                         </StackPanel>
                     </Button>
@@ -297,7 +305,7 @@
                                        Text="&#xE8EF;"
                                        Margin="0,0,8,0"
                                        FontSize="20"/>
-                            <TextBlock Text="Calculate"
+                            <TextBlock Text="{Binding PrimaryActionLabel}"
                                        FontSize="16"/>
                         </StackPanel>
                     </Button>

--- a/Models/GanttTask.cs
+++ b/Models/GanttTask.cs
@@ -1,0 +1,113 @@
+using System;
+
+namespace EconToolbox.Desktop.Models
+{
+    public class GanttTask : ObservableObject
+    {
+        private string _name = string.Empty;
+        private string _workstream = string.Empty;
+        private DateTime _startDate = DateTime.Today;
+        private int _durationDays = 1;
+        private DateTime _endDate = DateTime.Today;
+        private string _dependencies = string.Empty;
+        private double _percentComplete;
+        private bool _isMilestone;
+
+        public string Name
+        {
+            get => _name;
+            set
+            {
+                if (_name == value)
+                    return;
+                _name = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public string Workstream
+        {
+            get => _workstream;
+            set
+            {
+                if (_workstream == value)
+                    return;
+                _workstream = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public DateTime StartDate
+        {
+            get => _startDate;
+            set
+            {
+                if (_startDate == value)
+                    return;
+                _startDate = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public int DurationDays
+        {
+            get => _durationDays;
+            set
+            {
+                if (_durationDays == value)
+                    return;
+                _durationDays = Math.Max(0, value);
+                OnPropertyChanged();
+            }
+        }
+
+        public DateTime EndDate
+        {
+            get => _endDate;
+            set
+            {
+                if (_endDate == value)
+                    return;
+                _endDate = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public string Dependencies
+        {
+            get => _dependencies;
+            set
+            {
+                if (_dependencies == value)
+                    return;
+                _dependencies = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public double PercentComplete
+        {
+            get => _percentComplete;
+            set
+            {
+                var clamped = Math.Clamp(value, 0, 100);
+                if (Math.Abs(_percentComplete - clamped) < 0.0001)
+                    return;
+                _percentComplete = clamped;
+                OnPropertyChanged();
+            }
+        }
+
+        public bool IsMilestone
+        {
+            get => _isMilestone;
+            set
+            {
+                if (_isMilestone == value)
+                    return;
+                _isMilestone = value;
+                OnPropertyChanged();
+            }
+        }
+    }
+}

--- a/Models/Scenario.cs
+++ b/Models/Scenario.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.ObjectModel;
 using System.Windows.Media;
 
@@ -8,14 +9,96 @@ namespace EconToolbox.Desktop.Models
     /// </summary>
     public class Scenario : ObservableObject
     {
-        public string Name { get; set; } = string.Empty;
-        public string Description { get; set; } = string.Empty;
+        private string _name = string.Empty;
+        public string Name
+        {
+            get => _name;
+            set
+            {
+                if (_name == value)
+                    return;
+                _name = value;
+                OnPropertyChanged();
+            }
+        }
 
-        public int BaseYear { get; set; }
-        public double BasePopulation { get; set; }
-        public double BasePerCapitaDemand { get; set; }
-        public double PopulationGrowthRate { get; set; }
-        public double PerCapitaDemandChangeRate { get; set; }
+        private string _description = string.Empty;
+        public string Description
+        {
+            get => _description;
+            set
+            {
+                if (_description == value)
+                    return;
+                _description = value;
+                OnPropertyChanged();
+            }
+        }
+
+        private int _baseYear;
+        public int BaseYear
+        {
+            get => _baseYear;
+            set
+            {
+                if (_baseYear == value)
+                    return;
+                _baseYear = value;
+                OnPropertyChanged();
+            }
+        }
+
+        private double _basePopulation;
+        public double BasePopulation
+        {
+            get => _basePopulation;
+            set
+            {
+                if (Math.Abs(_basePopulation - value) < 0.0001)
+                    return;
+                _basePopulation = value;
+                OnPropertyChanged();
+            }
+        }
+
+        private double _basePerCapitaDemand;
+        public double BasePerCapitaDemand
+        {
+            get => _basePerCapitaDemand;
+            set
+            {
+                if (Math.Abs(_basePerCapitaDemand - value) < 0.0001)
+                    return;
+                _basePerCapitaDemand = value;
+                OnPropertyChanged();
+            }
+        }
+
+        private double _populationGrowthRate;
+        public double PopulationGrowthRate
+        {
+            get => _populationGrowthRate;
+            set
+            {
+                if (Math.Abs(_populationGrowthRate - value) < 0.0001)
+                    return;
+                _populationGrowthRate = value;
+                OnPropertyChanged();
+            }
+        }
+
+        private double _perCapitaDemandChangeRate;
+        public double PerCapitaDemandChangeRate
+        {
+            get => _perCapitaDemandChangeRate;
+            set
+            {
+                if (Math.Abs(_perCapitaDemandChangeRate - value) < 0.0001)
+                    return;
+                _perCapitaDemandChangeRate = value;
+                OnPropertyChanged();
+            }
+        }
 
         /// <summary>
         /// Percentage shares for each demand sector. The last entry is treated
@@ -28,8 +111,31 @@ namespace EconToolbox.Desktop.Models
             new SectorShare { Name = "Commercial" },
             new SectorShare { Name = "Agricultural", IsResidual = true }
         };
-        public double SystemImprovementsPercent { get; set; }
-        public double SystemLossesPercent { get; set; }
+        private double _systemImprovementsPercent;
+        public double SystemImprovementsPercent
+        {
+            get => _systemImprovementsPercent;
+            set
+            {
+                if (Math.Abs(_systemImprovementsPercent - value) < 0.0001)
+                    return;
+                _systemImprovementsPercent = value;
+                OnPropertyChanged();
+            }
+        }
+
+        private double _systemLossesPercent;
+        public double SystemLossesPercent
+        {
+            get => _systemLossesPercent;
+            set
+            {
+                if (Math.Abs(_systemLossesPercent - value) < 0.0001)
+                    return;
+                _systemLossesPercent = value;
+                OnPropertyChanged();
+            }
+        }
 
         public ObservableCollection<DemandEntry> Results { get; } = new();
 
@@ -40,6 +146,17 @@ namespace EconToolbox.Desktop.Models
             set { _chartPoints = value; OnPropertyChanged(); }
         }
 
-        public Brush LineBrush { get; set; } = Brushes.Blue;
+        private Brush _lineBrush = Brushes.Blue;
+        public Brush LineBrush
+        {
+            get => _lineBrush;
+            set
+            {
+                if (_lineBrush == value)
+                    return;
+                _lineBrush = value;
+                OnPropertyChanged();
+            }
+        }
     }
 }

--- a/Themes/Design.xaml
+++ b/Themes/Design.xaml
@@ -23,6 +23,11 @@
     <Color x:Key="Color.HighlightBorder">#AFCDE0</Color>
     <SolidColorBrush x:Key="Brush.HighlightBackground" Color="{StaticResource Color.HighlightBackground}"/>
     <SolidColorBrush x:Key="Brush.HighlightBorder" Color="{StaticResource Color.HighlightBorder}"/>
+    <converters:OffsetConverter x:Key="OffsetConverter"/>
+    <converters:DayToPixelConverter x:Key="DayToPixelConverter"/>
+    <converters:DayToPixelConverter x:Key="RowToPixelConverter" Scale="44"/>
+    <converters:PercentToOpacityConverter x:Key="PercentToOpacityConverter" MinimumOpacity="0.45"/>
+    <BooleanToVisibilityConverter x:Key="BoolToVisibilityConverter"/>
 
     <!-- Spacing tokens -->
     <sys:Double x:Key="Space.XS">4</sys:Double>
@@ -159,6 +164,20 @@
         <Setter Property="TextElement.FontFamily" Value="Segoe UI"/>
         <Setter Property="TextElement.FontSize" Value="13"/>
         <Setter Property="TextElement.Foreground" Value="White"/>
+        <Setter Property="ContentTemplate">
+            <Setter.Value>
+                <DataTemplate>
+                    <ContentPresenter RecognizesAccessKey="True" Content="{Binding}">
+                        <ContentPresenter.Resources>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="TextWrapping" Value="Wrap"/>
+                                <Setter Property="TextTrimming" Value="None"/>
+                            </Style>
+                        </ContentPresenter.Resources>
+                    </ContentPresenter>
+                </DataTemplate>
+            </Setter.Value>
+        </Setter>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="ToolTip">

--- a/ViewModels/DrawingViewModel.cs
+++ b/ViewModels/DrawingViewModel.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Windows.Ink;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows;
+
+namespace EconToolbox.Desktop.ViewModels
+{
+    public class DrawingViewModel : BaseViewModel
+    {
+        private readonly RelayCommand _clearCommand;
+        private readonly RelayCommand _undoCommand;
+        private Color _selectedColor = Colors.SteelBlue;
+        private double _penThickness = 3;
+        private bool _suppressStrokeNotification;
+
+        public DrawingViewModel()
+        {
+            Palette = new ObservableCollection<ColorOption>
+            {
+                new("Steel", Colors.SteelBlue),
+                new("Crimson", Colors.Crimson),
+                new("Emerald", Color.FromRgb(52, 168, 83)),
+                new("Amber", Color.FromRgb(255, 191, 0)),
+                new("Graphite", Color.FromRgb(66, 66, 66)),
+                new("Violet", Color.FromRgb(123, 97, 255))
+            };
+
+            DrawingAttributes = new DrawingAttributes
+            {
+                Color = _selectedColor,
+                Width = _penThickness,
+                Height = _penThickness,
+                FitToCurve = true
+            };
+
+            Strokes = new StrokeCollection();
+            Strokes.StrokesChanged += (_, _) => UpdateStrokeState();
+
+            _clearCommand = new RelayCommand(Clear, () => HasStrokes);
+            _undoCommand = new RelayCommand(Undo, () => HasStrokes);
+        }
+
+        public ObservableCollection<ColorOption> Palette { get; }
+
+        public StrokeCollection Strokes { get; }
+
+        public DrawingAttributes DrawingAttributes { get; }
+
+        public ICommand ClearCommand => _clearCommand;
+        public ICommand UndoCommand => _undoCommand;
+
+        public double CanvasWidth { get; set; } = 820;
+        public double CanvasHeight { get; set; } = 520;
+
+        public bool HasStrokes => Strokes.Count > 0;
+
+        public Color SelectedColor
+        {
+            get => _selectedColor;
+            set
+            {
+                if (_selectedColor == value)
+                    return;
+                _selectedColor = value;
+                DrawingAttributes.Color = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public double PenThickness
+        {
+            get => _penThickness;
+            set
+            {
+                var clamped = Math.Clamp(value, 1, 24);
+                if (Math.Abs(_penThickness - clamped) < 0.001)
+                    return;
+                _penThickness = clamped;
+                DrawingAttributes.Width = _penThickness;
+                DrawingAttributes.Height = _penThickness;
+                OnPropertyChanged();
+            }
+        }
+
+        private void Clear()
+        {
+            _suppressStrokeNotification = true;
+            Strokes.Clear();
+            _suppressStrokeNotification = false;
+            UpdateStrokeState();
+        }
+
+        private void Undo()
+        {
+            if (Strokes.Count == 0)
+                return;
+            _suppressStrokeNotification = true;
+            Strokes.RemoveAt(Strokes.Count - 1);
+            _suppressStrokeNotification = false;
+            UpdateStrokeState();
+        }
+
+        private void UpdateStrokeState()
+        {
+            if (_suppressStrokeNotification)
+                return;
+
+            OnPropertyChanged(nameof(HasStrokes));
+            _clearCommand.RaiseCanExecuteChanged();
+            _undoCommand.RaiseCanExecuteChanged();
+        }
+
+        public IEnumerable<IReadOnlyList<Point>> ExportStrokes()
+        {
+            return Strokes
+                .Select(stroke => stroke.StylusPoints.Select(p => (Point)p).ToList())
+                .ToList();
+        }
+
+        public record ColorOption(string Name, Color Color)
+        {
+            public Brush Swatch => new SolidColorBrush(Color);
+        }
+    }
+}

--- a/ViewModels/GanttViewModel.cs
+++ b/ViewModels/GanttViewModel.cs
@@ -1,0 +1,248 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Windows.Input;
+using EconToolbox.Desktop.Models;
+
+namespace EconToolbox.Desktop.ViewModels
+{
+    public class GanttViewModel : BaseViewModel
+    {
+        private readonly RelayCommand _addTaskCommand;
+        private readonly RelayCommand _removeTaskCommand;
+        private readonly RelayCommand _clearTasksCommand;
+        private readonly RelayCommand _computeCommand;
+        private GanttTask? _selectedTask;
+        private DateTime _projectStart = DateTime.Today;
+        private DateTime _projectFinish = DateTime.Today;
+        private string _scheduleSummary = string.Empty;
+
+        public ObservableCollection<GanttTask> Tasks { get; } = new();
+        public ObservableCollection<GanttBar> Bars { get; } = new();
+
+        public GanttTask? SelectedTask
+        {
+            get => _selectedTask;
+            set
+            {
+                if (_selectedTask == value)
+                    return;
+                _selectedTask = value;
+                OnPropertyChanged();
+                _removeTaskCommand.RaiseCanExecuteChanged();
+            }
+        }
+
+        public DateTime ProjectStart
+        {
+            get => _projectStart;
+            private set
+            {
+                if (_projectStart == value)
+                    return;
+                _projectStart = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public DateTime ProjectFinish
+        {
+            get => _projectFinish;
+            private set
+            {
+                if (_projectFinish == value)
+                    return;
+                _projectFinish = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public string ScheduleSummary
+        {
+            get => _scheduleSummary;
+            private set
+            {
+                if (_scheduleSummary == value)
+                    return;
+                _scheduleSummary = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public double TotalDurationDays => Math.Max(1, (ProjectFinish - ProjectStart).TotalDays);
+
+        public ICommand AddTaskCommand => _addTaskCommand;
+        public ICommand RemoveTaskCommand => _removeTaskCommand;
+        public ICommand ClearTasksCommand => _clearTasksCommand;
+        public ICommand ComputeCommand => _computeCommand;
+
+        public GanttViewModel()
+        {
+            _addTaskCommand = new RelayCommand(AddTask);
+            _removeTaskCommand = new RelayCommand(RemoveSelectedTask, () => SelectedTask != null);
+            _clearTasksCommand = new RelayCommand(ClearTasks);
+            _computeCommand = new RelayCommand(ComputeSchedule);
+
+            SeedDefaultTasks();
+            ComputeSchedule();
+        }
+
+        private void SeedDefaultTasks()
+        {
+            if (Tasks.Count > 0)
+                return;
+
+            var kickoff = new GanttTask
+            {
+                Name = "Project Kickoff",
+                Workstream = "Initiation",
+                StartDate = DateTime.Today,
+                DurationDays = 2,
+                PercentComplete = 100
+            };
+            kickoff.EndDate = kickoff.StartDate.AddDays(kickoff.DurationDays);
+
+            var planning = new GanttTask
+            {
+                Name = "Planning Workshops",
+                Workstream = "Planning",
+                StartDate = kickoff.EndDate,
+                DurationDays = 5,
+                Dependencies = kickoff.Name,
+                PercentComplete = 60
+            };
+            planning.EndDate = planning.StartDate.AddDays(planning.DurationDays);
+
+            var baseline = new GanttTask
+            {
+                Name = "Baseline Cost Estimate",
+                Workstream = "Analysis",
+                StartDate = planning.EndDate,
+                DurationDays = 7,
+                Dependencies = planning.Name,
+                PercentComplete = 25
+            };
+            baseline.EndDate = baseline.StartDate.AddDays(baseline.DurationDays);
+
+            Tasks.Add(kickoff);
+            Tasks.Add(planning);
+            Tasks.Add(baseline);
+        }
+
+        private void AddTask()
+        {
+            var task = new GanttTask
+            {
+                Name = $"Task {Tasks.Count + 1}",
+                Workstream = "General",
+                StartDate = ProjectFinish == DateTime.MinValue ? DateTime.Today : ProjectFinish,
+                DurationDays = 5
+            };
+            task.EndDate = task.StartDate.AddDays(task.DurationDays);
+            Tasks.Add(task);
+            SelectedTask = task;
+        }
+
+        private void RemoveSelectedTask()
+        {
+            if (SelectedTask == null)
+                return;
+            var index = Tasks.IndexOf(SelectedTask);
+            Tasks.Remove(SelectedTask);
+            if (index >= 0 && index < Tasks.Count)
+                SelectedTask = Tasks[index];
+            else
+                SelectedTask = Tasks.LastOrDefault();
+        }
+
+        private void ClearTasks()
+        {
+            Tasks.Clear();
+            Bars.Clear();
+            ScheduleSummary = string.Empty;
+            ProjectStart = DateTime.Today;
+            ProjectFinish = DateTime.Today;
+            OnPropertyChanged(nameof(TotalDurationDays));
+        }
+
+        public void ComputeSchedule()
+        {
+            if (Tasks.Count == 0)
+            {
+                Bars.Clear();
+                ScheduleSummary = "Add tasks to build your schedule.";
+                return;
+            }
+
+            var lookup = Tasks
+                .Where(t => !string.IsNullOrWhiteSpace(t.Name))
+                .GroupBy(t => t.Name.Trim(), StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(g => g.Key, g => g.Last(), StringComparer.OrdinalIgnoreCase);
+
+            foreach (var task in Tasks)
+            {
+                if (task.DurationDays == 0 && !task.IsMilestone)
+                {
+                    task.DurationDays = 1;
+                }
+
+                var dependencyNames = ParseDependencies(task.Dependencies);
+                if (dependencyNames.Count > 0)
+                {
+                    DateTime? latestDependencyFinish = null;
+                    foreach (var depName in dependencyNames)
+                    {
+                        if (!lookup.TryGetValue(depName, out var dependency))
+                            continue;
+                        if (latestDependencyFinish == null || dependency.EndDate > latestDependencyFinish)
+                            latestDependencyFinish = dependency.EndDate;
+                    }
+
+                    if (latestDependencyFinish.HasValue && latestDependencyFinish.Value > task.StartDate)
+                        task.StartDate = latestDependencyFinish.Value;
+                }
+
+                task.EndDate = task.IsMilestone
+                    ? task.StartDate
+                    : task.StartDate.AddDays(Math.Max(1, task.DurationDays));
+            }
+
+            ProjectStart = Tasks.Min(t => t.StartDate);
+            ProjectFinish = Tasks.Max(t => t.EndDate);
+            OnPropertyChanged(nameof(TotalDurationDays));
+
+            Bars.Clear();
+            int row = 0;
+            foreach (var task in Tasks.OrderBy(t => t.StartDate))
+            {
+                double offset = (task.StartDate - ProjectStart).TotalDays;
+                double length = task.IsMilestone ? 0.5 : Math.Max(1, task.DurationDays);
+                Bars.Add(new GanttBar(task, row++, offset, length));
+            }
+
+            double totalDays = (ProjectFinish - ProjectStart).TotalDays;
+            ScheduleSummary = totalDays <= 0
+                ? "Schedule contains a single-day milestone sequence."
+                : $"Project spans {(int)Math.Ceiling(totalDays)} days across {Tasks.Count} activities.";
+        }
+
+        private static List<string> ParseDependencies(string dependencies)
+        {
+            return dependencies
+                .Split(new[] { ',', ';', '\n' }, StringSplitOptions.RemoveEmptyEntries)
+                .Select(d => d.Trim())
+                .Where(d => !string.IsNullOrWhiteSpace(d))
+                .ToList();
+        }
+
+        public record GanttBar(GanttTask Task, int RowIndex, double OffsetDays, double DurationDays)
+        {
+            public bool IsMilestone => Task.IsMilestone;
+            public double PercentComplete => Task.PercentComplete;
+            public string Workstream => Task.Workstream;
+            public double CanvasOffsetDays => IsMilestone ? Math.Max(0, OffsetDays - 0.6) : OffsetDays;
+            public double CanvasDurationDays => IsMilestone ? 1.2 : DurationDays;
+        }
+    }
+}

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -12,6 +12,8 @@ namespace EconToolbox.Desktop.ViewModels
         public UdvViewModel Udv { get; } = new();
         public WaterDemandViewModel WaterDemand { get; } = new();
         public MindMapViewModel MindMap { get; } = new();
+        public GanttViewModel Gantt { get; } = new();
+        public DrawingViewModel Drawing { get; } = new();
 
         public IReadOnlyList<ModuleDefinition> Modules { get; }
 
@@ -26,6 +28,7 @@ namespace EconToolbox.Desktop.ViewModels
                 OnPropertyChanged();
                 OnPropertyChanged(nameof(IsCalculateVisible));
                 OnPropertyChanged(nameof(SelectedModule));
+                OnPropertyChanged(nameof(PrimaryActionLabel));
             }
         }
 
@@ -37,6 +40,13 @@ namespace EconToolbox.Desktop.ViewModels
             : null;
 
         public bool IsCalculateVisible => SelectedModule?.ComputeCommand?.CanExecute(null) == true;
+
+        public string PrimaryActionLabel => SelectedModule?.Title switch
+        {
+            "Water Demand Forecasting" => "Forecast",
+            "Standard Gantt Planner" => "Schedule",
+            _ => "Calculate"
+        };
 
         public MainViewModel()
         {
@@ -152,6 +162,42 @@ namespace EconToolbox.Desktop.ViewModels
                     },
                     "Example: Mapping insights from a coastal storm resilience workshop organizes nodes for risk drivers, mitigation concepts, funding leads, and assigned follow-up tasks.",
                     MindMap,
+                    null),
+                new ModuleDefinition(
+                    "Standard Gantt Planner",
+                    "Organize project activities, dependencies, and milestones in a timeline consistent with industry schedules.",
+                    new[]
+                    {
+                        "List each task with a start date, duration, and responsible workstream.",
+                        "Identify predecessors to respect finish-to-start dependencies across the plan.",
+                        "Adjust pen thickness and color in the sketch tab to annotate delivery risks or notes."
+                    },
+                    new[]
+                    {
+                        "Automatically sequences start and finish dates based on dependency logic.",
+                        "Generates a bar chart showing duration, percent complete, and milestones.",
+                        "Exports both the task register and timeline graphic alongside other modules."
+                    },
+                    "Example: A feasibility study includes kickoff, stakeholder workshops, baseline analysis, and a design milestone with finish-to-start dependencies.",
+                    Gantt,
+                    Gantt.ComputeCommand),
+                new ModuleDefinition(
+                    "Sketch Pad",
+                    "Capture freehand notes, diagrams, or signatures directly in the toolbox.",
+                    new[]
+                    {
+                        "Pick a pen color and thickness that complements your drawing style.",
+                        "Draw directly on the canvas using the mouse or stylus.",
+                        "Use undo or clear to refine the canvas before exporting."
+                    },
+                    new[]
+                    {
+                        "Maintains stroke data for export to Excel as an image.",
+                        "Supports multiple pen widths and color palettes for rapid sketching.",
+                        "Provides an always-available space to annotate workshop takeaways."
+                    },
+                    "Example: Sketching a reservoir layout with notes about control structures during a design charrette.",
+                    Drawing,
                     null)
             };
 
@@ -189,7 +235,7 @@ namespace EconToolbox.Desktop.ViewModels
             };
             if (dlg.ShowDialog() == true)
             {
-                ExcelExporter.ExportAll(Ead, UpdatedCost, Annualizer, WaterDemand, Udv, MindMap, dlg.FileName);
+                ExcelExporter.ExportAll(Ead, UpdatedCost, Annualizer, WaterDemand, Udv, MindMap, Gantt, Drawing, dlg.FileName);
             }
         }
     }

--- a/ViewModels/MindMapConnectionViewModel.cs
+++ b/ViewModels/MindMapConnectionViewModel.cs
@@ -22,6 +22,8 @@ namespace EconToolbox.Desktop.ViewModels
         public MindMapNodeViewModel Target { get; }
 
         private PointCollection _connectorPoints = new();
+        private Point _firstBend;
+        private Point _secondBend;
 
         public double StartX => Source.X + Source.VisualWidth / 2;
         public double StartY => Source.Y + Source.VisualHeight / 2;
@@ -36,6 +38,32 @@ namespace EconToolbox.Desktop.ViewModels
                 if (!Equals(_connectorPoints, value))
                 {
                     _connectorPoints = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public Point FirstBend
+        {
+            get => _firstBend;
+            private set
+            {
+                if (_firstBend != value)
+                {
+                    _firstBend = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public Point SecondBend
+        {
+            get => _secondBend;
+            private set
+            {
+                if (_secondBend != value)
+                {
+                    _secondBend = value;
                     OnPropertyChanged();
                 }
             }
@@ -95,13 +123,20 @@ namespace EconToolbox.Desktop.ViewModels
                 midX = (start.X + end.X) / 2;
             }
 
-            return new PointCollection
+            var points = new PointCollection
             {
                 start,
                 new Point(midX, start.Y),
                 new Point(midX, end.Y),
                 end
             };
+            if (points.Count >= 4)
+            {
+                FirstBend = points[1];
+                SecondBend = points[2];
+            }
+
+            return points;
         }
     }
 }

--- a/Views/DrawingView.xaml
+++ b/Views/DrawingView.xaml
@@ -1,0 +1,114 @@
+<UserControl x:Class="EconToolbox.Desktop.Views.DrawingView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Name="Root"
+             Background="{StaticResource Brush.SurfaceAlt}"
+             SnapsToDevicePixels="True"
+             UseLayoutRounding="True">
+    <ScrollViewer VerticalScrollBarVisibility="Auto"
+                  HorizontalScrollBarVisibility="Disabled"
+                  Padding="{StaticResource Padding.Card}">
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
+            <Border Grid.Row="0" Style="{StaticResource Border.Explainer}">
+                <StackPanel>
+                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                        <TextBlock FontFamily="Segoe MDL2 Assets"
+                                   Text=""
+                                   FontSize="18"
+                                   Foreground="{StaticResource Brush.Primary}"
+                                   Margin="0,0,8,0"/>
+                        <TextBlock Text="Sketch Workspace"
+                                   FontWeight="Bold"
+                                   FontSize="16"
+                                   Foreground="{StaticResource Brush.Primary}"/>
+                    </StackPanel>
+                    <TextBlock TextWrapping="Wrap" Margin="0,6,0,0">
+                        Draw directly on the canvas using your mouse or stylus. Adjust pen color and thickness with the controls below. Use the Calculate button at the bottom of the window when you want to include the latest strokes in the export package.
+                    </TextBlock>
+                </StackPanel>
+            </Border>
+            <Border Grid.Row="1" Background="{StaticResource Brush.Surface}" BorderBrush="{StaticResource Brush.Border}" BorderThickness="1" CornerRadius="8" Padding="12" Margin="0,12,0,0">
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Spacing="16">
+                    <StackPanel Width="240">
+                        <TextBlock Text="Pen Color" FontWeight="SemiBold"/>
+                        <ListBox ItemsSource="{Binding Palette}"
+                                 SelectedValuePath="Color"
+                                 SelectedValue="{Binding SelectedColor, Mode=TwoWay}"
+                                 Margin="0,6,0,0"
+                                 BorderThickness="0"
+                                 Background="Transparent"
+                                 ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                                 ScrollViewer.VerticalScrollBarVisibility="Disabled">
+                            <ListBox.ItemsPanel>
+                                <ItemsPanelTemplate>
+                                    <StackPanel Orientation="Horizontal"/>
+                                </ItemsPanelTemplate>
+                            </ListBox.ItemsPanel>
+                            <ListBox.ItemContainerStyle>
+                                <Style TargetType="ListBoxItem">
+                                    <Setter Property="Margin" Value="4"/>
+                                    <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+                                </Style>
+                            </ListBox.ItemContainerStyle>
+                            <ListBox.ItemTemplate>
+                                <DataTemplate>
+                                    <Border Width="28" Height="28" CornerRadius="14" BorderBrush="#1F3A7A">
+                                        <Border.Style>
+                                            <Style TargetType="Border">
+                                                <Setter Property="BorderThickness" Value="1"/>
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType=ListBoxItem}, Path=IsSelected}" Value="True">
+                                                        <Setter Property="BorderThickness" Value="3"/>
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </Border.Style>
+                                        <Border Background="{Binding Swatch}" CornerRadius="14"/>
+                                    </Border>
+                                </DataTemplate>
+                            </ListBox.ItemTemplate>
+                        </ListBox>
+                    </StackPanel>
+                    <StackPanel Width="180">
+                        <TextBlock Text="Pen Thickness" FontWeight="SemiBold"/>
+                        <Slider Minimum="1"
+                                Maximum="24"
+                                TickFrequency="1"
+                                IsSnapToTickEnabled="True"
+                                Value="{Binding PenThickness, Mode=TwoWay}"
+                                Margin="0,6,0,0"/>
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal" VerticalAlignment="Bottom">
+                        <Button Command="{Binding UndoCommand}" Width="110" Margin="0,0,8,0">
+                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                                <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Margin="0,0,6,0"/>
+                                <TextBlock Text="Undo"/>
+                            </StackPanel>
+                        </Button>
+                        <Button Command="{Binding ClearCommand}" Width="110">
+                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                                <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Margin="0,0,6,0"/>
+                                <TextBlock Text="Clear"/>
+                            </StackPanel>
+                        </Button>
+                    </StackPanel>
+                </StackPanel>
+            </Border>
+            <Border Grid.Row="2" Background="White" BorderBrush="#D5E3F6" BorderThickness="1" CornerRadius="10" Padding="6" Margin="0,12,0,0">
+                <Grid>
+                    <InkCanvas x:Name="Canvas"
+                               Strokes="{Binding Strokes}"
+                               Background="#FAFCFF"
+                               Width="{Binding CanvasWidth}"
+                               Height="{Binding CanvasHeight}"
+                               EditingMode="Ink"/>
+                </Grid>
+            </Border>
+        </Grid>
+    </ScrollViewer>
+</UserControl>

--- a/Views/DrawingView.xaml.cs
+++ b/Views/DrawingView.xaml.cs
@@ -1,0 +1,22 @@
+using System.Windows.Controls;
+using EconToolbox.Desktop.ViewModels;
+
+namespace EconToolbox.Desktop.Views
+{
+    public partial class DrawingView : UserControl
+    {
+        public DrawingView()
+        {
+            InitializeComponent();
+            DataContextChanged += OnDataContextChanged;
+        }
+
+        private void OnDataContextChanged(object sender, System.Windows.DependencyPropertyChangedEventArgs e)
+        {
+            if (DataContext is DrawingViewModel vm)
+            {
+                Canvas.DefaultDrawingAttributes = vm.DrawingAttributes;
+            }
+        }
+    }
+}

--- a/Views/EadView.xaml
+++ b/Views/EadView.xaml
@@ -38,7 +38,7 @@
                             <LineBreak/>
                             <Run Text="Toggle Include Stage if you have stage data aligned with the same probabilities."/>
                             <LineBreak/>
-                            <Run Text="After editing the grid, click Calculate EAD so charts and statistics capture your latest entries."/>
+                            <Run Text="After editing the grid, use the Calculate button at the bottom of the window so charts and statistics capture your latest entries."/>
                         </TextBlock>
                     </StackPanel>
                 </Border>
@@ -83,18 +83,6 @@
                             <TextBlock Text="Include Stage" Margin="4,0,0,0" VerticalAlignment="Center"/>
                         </StackPanel>
                     </CheckBox>
-                    <Button Command="{Binding ComputeCommand}" Margin="{StaticResource Margin.Inline}">
-                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-                            <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Margin="{StaticResource Margin.Inline}"/>
-                            <TextBlock Text="Calculate EAD"/>
-                        </StackPanel>
-                    </Button>
-                    <Button Command="{Binding ExportCommand}" Margin="{StaticResource Margin.Inline}">
-                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-                            <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Margin="{StaticResource Margin.Inline}"/>
-                            <TextBlock Text="Export Summary"/>
-                        </StackPanel>
-                    </Button>
                 </WrapPanel>
 
                 <UniformGrid Grid.Row="2"

--- a/Views/GanttView.xaml
+++ b/Views/GanttView.xaml
@@ -1,0 +1,211 @@
+<UserControl x:Class="EconToolbox.Desktop.Views.GanttView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             Background="{StaticResource Brush.SurfaceAlt}"
+             SnapsToDevicePixels="True"
+             UseLayoutRounding="True">
+    <ScrollViewer HorizontalScrollBarVisibility="Disabled"
+                  VerticalScrollBarVisibility="Auto"
+                  Padding="{StaticResource Padding.Card}">
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+            <Border Grid.Row="0"
+                    Style="{StaticResource Border.Explainer}">
+                <StackPanel>
+                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                        <TextBlock FontFamily="Segoe MDL2 Assets"
+                                   Text=""
+                                   FontSize="18"
+                                   Foreground="{StaticResource Brush.Primary}"
+                                   Margin="0,0,8,0"/>
+                        <TextBlock Text="Standard Gantt Planner"
+                                   FontSize="16"
+                                   FontWeight="Bold"
+                                   Foreground="{StaticResource Brush.Primary}"/>
+                    </StackPanel>
+                    <TextBlock TextWrapping="Wrap"
+                               Margin="0,6,0,0">
+                        Document project tasks, durations, and dependencies. Use the Calculate button at the bottom of the window to refresh the schedule and bars. Export shares the task table and timeline with the rest of the workbook.
+                    </TextBlock>
+                </StackPanel>
+            </Border>
+            <Grid Grid.Row="1"
+                  Margin="0,12,0,0">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="2.2*"/>
+                    <ColumnDefinition Width="1.8*"/>
+                </Grid.ColumnDefinitions>
+                <StackPanel Grid.Column="0"
+                            Margin="0,0,16,0">
+                    <Border Background="{StaticResource Brush.Surface}" BorderBrush="{StaticResource Brush.Border}" BorderThickness="1" CornerRadius="8" Padding="12">
+                        <StackPanel>
+                            <TextBlock Text="Work Breakdown"
+                                       FontWeight="SemiBold"
+                                       FontSize="15"
+                                       Margin="0,0,0,8"/>
+                            <DataGrid ItemsSource="{Binding Tasks}"
+                                      SelectedItem="{Binding SelectedTask, Mode=TwoWay}"
+                                      AutoGenerateColumns="False"
+                                      CanUserAddRows="True"
+                                      HeadersVisibility="Column"
+                                      Margin="0,0,0,8">
+                                <DataGrid.Columns>
+                                    <DataGridTextColumn Header="Task" Binding="{Binding Name, Mode=TwoWay}" Width="160"/>
+                                    <DataGridTextColumn Header="Workstream" Binding="{Binding Workstream, Mode=TwoWay}" Width="110"/>
+                                    <DataGridTemplateColumn Header="Start" Width="120">
+                                        <DataGridTemplateColumn.CellTemplate>
+                                            <DataTemplate>
+                                                <DatePicker SelectedDate="{Binding StartDate, Mode=TwoWay}"/>
+                                            </DataTemplate>
+                                        </DataGridTemplateColumn.CellTemplate>
+                                    </DataGridTemplateColumn>
+                                    <DataGridTextColumn Header="Duration (days)" Binding="{Binding DurationDays, Mode=TwoWay}" Width="100"/>
+                                    <DataGridTextColumn Header="Dependencies" Binding="{Binding Dependencies, Mode=TwoWay}" Width="140"/>
+                                    <DataGridCheckBoxColumn Header="Milestone" Binding="{Binding IsMilestone, Mode=TwoWay}" Width="80"/>
+                                    <DataGridTextColumn Header="% Complete" Binding="{Binding PercentComplete, Mode=TwoWay}" Width="90"/>
+                                </DataGrid.Columns>
+                            </DataGrid>
+                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Left">
+                                <Button Command="{Binding AddTaskCommand}" Width="120" Margin="0,0,8,0">
+                                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                                        <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Margin="0,0,6,0"/>
+                                        <TextBlock Text="Add Task"/>
+                                    </StackPanel>
+                                </Button>
+                                <Button Command="{Binding RemoveTaskCommand}" Width="140" Margin="0,0,8,0">
+                                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                                        <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Margin="0,0,6,0"/>
+                                        <TextBlock Text="Remove Selected"/>
+                                    </StackPanel>
+                                </Button>
+                                <Button Command="{Binding ClearTasksCommand}" Width="120">
+                                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                                        <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Margin="0,0,6,0"/>
+                                        <TextBlock Text="Clear"/>
+                                    </StackPanel>
+                                </Button>
+                            </StackPanel>
+                        </StackPanel>
+                    </Border>
+                </StackPanel>
+                <Border Grid.Column="1"
+                        Background="{StaticResource Brush.Surface}"
+                        BorderBrush="{StaticResource Brush.Border}"
+                        BorderThickness="1"
+                        CornerRadius="8"
+                        Padding="12">
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="*"/>
+                        </Grid.RowDefinitions>
+                        <StackPanel Orientation="Horizontal" Grid.Row="0" Margin="0,0,0,12" VerticalAlignment="Center">
+                            <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="16" Foreground="{StaticResource Brush.Primary}" Margin="0,0,8,0"/>
+                            <StackPanel>
+                                <TextBlock Text="Schedule Timeline" FontWeight="SemiBold"/>
+                                <TextBlock Text="{Binding ScheduleSummary}" FontSize="12" Foreground="{StaticResource Brush.TextSecondary}"/>
+                            </StackPanel>
+                        </StackPanel>
+                        <Border Grid.Row="1" Background="#F5F8FE" BorderBrush="#D4E0F4" BorderThickness="1" CornerRadius="6" Padding="8">
+                            <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Disabled">
+                                <Canvas Height="{Binding Bars.Count, Converter={StaticResource RowToPixelConverter}}"
+                                        Width="{Binding TotalDurationDays, Converter={StaticResource DayToPixelConverter}}"
+                                        MinHeight="220"
+                                        MinWidth="560">
+                                    <ItemsControl ItemsSource="{Binding Bars}">
+                                        <ItemsControl.ItemsPanel>
+                                            <ItemsPanelTemplate>
+                                                <Canvas />
+                                            </ItemsPanelTemplate>
+                                        </ItemsControl.ItemsPanel>
+                                        <ItemsControl.ItemContainerStyle>
+                                            <Style TargetType="ContentPresenter">
+                                                <Setter Property="Canvas.Left" Value="{Binding CanvasOffsetDays, Converter={StaticResource DayToPixelConverter}}"/>
+                                                <Setter Property="Canvas.Top" Value="{Binding RowIndex, Converter={StaticResource RowToPixelConverter}}"/>
+                                            </Style>
+                                        </ItemsControl.ItemContainerStyle>
+                                        <ItemsControl.ItemTemplate>
+                                            <DataTemplate>
+                                                <Grid>
+                                                    <Rectangle Height="28"
+                                                               Width="{Binding CanvasDurationDays, Converter={StaticResource DayToPixelConverter}}"
+                                                               RadiusX="4"
+                                                               RadiusY="4"
+                                                               Fill="#4F6EB8"
+                                                               Opacity="{Binding Task.PercentComplete, Converter={StaticResource PercentToOpacityConverter}}"
+                                                               Stroke="#233B70"
+                                                               StrokeThickness="1.2">
+                                                        <Rectangle.Style>
+                                                            <Style TargetType="Rectangle">
+                                                                <Setter Property="Visibility" Value="Visible"/>
+                                                                <Style.Triggers>
+                                                                    <DataTrigger Binding="{Binding IsMilestone}" Value="True">
+                                                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                                                    </DataTrigger>
+                                                                </Style.Triggers>
+                                                            </Style>
+                                                        </Rectangle.Style>
+                                                    </Rectangle>
+                                                    <Polygon Points="0,14 12,0 24,14 12,28"
+                                                             Fill="#4F6EB8"
+                                                             Stroke="#233B70"
+                                                             StrokeThickness="1.2">
+                                                        <Polygon.Style>
+                                                            <Style TargetType="Polygon">
+                                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                                                <Style.Triggers>
+                                                                    <DataTrigger Binding="{Binding IsMilestone}" Value="True">
+                                                                        <Setter Property="Visibility" Value="Visible"/>
+                                                                    </DataTrigger>
+                                                                </Style.Triggers>
+                                                            </Style>
+                                                        </Polygon.Style>
+                                                    </Polygon>
+                                                    <TextBlock Text="{Binding Task.Name}"
+                                                               Foreground="White"
+                                                               FontSize="11"
+                                                               Margin="6,0,4,0"
+                                                               VerticalAlignment="Center">
+                                                        <TextBlock.Style>
+                                                            <Style TargetType="TextBlock">
+                                                                <Setter Property="Visibility" Value="Visible"/>
+                                                                <Style.Triggers>
+                                                                    <DataTrigger Binding="{Binding IsMilestone}" Value="True">
+                                                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                                                    </DataTrigger>
+                                                                </Style.Triggers>
+                                                            </Style>
+                                                        </TextBlock.Style>
+                                                    </TextBlock>
+                                                </Grid>
+                                            </DataTemplate>
+                                        </ItemsControl.ItemTemplate>
+                                    </ItemsControl>
+                                </Canvas>
+                            </ScrollViewer>
+                        </Border>
+                    </Grid>
+                </Border>
+            </Grid>
+            <Border Grid.Row="2"
+                    Margin="0,16,0,0"
+                    Background="#F9FAFE"
+                    BorderBrush="#D8E4F8"
+                    BorderThickness="1"
+                    CornerRadius="8"
+                    Padding="12">
+                <StackPanel>
+                    <TextBlock Text="Milestone Notes"
+                               FontWeight="SemiBold"/>
+                    <TextBlock TextWrapping="Wrap" Margin="0,4,0,0" FontSize="12">
+                        Milestones use zero duration and the diamond marker in the timeline. Enter comma separated dependencies to chain tasks in the correct order.
+                    </TextBlock>
+                </StackPanel>
+            </Border>
+        </Grid>
+    </ScrollViewer>
+</UserControl>

--- a/Views/GanttView.xaml.cs
+++ b/Views/GanttView.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows.Controls;
+
+namespace EconToolbox.Desktop.Views
+{
+    public partial class GanttView : UserControl
+    {
+        public GanttView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/Views/MindMapView.xaml
+++ b/Views/MindMapView.xaml
@@ -8,13 +8,14 @@
              UseLayoutRounding="True">
     <UserControl.Resources>
         <Style x:Key="ConnectionLineStyle" TargetType="Polyline">
-            <Setter Property="Stroke" Value="#92A8D4"/>
-            <Setter Property="StrokeThickness" Value="2.4"/>
-            <Setter Property="StrokeStartLineCap" Value="Round"/>
-            <Setter Property="StrokeEndLineCap" Value="Round"/>
-            <Setter Property="StrokeLineJoin" Value="Round"/>
-            <Setter Property="Opacity" Value="0.9"/>
+            <Setter Property="Stroke" Value="#3F5DAA"/>
+            <Setter Property="StrokeThickness" Value="3"/>
+            <Setter Property="StrokeStartLineCap" Value="Square"/>
+            <Setter Property="StrokeEndLineCap" Value="Square"/>
+            <Setter Property="StrokeLineJoin" Value="Bevel"/>
+            <Setter Property="Opacity" Value="0.95"/>
             <Setter Property="Fill" Value="Transparent"/>
+            <Setter Property="SnapsToDevicePixels" Value="True"/>
         </Style>
     </UserControl.Resources>
 
@@ -159,8 +160,42 @@
                                 </ItemsControl.ItemsPanel>
                                 <ItemsControl.ItemTemplate>
                                     <DataTemplate DataType="{x:Type vm:MindMapConnectionViewModel}">
-                                        <Polyline Style="{StaticResource ConnectionLineStyle}"
-                                                  Points="{Binding ConnectorPoints}"/>
+                                        <Canvas IsHitTestVisible="False">
+                                            <Polyline Style="{StaticResource ConnectionLineStyle}"
+                                                      Points="{Binding ConnectorPoints}"/>
+                                            <Rectangle Width="8"
+                                                       Height="8"
+                                                       RadiusX="1"
+                                                       RadiusY="1"
+                                                       Fill="#E4E9FB"
+                                                       Stroke="#27477F"
+                                                       StrokeThickness="1.2"
+                                                       Canvas.Left="{Binding FirstBend.X, Converter={StaticResource OffsetConverter}, ConverterParameter=4}"
+                                                       Canvas.Top="{Binding FirstBend.Y, Converter={StaticResource OffsetConverter}, ConverterParameter=4}"/>
+                                            <Rectangle Width="8"
+                                                       Height="8"
+                                                       RadiusX="1"
+                                                       RadiusY="1"
+                                                       Fill="#E4E9FB"
+                                                       Stroke="#27477F"
+                                                       StrokeThickness="1.2"
+                                                       Canvas.Left="{Binding SecondBend.X, Converter={StaticResource OffsetConverter}, ConverterParameter=4}"
+                                                       Canvas.Top="{Binding SecondBend.Y, Converter={StaticResource OffsetConverter}, ConverterParameter=4}"/>
+                                            <Ellipse Width="10"
+                                                     Height="10"
+                                                     Fill="White"
+                                                     Stroke="#1F3A7A"
+                                                     StrokeThickness="1.4"
+                                                     Canvas.Left="{Binding StartX, Converter={StaticResource OffsetConverter}, ConverterParameter=5}"
+                                                     Canvas.Top="{Binding StartY, Converter={StaticResource OffsetConverter}, ConverterParameter=5}"/>
+                                            <Ellipse Width="10"
+                                                     Height="10"
+                                                     Fill="#1F3A7A"
+                                                     Stroke="#F7F9FF"
+                                                     StrokeThickness="1"
+                                                     Canvas.Left="{Binding EndX, Converter={StaticResource OffsetConverter}, ConverterParameter=5}"
+                                                     Canvas.Top="{Binding EndY, Converter={StaticResource OffsetConverter}, ConverterParameter=5}"/>
+                                        </Canvas>
                                     </DataTemplate>
                                 </ItemsControl.ItemTemplate>
                             </ItemsControl>

--- a/Views/UdvView.xaml
+++ b/Views/UdvView.xaml
@@ -29,7 +29,7 @@
                     <TextBlock Text="Unit Day Value Overview" FontWeight="Bold" Foreground="#C23E64"/>
                 </StackPanel>
                 <TextBlock TextWrapping="Wrap" Margin="{StaticResource Margin.TopSmall}">
-                    Choose the recreation and activity classification, then supply point scores, user days, and visitation. Points must align with the table order to return the correct value tier.
+                    Choose the recreation and activity classification, then supply point scores, user days, and visitation. Points must align with the table order to return the correct value tier. Use the Calculate button at the bottom of the window whenever you change inputs so the unit day value stays synchronized.
                 </TextBlock>
             </StackPanel>
         </Border>
@@ -67,63 +67,120 @@
                 <ComboBox ItemsSource="{Binding ActivityTypes}" SelectedItem="{Binding ActivityType}" MinWidth="200"/>
             </StackPanel>
         </StackPanel>
-        <StackPanel Orientation="Horizontal" Grid.Row="2" Margin="{StaticResource Margin.Stack}">
-            <StackPanel.Style>
-                <Style TargetType="StackPanel">
-                    <Setter Property="Orientation" Value="Horizontal"/>
-                    <Setter Property="HorizontalAlignment" Value="Stretch"/>
-                    <Style.Triggers>
-                        <DataTrigger Binding="{Binding ActualWidth, RelativeSource={RelativeSource AncestorType=UserControl}, Converter={StaticResource WidthToLayoutModeConverter}}"
-                                     Value="Narrow">
-                            <Setter Property="Orientation" Value="Vertical"/>
-                        </DataTrigger>
-                    </Style.Triggers>
-                </Style>
-            </StackPanel.Style>
-            <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Foreground="{StaticResource Brush.Primary}" Margin="{StaticResource Margin.Inline}" VerticalAlignment="Center"/>
-            <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="{StaticResource Margin.Inline}">
+        <Grid Grid.Row="2"
+              Grid.RowSpan="2"
+              Margin="{StaticResource Margin.Stack}"
+              Grid.IsSharedSizeScope="True">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" SharedSizeGroup="UdvIcon"/>
+                <ColumnDefinition Width="Auto" SharedSizeGroup="UdvLabel"/>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto" SharedSizeGroup="UdvValue"/>
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <TextBlock Grid.Row="0"
+                       Grid.Column="0"
+                       FontFamily="Segoe MDL2 Assets"
+                       Text=""
+                       Foreground="{StaticResource Brush.Primary}"
+                       Margin="{StaticResource Margin.Inline}"
+                       VerticalAlignment="Center"/>
+            <StackPanel Grid.Row="0"
+                        Grid.Column="1"
+                        Orientation="Horizontal"
+                        VerticalAlignment="Center"
+                        Margin="{StaticResource Margin.Inline}">
                 <ContentControl Style="{StaticResource Content.InfoIcon}"
                                 ToolTip="Enter the point score from the Unit Day Value table that reflects recreation quality."/>
                 <TextBlock Text="Points" Margin="4,0,0,0" VerticalAlignment="Center"/>
             </StackPanel>
-            <TextBox Text="{Binding Points}" Width="60" Margin="{StaticResource Margin.InlineMedium}"/>
-            <TextBlock Text="Unit Day Value" VerticalAlignment="Center" Margin="{StaticResource Margin.Inline}"/>
-            <TextBlock Text="{Binding UnitDayValue, StringFormat={}{0:F2}}" VerticalAlignment="Center" FontWeight="SemiBold"/>
-        </StackPanel>
-        <StackPanel Orientation="Horizontal" Grid.Row="3" Margin="{StaticResource Margin.Stack}">
-            <StackPanel.Style>
-                <Style TargetType="StackPanel">
-                    <Setter Property="Orientation" Value="Horizontal"/>
-                    <Setter Property="HorizontalAlignment" Value="Stretch"/>
-                    <Style.Triggers>
-                        <DataTrigger Binding="{Binding ActualWidth, RelativeSource={RelativeSource AncestorType=UserControl}, Converter={StaticResource WidthToLayoutModeConverter}}"
-                                     Value="Narrow">
-                            <Setter Property="Orientation" Value="Vertical"/>
-                            <Setter Property="HorizontalAlignment" Value="Left"/>
-                        </DataTrigger>
-                    </Style.Triggers>
-                </Style>
-            </StackPanel.Style>
-            <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Foreground="{StaticResource Brush.Primary}" Margin="{StaticResource Margin.Inline}" VerticalAlignment="Center"/>
-            <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="{StaticResource Margin.Inline}">
+            <TextBox Grid.Row="0"
+                     Grid.Column="2"
+                     Text="{Binding Points}"
+                     Width="80"
+                     Margin="12,0,0,0"/>
+
+            <TextBlock Grid.Row="1"
+                       Grid.Column="0"
+                       FontFamily="Segoe MDL2 Assets"
+                       Text=""
+                       Foreground="{StaticResource Brush.Primary}"
+                       Margin="{StaticResource Margin.Inline}"
+                       VerticalAlignment="Center"/>
+            <TextBlock Grid.Row="1"
+                       Grid.Column="1"
+                       Text="Unit Day Value"
+                       Margin="{StaticResource Margin.Inline}"
+                       VerticalAlignment="Center"/>
+            <TextBlock Grid.Row="1"
+                       Grid.Column="3"
+                       Text="{Binding UnitDayValue, StringFormat={}{0:F2}}"
+                       Margin="12,0,0,0"
+                       VerticalAlignment="Center"
+                       FontWeight="SemiBold"/>
+
+            <TextBlock Grid.Row="2"
+                       Grid.Column="0"
+                       FontFamily="Segoe MDL2 Assets"
+                       Text=""
+                       Foreground="{StaticResource Brush.Primary}"
+                       Margin="{StaticResource Margin.Inline}"
+                       VerticalAlignment="Center"/>
+            <StackPanel Grid.Row="2"
+                        Grid.Column="1"
+                        Orientation="Horizontal"
+                        VerticalAlignment="Center"
+                        Margin="{StaticResource Margin.Inline}">
                 <ContentControl Style="{StaticResource Content.InfoIcon}"
                                 ToolTip="Provide the total projected recreation user days per year for the study area."/>
                 <TextBlock Text="Annual User Days" Margin="4,0,0,0" VerticalAlignment="Center"/>
             </StackPanel>
-            <TextBox Text="{Binding UserDays}" Width="80" Margin="{StaticResource Margin.InlineMedium}"/>
-            <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="{StaticResource Margin.Inline}">
+            <TextBox Grid.Row="2"
+                     Grid.Column="2"
+                     Text="{Binding UserDays}"
+                     Width="120"
+                     Margin="12,0,0,0"/>
+            <TextBlock Grid.Row="2"
+                       Grid.Column="3"
+                       Text="days"
+                       Margin="12,0,0,0"
+                       VerticalAlignment="Center"
+                       Foreground="{StaticResource Brush.TextSecondary}"/>
+
+            <TextBlock Grid.Row="3"
+                       Grid.Column="0"
+                       FontFamily="Segoe MDL2 Assets"
+                       Text=""
+                       Foreground="{StaticResource Brush.Primary}"
+                       Margin="{StaticResource Margin.Inline}"
+                       VerticalAlignment="Center"/>
+            <StackPanel Grid.Row="3"
+                        Grid.Column="1"
+                        Orientation="Horizontal"
+                        VerticalAlignment="Center"
+                        Margin="{StaticResource Margin.Inline}">
                 <ContentControl Style="{StaticResource Content.InfoIcon}"
                                 ToolTip="Fraction of total user days attributable to the plan or alternative being valued."/>
-                <TextBlock Text="Visitation" Margin="4,0,0,0" VerticalAlignment="Center"/>
+                <TextBlock Text="Visitation Share" Margin="4,0,0,0" VerticalAlignment="Center"/>
             </StackPanel>
-            <TextBox Text="{Binding Visitation}" Width="60" Margin="{StaticResource Margin.InlineMedium}"/>
-            <Button Command="{Binding ComputeCommand}">
-                <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-                    <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Margin="{StaticResource Margin.Inline}"/>
-                    <TextBlock Text="Compute"/>
-                </StackPanel>
-            </Button>
-        </StackPanel>
+            <TextBox Grid.Row="3"
+                     Grid.Column="2"
+                     Text="{Binding Visitation}"
+                     Width="80"
+                     Margin="12,0,0,0"/>
+            <TextBlock Grid.Row="3"
+                       Grid.Column="3"
+                       Text="%"
+                       Margin="12,0,0,0"
+                       VerticalAlignment="Center"
+                       Foreground="{StaticResource Brush.TextSecondary}"/>
+        </Grid>
         <Border Grid.Row="4" Background="#FFF7F0" BorderBrush="#E9C28E" BorderThickness="1" CornerRadius="8" Padding="{StaticResource Padding.Content}" Margin="{StaticResource Margin.Stack}">
             <StackPanel>
                 <TextBlock Text="{Binding Result}" FontWeight="Bold"/>

--- a/Views/UpdatedCostView.xaml
+++ b/Views/UpdatedCostView.xaml
@@ -137,7 +137,10 @@
                     <TextBox Text="{Binding StorageRecommendation}" Grid.Row="1" Grid.Column="1" Margin="0,0,0,5"/>
                     <Button Command="{Binding ComputeStorageCommand}" Grid.Row="2" Grid.ColumnSpan="2" Margin="0,5,0,5">
                         <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-                            <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Margin="0,0,6,0"/>
+                            <TextBlock FontFamily="Segoe MDL2 Assets"
+                                       Text="&#xE8EF;"
+                                       FontSize="18"
+                                       Margin="0,0,6,0"/>
                             <TextBlock Text="Compute"/>
                         </StackPanel>
                     </Button>
@@ -198,7 +201,10 @@
                     <TextBox Text="{Binding JointMaintenanceCost}" Grid.Row="1" Grid.Column="1" Margin="0,0,0,5"/>
                     <Button Grid.Row="2" Grid.ColumnSpan="2" Margin="0,5,0,5" Command="{Binding ComputeJointCommand}">
                         <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-                            <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Margin="0,0,6,0"/>
+                            <TextBlock FontFamily="Segoe MDL2 Assets"
+                                       Text="&#xE8EF;"
+                                       FontSize="18"
+                                       Margin="0,0,6,0"/>
                             <TextBlock Text="Compute"/>
                         </StackPanel>
                     </Button>
@@ -264,7 +270,10 @@
                 </DataGrid>
                 <Button Margin="0,5,0,5" Command="{Binding ComputeUpdatedStorageCommand}">
                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-                        <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Margin="0,0,6,0"/>
+                        <TextBlock FontFamily="Segoe MDL2 Assets"
+                                   Text="&#xE8EF;"
+                                   FontSize="18"
+                                   Margin="0,0,6,0"/>
                         <TextBlock Text="Compute"/>
                     </StackPanel>
                 </Button>
@@ -378,7 +387,10 @@
                     </DataGrid>
                     <Button Grid.Row="5" Grid.ColumnSpan="2" Margin="0,5,0,5" Command="{Binding ComputeRrrCommand}">
                         <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-                            <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Margin="0,0,6,0"/>
+                            <TextBlock FontFamily="Segoe MDL2 Assets"
+                                       Text="&#xE8EF;"
+                                       FontSize="18"
+                                       Margin="0,0,6,0"/>
                             <TextBlock Text="Compute"/>
                         </StackPanel>
                     </Button>
@@ -460,7 +472,10 @@
                     <TextBox Text="{Binding AnalysisPeriod2}" Grid.Row="3" Grid.Column="1" Margin="0,0,0,5"/>
                     <Button Grid.Row="4" Grid.ColumnSpan="2" Margin="0,5,0,5" Command="{Binding ComputeTotalCommand}">
                         <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-                            <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Margin="0,0,6,0"/>
+                            <TextBlock FontFamily="Segoe MDL2 Assets"
+                                       Text="&#xE8EF;"
+                                       FontSize="18"
+                                       Margin="0,0,6,0"/>
                             <TextBlock Text="Compute"/>
                         </StackPanel>
                     </Button>

--- a/Views/WaterDemandView.xaml
+++ b/Views/WaterDemandView.xaml
@@ -29,7 +29,7 @@
                     <StackPanel Grid.Column="1" Margin="12,0,0,0">
                         <TextBlock Text="Water Demand Forecast Instructions" FontSize="18" FontWeight="Bold" Foreground="#1F6AB0"/>
                         <TextBlock TextWrapping="Wrap" Margin="0,6,0,0">
-                            Enter historic data first, choose or add scenarios, then specify forecast horizon and demographic assumptions. Use the Forecast button within each scenario to update charts and tables, and Export when you are ready to archive the scenario.
+                            Enter historic data first, choose or add scenarios, then specify forecast horizon and demographic assumptions. Use the Calculate and Export buttons at the bottom of the window to refresh forecasts or download your workbook.
                         </TextBlock>
                     </StackPanel>
                 </Grid>
@@ -83,6 +83,7 @@
                                 </Border>
                                 <Grid Grid.Row="1" Margin="0,0,0,5" VerticalAlignment="Top" HorizontalAlignment="Stretch">
                                     <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto"/>
                                         <RowDefinition Height="Auto"/>
                                         <RowDefinition Height="Auto"/>
                                         <RowDefinition Height="Auto"/>
@@ -190,53 +191,97 @@
                                     </DataGrid>
 
                                     <Expander Grid.Row="7" Grid.ColumnSpan="3" Header="Advanced Adjustments" Margin="0,5,0,5">
-                                        <StackPanel Orientation="Vertical">
-                                            <StackPanel Orientation="Horizontal">
-                                                <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="0,0,5,0">
-                                                    <ContentControl Style="{StaticResource Content.InfoIcon}"
-                                                                    ToolTip="Percent reduction in demand from planned system improvements."/>
-                                                    <TextBlock Text="Improvements %" Margin="4,0,0,0" VerticalAlignment="Center"/>
-                                                </StackPanel>
-                                                <TextBox Text="{Binding SystemImprovementsPercent}"/>
-                                            </StackPanel>
-                                            <StackPanel Orientation="Horizontal">
-                                                <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="0,0,5,0">
-                                                    <ContentControl Style="{StaticResource Content.InfoIcon}"
-                                                                    ToolTip="Percent of demand lost to system leakage or other losses."/>
-                                                    <TextBlock Text="Losses %" Margin="4,0,0,0" VerticalAlignment="Center"/>
-                                                </StackPanel>
-                                                <TextBox Text="{Binding SystemLossesPercent}"/>
-                                            </StackPanel>
-                                        </StackPanel>
+                                        <Grid Margin="0,4,0,0" Grid.IsSharedSizeScope="True">
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="Auto" SharedSizeGroup="InfoIcon"/>
+                                                <ColumnDefinition Width="Auto" SharedSizeGroup="Label"/>
+                                                <ColumnDefinition Width="*"/>
+                                            </Grid.ColumnDefinitions>
+                                            <Grid.RowDefinitions>
+                                                <RowDefinition Height="Auto"/>
+                                                <RowDefinition Height="Auto"/>
+                                            </Grid.RowDefinitions>
+                                            <ContentControl Grid.Row="0"
+                                                            Grid.Column="0"
+                                                            Style="{StaticResource Content.InfoIcon}"
+                                                            ToolTip="Percent reduction in demand from planned system improvements."/>
+                                            <TextBlock Grid.Row="0"
+                                                       Grid.Column="1"
+                                                       Text="Improvements %"
+                                                       Margin="4,0,0,0"
+                                                       VerticalAlignment="Center"/>
+                                            <TextBox Grid.Row="0"
+                                                     Grid.Column="2"
+                                                     Margin="12,0,0,0"
+                                                     Text="{Binding SystemImprovementsPercent}"/>
+                                            <ContentControl Grid.Row="1"
+                                                            Grid.Column="0"
+                                                            Style="{StaticResource Content.InfoIcon}"
+                                                            ToolTip="Percent of demand lost to system leakage or other losses."/>
+                                            <TextBlock Grid.Row="1"
+                                                       Grid.Column="1"
+                                                       Text="Losses %"
+                                                       Margin="4,6,0,0"
+                                                       VerticalAlignment="Center"/>
+                                            <TextBox Grid.Row="1"
+                                                     Grid.Column="2"
+                                                     Margin="12,6,0,0"
+                                                     Text="{Binding SystemLossesPercent}"/>
+                                        </Grid>
                                     </Expander>
 
-                                    <StackPanel Grid.Row="8" Grid.ColumnSpan="3" Orientation="Horizontal" HorizontalAlignment="Left">
-                                        <StackPanel.Style>
-                                            <Style TargetType="StackPanel">
-                                                <Setter Property="Orientation" Value="Horizontal"/>
-                                                <Setter Property="HorizontalAlignment" Value="Left"/>
+                                    <Border Grid.Row="8" Grid.ColumnSpan="3" Background="#F7FBFF" BorderBrush="#C6DBF4" BorderThickness="1" CornerRadius="6" Padding="10" Margin="0,8,0,0">
+                                        <Border.Style>
+                                            <Style TargetType="Border">
+                                                <Setter Property="Visibility" Value="Collapsed"/>
                                                 <Style.Triggers>
-                                                    <DataTrigger Binding="{Binding ActualWidth, RelativeSource={RelativeSource AncestorType=ContentPresenter}, Converter={StaticResource WidthToLayoutModeConverter}}"
-                                                                 Value="Narrow">
-                                                        <Setter Property="Orientation" Value="Vertical"/>
-                                                        <Setter Property="HorizontalAlignment" Value="Stretch"/>
+                                                    <DataTrigger Binding="{Binding Name}" Value="Baseline">
+                                                        <Setter Property="Visibility" Value="Visible"/>
                                                     </DataTrigger>
                                                 </Style.Triggers>
                                             </Style>
-                                        </StackPanel.Style>
-                                        <Button MinWidth="110" Command="{Binding DataContext.ForecastCommand, ElementName=Root}" Margin="0,0,5,0">
-                                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-                                                <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Margin="0,0,6,0"/>
-                                                <TextBlock Text="Forecast"/>
-                                            </StackPanel>
-                                        </Button>
-                                        <Button MinWidth="110" Command="{Binding DataContext.ExportCommand, ElementName=Root}">
-                                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-                                                <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Margin="0,0,6,0"/>
-                                                <TextBlock Text="Export"/>
-                                            </StackPanel>
-                                        </Button>
-                                    </StackPanel>
+                                        </Border.Style>
+                                        <Grid>
+                                            <Grid.RowDefinitions>
+                                                <RowDefinition Height="Auto"/>
+                                                <RowDefinition Height="Auto"/>
+                                                <RowDefinition Height="Auto"/>
+                                                <RowDefinition Height="Auto"/>
+                                                <RowDefinition Height="Auto"/>
+                                                <RowDefinition Height="Auto"/>
+                                                <RowDefinition Height="Auto"/>
+                                            </Grid.RowDefinitions>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="*"/>
+                                                <ColumnDefinition Width="Auto"/>
+                                                <ColumnDefinition Width="*"/>
+                                            </Grid.ColumnDefinitions>
+                                            <TextBlock Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="3" FontWeight="SemiBold" Foreground="#1F6AB0" Margin="0,0,0,8" Text="Scenario Variations (% change applied to baseline rates)"/>
+                                            <TextBlock Grid.Row="1" Grid.Column="0" FontWeight="SemiBold" Foreground="#31556F" Text="Parameter"/>
+                                            <TextBlock Grid.Row="1" Grid.Column="1" FontWeight="SemiBold" Foreground="#31556F" Margin="24,0,24,0" Text="Optimistic"/>
+                                            <TextBlock Grid.Row="1" Grid.Column="2" FontWeight="SemiBold" Foreground="#31556F" Text="Pessimistic"/>
+
+                                            <TextBlock Grid.Row="2" Grid.Column="0" Text="Population growth"/>
+                                            <TextBox Grid.Row="2" Grid.Column="1" Width="80" HorizontalAlignment="Center" Text="{Binding DataContext.OptimisticPopulationGrowthChangePercent, ElementName=Root}" ToolTip="Percent change applied to the baseline population growth rate for the optimistic scenario."/>
+                                            <TextBox Grid.Row="2" Grid.Column="2" Width="80" HorizontalAlignment="Center" Text="{Binding DataContext.PessimisticPopulationGrowthChangePercent, ElementName=Root}" ToolTip="Percent change applied to the baseline population growth rate for the pessimistic scenario."/>
+
+                                            <TextBlock Grid.Row="3" Grid.Column="0" Text="Per capita demand change"/>
+                                            <TextBox Grid.Row="3" Grid.Column="1" Width="80" HorizontalAlignment="Center" Margin="0,4,0,0" Text="{Binding DataContext.OptimisticPerCapitaChangePercent, ElementName=Root}" ToolTip="Percent change applied to the baseline per capita demand growth rate for the optimistic scenario."/>
+                                            <TextBox Grid.Row="3" Grid.Column="2" Width="80" HorizontalAlignment="Center" Margin="0,4,0,0" Text="{Binding DataContext.PessimisticPerCapitaChangePercent, ElementName=Root}" ToolTip="Percent change applied to the baseline per capita demand growth rate for the pessimistic scenario."/>
+
+                                            <TextBlock Grid.Row="4" Grid.Column="0" Text="System improvements"/>
+                                            <TextBox Grid.Row="4" Grid.Column="1" Width="80" HorizontalAlignment="Center" Margin="0,4,0,0" Text="{Binding DataContext.OptimisticImprovementChangePercent, ElementName=Root}" ToolTip="Percent change applied to baseline system improvements for the optimistic scenario."/>
+                                            <TextBox Grid.Row="4" Grid.Column="2" Width="80" HorizontalAlignment="Center" Margin="0,4,0,0" Text="{Binding DataContext.PessimisticImprovementChangePercent, ElementName=Root}" ToolTip="Percent change applied to baseline system improvements for the pessimistic scenario."/>
+
+                                            <TextBlock Grid.Row="5" Grid.Column="0" Text="System losses"/>
+                                            <TextBox Grid.Row="5" Grid.Column="1" Width="80" HorizontalAlignment="Center" Margin="0,4,0,0" Text="{Binding DataContext.OptimisticLossChangePercent, ElementName=Root}" ToolTip="Percent change applied to baseline loss percentages for the optimistic scenario."/>
+                                            <TextBox Grid.Row="5" Grid.Column="2" Width="80" HorizontalAlignment="Center" Margin="0,4,0,0" Text="{Binding DataContext.PessimisticLossChangePercent, ElementName=Root}" ToolTip="Percent change applied to baseline loss percentages for the pessimistic scenario."/>
+
+                                            <TextBlock Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="3" Margin="0,10,0,0" FontSize="12" Foreground="#31556F" TextWrapping="Wrap">
+                                                Positive values increase the baseline rate, while negative values decrease it. Changes apply automatically to the Optimistic and Pessimistic tabs without altering the Baseline inputs.
+                                            </TextBlock>
+                                        </Grid>
+                                    </Border>
                                 </Grid>
                                 <Border Grid.Row="2" Background="White" CornerRadius="4" Padding="5">
                                     <DataGrid ItemsSource="{Binding Results}" AutoGenerateColumns="False" FontWeight="Bold" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" ScrollViewer.VerticalScrollBarVisibility="Auto" ScrollViewer.HorizontalScrollBarVisibility="Auto">


### PR DESCRIPTION
## Summary
- replace the landing hero graphic with the .ico logo, refresh the tooltip styling, and wire the shell to expose new module tabs with context-aware action labels.
- extend water-demand forecasting with baseline-linked optimistic/pessimistic adjustments, align the advanced controls and UDV inputs into tabular layouts, and swap redundant compute buttons for calculator glyphs.
- add the standard Gantt planner and sketch workspace, enhance mind-map connectors with bend markers, and expand Excel export to emit named tables plus new module sheets.

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cc8e3d6ef88330bc2203bfd0a71125