### PR TITLE
Fix unsupported Spacing property usage in DrawingView

### DIFF
--- a/Views/DrawingView.xaml
+++ b/Views/DrawingView.xaml
@@ -33,8 +33,8 @@
                 </StackPanel>
             </Border>
             <Border Grid.Row="1" Background="{StaticResource Brush.Surface}" BorderBrush="{StaticResource Brush.Border}" BorderThickness="1" CornerRadius="8" Padding="12" Margin="0,12,0,0">
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Spacing="16">
-                    <StackPanel Width="240">
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                    <StackPanel Width="240" Margin="0,0,16,0">
                         <TextBlock Text="Pen Color" FontWeight="SemiBold"/>
                         <ListBox ItemsSource="{Binding Palette}"
                                  SelectedValuePath="Color"
@@ -74,7 +74,7 @@
                             </ListBox.ItemTemplate>
                         </ListBox>
                     </StackPanel>
-                    <StackPanel Width="180">
+                    <StackPanel Width="180" Margin="0,0,16,0">
                         <TextBlock Text="Pen Thickness" FontWeight="SemiBold"/>
                         <Slider Minimum="1"
                                 Maximum="24"


### PR DESCRIPTION
## Summary
- remove the unsupported `Spacing` attribute from the horizontal toolbar stack panel in DrawingView
- add explicit right margins to the child panels to maintain consistent spacing between controls

## Testing
- `dotnet build EconToolbox.Desktop.csproj /property:GenerateFullPaths=true /p:Configuration=Debug /p:Platform="AnyCPU" /consoleloggerparameters:NoSummary` *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc94e8b390833095d1fe40fa4ebf1d