### PR TITLE
Align layouts and add labor cost tracking to Gantt planner

### DIFF
--- a/Models/GanttTask.cs
+++ b/Models/GanttTask.cs
@@ -12,6 +12,7 @@ namespace EconToolbox.Desktop.Models
         private string _dependencies = string.Empty;
         private double _percentComplete;
         private bool _isMilestone;
+        private double _laborCostPerDay;
 
         public string Name
         {
@@ -58,6 +59,7 @@ namespace EconToolbox.Desktop.Models
                     return;
                 _durationDays = Math.Max(0, value);
                 OnPropertyChanged();
+                OnPropertyChanged(nameof(TotalCost));
             }
         }
 
@@ -109,5 +111,21 @@ namespace EconToolbox.Desktop.Models
                 OnPropertyChanged();
             }
         }
+
+        public double LaborCostPerDay
+        {
+            get => _laborCostPerDay;
+            set
+            {
+                var sanitized = Math.Max(0, value);
+                if (Math.Abs(_laborCostPerDay - sanitized) < 0.0001)
+                    return;
+                _laborCostPerDay = sanitized;
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(TotalCost));
+            }
+        }
+
+        public double TotalCost => Math.Max(0, _durationDays) * _laborCostPerDay;
     }
 }

--- a/Services/ExcelExporter.cs
+++ b/Services/ExcelExporter.cs
@@ -397,9 +397,11 @@ namespace EconToolbox.Desktop.Services
             ganttSheet.Cell(1, 3).Value = "Start";
             ganttSheet.Cell(1, 4).Value = "Finish";
             ganttSheet.Cell(1, 5).Value = "Duration (days)";
-            ganttSheet.Cell(1, 6).Value = "Dependencies";
-            ganttSheet.Cell(1, 7).Value = "% Complete";
-            ganttSheet.Cell(1, 8).Value = "Milestone";
+            ganttSheet.Cell(1, 6).Value = "Labor Cost $/day";
+            ganttSheet.Cell(1, 7).Value = "Task Cost $";
+            ganttSheet.Cell(1, 8).Value = "Dependencies";
+            ganttSheet.Cell(1, 9).Value = "Milestone";
+            ganttSheet.Cell(1, 10).Value = "% Complete";
             rowIdx = 2;
             foreach (var task in gantt.Tasks)
             {
@@ -408,15 +410,19 @@ namespace EconToolbox.Desktop.Services
                 ganttSheet.Cell(rowIdx, 3).Value = task.StartDate;
                 ganttSheet.Cell(rowIdx, 4).Value = task.EndDate;
                 ganttSheet.Cell(rowIdx, 5).Value = task.DurationDays;
-                ganttSheet.Cell(rowIdx, 6).Value = task.Dependencies;
-                ganttSheet.Cell(rowIdx, 7).Value = task.PercentComplete / 100.0;
-                ganttSheet.Cell(rowIdx, 7).Style.NumberFormat.Format = "0.00%";
-                ganttSheet.Cell(rowIdx, 8).Value = task.IsMilestone ? "Yes" : "No";
+                ganttSheet.Cell(rowIdx, 6).Value = task.LaborCostPerDay;
+                ganttSheet.Cell(rowIdx, 6).Style.NumberFormat.Format = "$#,##0.00";
+                ganttSheet.Cell(rowIdx, 7).Value = task.TotalCost;
+                ganttSheet.Cell(rowIdx, 7).Style.NumberFormat.Format = "$#,##0.00";
+                ganttSheet.Cell(rowIdx, 8).Value = task.Dependencies;
+                ganttSheet.Cell(rowIdx, 9).Value = task.IsMilestone ? "Yes" : "No";
+                ganttSheet.Cell(rowIdx, 10).Value = task.PercentComplete / 100.0;
+                ganttSheet.Cell(rowIdx, 10).Style.NumberFormat.Format = "0.00%";
                 rowIdx++;
             }
             if (rowIdx > 2)
             {
-                var ganttRange = ganttSheet.Range(1, 1, rowIdx - 1, 8);
+                var ganttRange = ganttSheet.Range(1, 1, rowIdx - 1, 10);
                 var ganttTable = ganttRange.CreateTable(GetTableName("GanttTasks", tableNames));
                 ganttTable.Theme = XLTableTheme.TableStyleMedium2;
             }
@@ -619,6 +625,7 @@ namespace EconToolbox.Desktop.Services
                 ("Project Start", ganttStart.HasValue ? (object)ganttStart.Value : "Not scheduled", ganttStart.HasValue ? "mmmm d, yyyy" : null, null, false),
                 ("Project Finish", ganttFinish.HasValue ? (object)ganttFinish.Value : "Not scheduled", ganttFinish.HasValue ? "mmmm d, yyyy" : null, null, false),
                 ("Duration (days)", ganttTaskCount > 0 ? gantt.TotalDurationDays : 0, "0", "Total span between start and finish.", false),
+                ("Total Labor Cost", gantt.TotalLaborCost, "$#,##0.00", "Sum of labor spending computed from task rates and durations.", gantt.TotalLaborCost > 0),
                 ("Milestones", milestoneCount, "0", "Tasks flagged as milestones.", milestoneCount > 0),
                 ("Average % Complete", ganttTaskCount > 0 ? averagePercent / 100.0 : 0, "0.0%", "Mean percent complete across all tasks.", false)
             };

--- a/Views/AnnualizerView.xaml
+++ b/Views/AnnualizerView.xaml
@@ -92,145 +92,142 @@
                       </StackPanel>
                   </Border>
 
-                  <TextBlock Grid.Row="1" Style="{StaticResource AnnualizerLabelStyle}">
-                      <InlineUIContainer BaselineAlignment="Center">
-                          <ContentControl Style="{StaticResource Content.InfoIcon}"
-                                          ToolTip="Initial project cost."/>
-                      </InlineUIContainer>
-                      <Run Text="First Cost"/>
-                  </TextBlock>
-                  <TextBox Grid.Row="2" Text="{Binding FirstCost}">
-                      <TextBox.Style>
-                          <Style TargetType="TextBox" BasedOn="{StaticResource AnnualizerInputStyle}">
+                  <Grid Grid.Row="1"
+                        Grid.RowSpan="14"
+                        Grid.ColumnSpan="2"
+                        Margin="0,16,0,0"
+                        Grid.IsSharedSizeScope="True">
+                      <Grid.Resources>
+                          <Style x:Key="AnnualizerFieldLabelStyle" TargetType="TextBlock">
+                              <Setter Property="Grid.Column" Value="0"/>
+                              <Setter Property="Grid.ColumnSpan" Value="1"/>
+                              <Setter Property="Margin" Value="0,16,12,4"/>
+                              <Setter Property="VerticalAlignment" Value="Center"/>
                               <Style.Triggers>
                                   <DataTrigger Binding="{Binding ActualWidth, RelativeSource={RelativeSource AncestorType=UserControl}, Converter={StaticResource WidthToLayoutModeConverter}}"
-                                               Value="Wide">
-                                      <Setter Property="Grid.Row" Value="1"/>
+                                               Value="Narrow">
+                                      <Setter Property="Grid.ColumnSpan" Value="3"/>
+                                      <Setter Property="Margin" Value="0,16,0,4"/>
                                   </DataTrigger>
                               </Style.Triggers>
                           </Style>
-                      </TextBox.Style>
-                  </TextBox>
+                          <Style x:Key="AnnualizerFieldInputStyle" TargetType="TextBox">
+                              <Setter Property="Grid.Column" Value="2"/>
+                              <Setter Property="Grid.ColumnSpan" Value="1"/>
+                              <Setter Property="Margin" Value="0,0,0,16"/>
+                              <Setter Property="HorizontalAlignment" Value="Stretch"/>
+                              <Style.Triggers>
+                                  <DataTrigger Binding="{Binding ActualWidth, RelativeSource={RelativeSource AncestorType=UserControl}, Converter={StaticResource WidthToLayoutModeConverter}}"
+                                               Value="Narrow">
+                                      <Setter Property="Grid.Column" Value="0"/>
+                                      <Setter Property="Grid.ColumnSpan" Value="3"/>
+                                      <Setter Property="Grid.Row" Value="{Binding Tag, RelativeSource={RelativeSource Self}}"/>
+                                      <Setter Property="Margin" Value="0,4,0,16"/>
+                                  </DataTrigger>
+                              </Style.Triggers>
+                          </Style>
+                      </Grid.Resources>
+                      <Grid.ColumnDefinitions>
+                          <ColumnDefinition Width="Auto" SharedSizeGroup="AnnualizerLabel"/>
+                          <ColumnDefinition Width="16"/>
+                          <ColumnDefinition Width="*" SharedSizeGroup="AnnualizerInput"/>
+                      </Grid.ColumnDefinitions>
+                      <Grid.RowDefinitions>
+                          <RowDefinition Height="Auto"/>
+                          <RowDefinition Height="Auto"/>
+                          <RowDefinition Height="Auto"/>
+                          <RowDefinition Height="Auto"/>
+                          <RowDefinition Height="Auto"/>
+                          <RowDefinition Height="Auto"/>
+                          <RowDefinition Height="Auto"/>
+                          <RowDefinition Height="Auto"/>
+                          <RowDefinition Height="Auto"/>
+                          <RowDefinition Height="Auto"/>
+                          <RowDefinition Height="Auto"/>
+                          <RowDefinition Height="Auto"/>
+                          <RowDefinition Height="Auto"/>
+                          <RowDefinition Height="Auto"/>
+                      </Grid.RowDefinitions>
 
-                  <TextBlock Grid.Row="3" Style="{StaticResource AnnualizerLabelStyle}">
-                      <InlineUIContainer BaselineAlignment="Center">
-                          <ContentControl Style="{StaticResource Content.InfoIcon}"
-                                          ToolTip="Discount rate in percent."/>
-                      </InlineUIContainer>
-                      <Run Text="Rate (%)"/>
-                  </TextBlock>
-                  <TextBox Grid.Row="4" Text="{Binding Rate}">
-                      <TextBox.Style>
-                          <Style TargetType="TextBox" BasedOn="{StaticResource AnnualizerInputStyle}">
-                              <Style.Triggers>
-                                  <DataTrigger Binding="{Binding ActualWidth, RelativeSource={RelativeSource AncestorType=UserControl}, Converter={StaticResource WidthToLayoutModeConverter}}"
-                                               Value="Wide">
-                                      <Setter Property="Grid.Row" Value="3"/>
-                                  </DataTrigger>
-                              </Style.Triggers>
-                          </Style>
-                      </TextBox.Style>
-                  </TextBox>
+                      <TextBlock Grid.Row="0"
+                                 Style="{StaticResource AnnualizerFieldLabelStyle}"
+                                 Margin="0,0,12,4">
+                          <InlineUIContainer BaselineAlignment="Center">
+                              <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                              ToolTip="Initial project cost."/>
+                          </InlineUIContainer>
+                          <Run Text="First Cost"/>
+                      </TextBlock>
+                      <TextBox Grid.Row="0"
+                               Text="{Binding FirstCost}"
+                               Tag="1">
+                          <TextBox.Style>
+                              <Style TargetType="TextBox" BasedOn="{StaticResource AnnualizerFieldInputStyle}">
+                                  <Setter Property="Margin" Value="0,0,0,16"/>
+                                  <Style.Triggers>
+                                      <DataTrigger Binding="{Binding ActualWidth, RelativeSource={RelativeSource AncestorType=UserControl}, Converter={StaticResource WidthToLayoutModeConverter}}"
+                                                   Value="Narrow">
+                                          <Setter Property="Margin" Value="0,4,0,16"/>
+                                      </DataTrigger>
+                                  </Style.Triggers>
+                              </Style>
+                          </TextBox.Style>
+                      </TextBox>
 
-                  <TextBlock Grid.Row="5" Style="{StaticResource AnnualizerLabelStyle}">
-                      <InlineUIContainer BaselineAlignment="Center">
-                          <ContentControl Style="{StaticResource Content.InfoIcon}"
-                                          ToolTip="Reference year that anchors discounting for future costs and benefits."/>
-                      </InlineUIContainer>
-                      <Run Text="Base Year"/>
-                  </TextBlock>
-                  <TextBox Grid.Row="6" Text="{Binding BaseYear}">
-                      <TextBox.Style>
-                          <Style TargetType="TextBox" BasedOn="{StaticResource AnnualizerInputStyle}">
-                              <Style.Triggers>
-                                  <DataTrigger Binding="{Binding ActualWidth, RelativeSource={RelativeSource AncestorType=UserControl}, Converter={StaticResource WidthToLayoutModeConverter}}"
-                                               Value="Wide">
-                                      <Setter Property="Grid.Row" Value="5"/>
-                                  </DataTrigger>
-                              </Style.Triggers>
-                          </Style>
-                      </TextBox.Style>
-                  </TextBox>
+                      <TextBlock Grid.Row="2" Style="{StaticResource AnnualizerFieldLabelStyle}">
+                          <InlineUIContainer BaselineAlignment="Center">
+                              <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                              ToolTip="Discount rate in percent."/>
+                          </InlineUIContainer>
+                          <Run Text="Rate (%)"/>
+                      </TextBlock>
+                      <TextBox Grid.Row="2" Text="{Binding Rate}" Tag="3" Style="{StaticResource AnnualizerFieldInputStyle}"/>
 
-                  <TextBlock Grid.Row="7" Style="{StaticResource AnnualizerLabelStyle}">
-                      <InlineUIContainer BaselineAlignment="Center">
-                          <ContentControl Style="{StaticResource Content.InfoIcon}"
-                                          ToolTip="Number of periods for capital recovery."/>
-                      </InlineUIContainer>
-                      <Run Text="Analysis Period"/>
-                  </TextBlock>
-                  <TextBox Grid.Row="8" Text="{Binding AnalysisPeriod}">
-                      <TextBox.Style>
-                          <Style TargetType="TextBox" BasedOn="{StaticResource AnnualizerInputStyle}">
-                              <Style.Triggers>
-                                  <DataTrigger Binding="{Binding ActualWidth, RelativeSource={RelativeSource AncestorType=UserControl}, Converter={StaticResource WidthToLayoutModeConverter}}"
-                                               Value="Wide">
-                                      <Setter Property="Grid.Row" Value="7"/>
-                                  </DataTrigger>
-                              </Style.Triggers>
-                          </Style>
-                      </TextBox.Style>
-                  </TextBox>
+                      <TextBlock Grid.Row="4" Style="{StaticResource AnnualizerFieldLabelStyle}">
+                          <InlineUIContainer BaselineAlignment="Center">
+                              <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                              ToolTip="Reference year that anchors discounting for future costs and benefits."/>
+                          </InlineUIContainer>
+                          <Run Text="Base Year"/>
+                      </TextBlock>
+                      <TextBox Grid.Row="4" Text="{Binding BaseYear}" Tag="5" Style="{StaticResource AnnualizerFieldInputStyle}"/>
 
-                  <TextBlock Grid.Row="9" Style="{StaticResource AnnualizerLabelStyle}">
-                      <InlineUIContainer BaselineAlignment="Center">
-                          <ContentControl Style="{StaticResource Content.InfoIcon}"
-                                          ToolTip="Annual operations and maintenance cost."/>
-                      </InlineUIContainer>
-                      <Run Text="Annual O&amp;M"/>
-                  </TextBlock>
-                  <TextBox Grid.Row="10" Text="{Binding AnnualOm}">
-                      <TextBox.Style>
-                          <Style TargetType="TextBox" BasedOn="{StaticResource AnnualizerInputStyle}">
-                              <Style.Triggers>
-                                  <DataTrigger Binding="{Binding ActualWidth, RelativeSource={RelativeSource AncestorType=UserControl}, Converter={StaticResource WidthToLayoutModeConverter}}"
-                                               Value="Wide">
-                                      <Setter Property="Grid.Row" Value="9"/>
-                                  </DataTrigger>
-                              </Style.Triggers>
-                          </Style>
-                      </TextBox.Style>
-                  </TextBox>
+                      <TextBlock Grid.Row="6" Style="{StaticResource AnnualizerFieldLabelStyle}">
+                          <InlineUIContainer BaselineAlignment="Center">
+                              <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                              ToolTip="Number of periods for capital recovery."/>
+                          </InlineUIContainer>
+                          <Run Text="Analysis Period"/>
+                      </TextBlock>
+                      <TextBox Grid.Row="6" Text="{Binding AnalysisPeriod}" Tag="7" Style="{StaticResource AnnualizerFieldInputStyle}"/>
 
-                  <TextBlock Grid.Row="11" Style="{StaticResource AnnualizerLabelStyle}">
-                      <InlineUIContainer BaselineAlignment="Center">
-                          <ContentControl Style="{StaticResource Content.InfoIcon}"
-                                          ToolTip="Expected annual benefits."/>
-                      </InlineUIContainer>
-                      <Run Text="Annual Benefits"/>
-                  </TextBlock>
-                  <TextBox Grid.Row="12" Text="{Binding AnnualBenefits}">
-                      <TextBox.Style>
-                          <Style TargetType="TextBox" BasedOn="{StaticResource AnnualizerInputStyle}">
-                              <Style.Triggers>
-                                  <DataTrigger Binding="{Binding ActualWidth, RelativeSource={RelativeSource AncestorType=UserControl}, Converter={StaticResource WidthToLayoutModeConverter}}"
-                                               Value="Wide">
-                                      <Setter Property="Grid.Row" Value="11"/>
-                                  </DataTrigger>
-                              </Style.Triggers>
-                          </Style>
-                      </TextBox.Style>
-                  </TextBox>
+                      <TextBlock Grid.Row="8" Style="{StaticResource AnnualizerFieldLabelStyle}">
+                          <InlineUIContainer BaselineAlignment="Center">
+                              <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                              ToolTip="Annual operations and maintenance cost."/>
+                          </InlineUIContainer>
+                          <Run Text="Annual O&amp;M"/>
+                      </TextBlock>
+                      <TextBox Grid.Row="8" Text="{Binding AnnualOm}" Tag="9" Style="{StaticResource AnnualizerFieldInputStyle}"/>
 
-                  <TextBlock Grid.Row="13" Style="{StaticResource AnnualizerLabelStyle}">
-                      <InlineUIContainer BaselineAlignment="Center">
-                          <ContentControl Style="{StaticResource Content.InfoIcon}"
-                                          ToolTip="Total construction duration in months used to accumulate IDC."/>
-                      </InlineUIContainer>
-                      <Run Text="Construction Months"/>
-                  </TextBlock>
-                  <TextBox Grid.Row="14" Text="{Binding ConstructionMonths}">
-                      <TextBox.Style>
-                          <Style TargetType="TextBox" BasedOn="{StaticResource AnnualizerInputStyle}">
-                              <Style.Triggers>
-                                  <DataTrigger Binding="{Binding ActualWidth, RelativeSource={RelativeSource AncestorType=UserControl}, Converter={StaticResource WidthToLayoutModeConverter}}"
-                                               Value="Wide">
-                                      <Setter Property="Grid.Row" Value="13"/>
-                                  </DataTrigger>
-                              </Style.Triggers>
-                          </Style>
-                      </TextBox.Style>
-                  </TextBox>
+                      <TextBlock Grid.Row="10" Style="{StaticResource AnnualizerFieldLabelStyle}">
+                          <InlineUIContainer BaselineAlignment="Center">
+                              <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                              ToolTip="Expected annual benefits."/>
+                          </InlineUIContainer>
+                          <Run Text="Annual Benefits"/>
+                      </TextBlock>
+                      <TextBox Grid.Row="10" Text="{Binding AnnualBenefits}" Tag="11" Style="{StaticResource AnnualizerFieldInputStyle}"/>
+
+                      <TextBlock Grid.Row="12" Style="{StaticResource AnnualizerFieldLabelStyle}">
+                          <InlineUIContainer BaselineAlignment="Center">
+                              <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                              ToolTip="Total construction duration in months used to accumulate IDC."/>
+                          </InlineUIContainer>
+                          <Run Text="Construction Months"/>
+                      </TextBlock>
+                      <TextBox Grid.Row="12" Text="{Binding ConstructionMonths}" Tag="13" Style="{StaticResource AnnualizerFieldInputStyle}"/>
+                  </Grid>
 
                   <TextBlock Grid.Row="15">
                       <TextBlock.Style>

--- a/Views/GanttView.xaml
+++ b/Views/GanttView.xaml
@@ -64,6 +64,13 @@
                                         </DataGridTemplateColumn.CellTemplate>
                                     </DataGridTemplateColumn>
                                     <DataGridTextColumn Header="Duration (days)" Binding="{Binding DurationDays, Mode=TwoWay}" Width="100"/>
+                                    <DataGridTextColumn Header="Labor Cost $/day"
+                                                        Binding="{Binding LaborCostPerDay, Mode=TwoWay, StringFormat={}{0:N2}}"
+                                                        Width="120"/>
+                                    <DataGridTextColumn Header="Task Cost $"
+                                                        Binding="{Binding TotalCost, Mode=OneWay, StringFormat={}{0:N2}}"
+                                                        Width="120"
+                                                        IsReadOnly="True"/>
                                     <DataGridTextColumn Header="Dependencies" Binding="{Binding Dependencies, Mode=TwoWay}" Width="140"/>
                                     <DataGridCheckBoxColumn Header="Milestone" Binding="{Binding IsMilestone, Mode=TwoWay}" Width="80"/>
                                     <DataGridTextColumn Header="% Complete" Binding="{Binding PercentComplete, Mode=TwoWay}" Width="90"/>
@@ -88,6 +95,11 @@
                                         <TextBlock Text="Clear"/>
                                     </StackPanel>
                                 </Button>
+                                <TextBlock Text="{Binding TotalLaborCost, StringFormat=Total Cost: {0:C2}}"
+                                           Margin="16,0,0,0"
+                                           VerticalAlignment="Center"
+                                           FontWeight="SemiBold"
+                                           Foreground="{StaticResource Brush.Primary}"/>
                             </StackPanel>
                         </StackPanel>
                     </Border>

--- a/Views/UdvView.xaml
+++ b/Views/UdvView.xaml
@@ -74,8 +74,8 @@
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto" SharedSizeGroup="UdvIcon"/>
                 <ColumnDefinition Width="Auto" SharedSizeGroup="UdvLabel"/>
-                <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="Auto" SharedSizeGroup="UdvValue"/>
+                <ColumnDefinition Width="Auto" SharedSizeGroup="UdvUnit"/>
             </Grid.ColumnDefinitions>
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>
@@ -103,7 +103,7 @@
             <TextBox Grid.Row="0"
                      Grid.Column="2"
                      Text="{Binding Points}"
-                     Width="80"
+                     MinWidth="80"
                      Margin="12,0,0,0"/>
 
             <TextBlock Grid.Row="1"
@@ -144,7 +144,7 @@
             <TextBox Grid.Row="2"
                      Grid.Column="2"
                      Text="{Binding UserDays}"
-                     Width="120"
+                     MinWidth="120"
                      Margin="12,0,0,0"/>
             <TextBlock Grid.Row="2"
                        Grid.Column="3"
@@ -172,7 +172,7 @@
             <TextBox Grid.Row="3"
                      Grid.Column="2"
                      Text="{Binding Visitation}"
-                     Width="80"
+                     MinWidth="80"
                      Margin="12,0,0,0"/>
             <TextBlock Grid.Row="3"
                        Grid.Column="3"

--- a/Views/WaterDemandView.xaml
+++ b/Views/WaterDemandView.xaml
@@ -241,7 +241,7 @@
                                                 </Style.Triggers>
                                             </Style>
                                         </Border.Style>
-                                        <Grid>
+                                        <Grid Grid.IsSharedSizeScope="True">
                                             <Grid.RowDefinitions>
                                                 <RowDefinition Height="Auto"/>
                                                 <RowDefinition Height="Auto"/>
@@ -252,30 +252,30 @@
                                                 <RowDefinition Height="Auto"/>
                                             </Grid.RowDefinitions>
                                             <Grid.ColumnDefinitions>
-                                                <ColumnDefinition Width="*"/>
-                                                <ColumnDefinition Width="Auto"/>
-                                                <ColumnDefinition Width="*"/>
+                                                <ColumnDefinition Width="*" SharedSizeGroup="ScenarioLabel"/>
+                                                <ColumnDefinition Width="Auto" SharedSizeGroup="ScenarioValue"/>
+                                                <ColumnDefinition Width="Auto" SharedSizeGroup="ScenarioValue"/>
                                             </Grid.ColumnDefinitions>
                                             <TextBlock Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="3" FontWeight="SemiBold" Foreground="#1F6AB0" Margin="0,0,0,8" Text="Scenario Variations (% change applied to baseline rates)"/>
                                             <TextBlock Grid.Row="1" Grid.Column="0" FontWeight="SemiBold" Foreground="#31556F" Text="Parameter"/>
-                                            <TextBlock Grid.Row="1" Grid.Column="1" FontWeight="SemiBold" Foreground="#31556F" Margin="24,0,24,0" Text="Optimistic"/>
-                                            <TextBlock Grid.Row="1" Grid.Column="2" FontWeight="SemiBold" Foreground="#31556F" Text="Pessimistic"/>
+                                            <TextBlock Grid.Row="1" Grid.Column="1" FontWeight="SemiBold" Foreground="#31556F" Margin="16,0,16,0" Text="Optimistic" HorizontalAlignment="Left"/>
+                                            <TextBlock Grid.Row="1" Grid.Column="2" FontWeight="SemiBold" Foreground="#31556F" Text="Pessimistic" HorizontalAlignment="Left"/>
 
                                             <TextBlock Grid.Row="2" Grid.Column="0" Text="Population growth"/>
-                                            <TextBox Grid.Row="2" Grid.Column="1" Width="80" HorizontalAlignment="Center" Text="{Binding DataContext.OptimisticPopulationGrowthChangePercent, ElementName=Root}" ToolTip="Percent change applied to the baseline population growth rate for the optimistic scenario."/>
-                                            <TextBox Grid.Row="2" Grid.Column="2" Width="80" HorizontalAlignment="Center" Text="{Binding DataContext.PessimisticPopulationGrowthChangePercent, ElementName=Root}" ToolTip="Percent change applied to the baseline population growth rate for the pessimistic scenario."/>
+                                            <TextBox Grid.Row="2" Grid.Column="1" MinWidth="90" HorizontalAlignment="Left" Text="{Binding DataContext.OptimisticPopulationGrowthChangePercent, ElementName=Root}" ToolTip="Percent change applied to the baseline population growth rate for the optimistic scenario."/>
+                                            <TextBox Grid.Row="2" Grid.Column="2" MinWidth="90" HorizontalAlignment="Left" Text="{Binding DataContext.PessimisticPopulationGrowthChangePercent, ElementName=Root}" ToolTip="Percent change applied to the baseline population growth rate for the pessimistic scenario."/>
 
                                             <TextBlock Grid.Row="3" Grid.Column="0" Text="Per capita demand change"/>
-                                            <TextBox Grid.Row="3" Grid.Column="1" Width="80" HorizontalAlignment="Center" Margin="0,4,0,0" Text="{Binding DataContext.OptimisticPerCapitaChangePercent, ElementName=Root}" ToolTip="Percent change applied to the baseline per capita demand growth rate for the optimistic scenario."/>
-                                            <TextBox Grid.Row="3" Grid.Column="2" Width="80" HorizontalAlignment="Center" Margin="0,4,0,0" Text="{Binding DataContext.PessimisticPerCapitaChangePercent, ElementName=Root}" ToolTip="Percent change applied to the baseline per capita demand growth rate for the pessimistic scenario."/>
+                                            <TextBox Grid.Row="3" Grid.Column="1" MinWidth="90" HorizontalAlignment="Left" Margin="0,4,0,0" Text="{Binding DataContext.OptimisticPerCapitaChangePercent, ElementName=Root}" ToolTip="Percent change applied to the baseline per capita demand growth rate for the optimistic scenario."/>
+                                            <TextBox Grid.Row="3" Grid.Column="2" MinWidth="90" HorizontalAlignment="Left" Margin="0,4,0,0" Text="{Binding DataContext.PessimisticPerCapitaChangePercent, ElementName=Root}" ToolTip="Percent change applied to the baseline per capita demand growth rate for the pessimistic scenario."/>
 
                                             <TextBlock Grid.Row="4" Grid.Column="0" Text="System improvements"/>
-                                            <TextBox Grid.Row="4" Grid.Column="1" Width="80" HorizontalAlignment="Center" Margin="0,4,0,0" Text="{Binding DataContext.OptimisticImprovementChangePercent, ElementName=Root}" ToolTip="Percent change applied to baseline system improvements for the optimistic scenario."/>
-                                            <TextBox Grid.Row="4" Grid.Column="2" Width="80" HorizontalAlignment="Center" Margin="0,4,0,0" Text="{Binding DataContext.PessimisticImprovementChangePercent, ElementName=Root}" ToolTip="Percent change applied to baseline system improvements for the pessimistic scenario."/>
+                                            <TextBox Grid.Row="4" Grid.Column="1" MinWidth="90" HorizontalAlignment="Left" Margin="0,4,0,0" Text="{Binding DataContext.OptimisticImprovementChangePercent, ElementName=Root}" ToolTip="Percent change applied to baseline system improvements for the optimistic scenario."/>
+                                            <TextBox Grid.Row="4" Grid.Column="2" MinWidth="90" HorizontalAlignment="Left" Margin="0,4,0,0" Text="{Binding DataContext.PessimisticImprovementChangePercent, ElementName=Root}" ToolTip="Percent change applied to baseline system improvements for the pessimistic scenario."/>
 
                                             <TextBlock Grid.Row="5" Grid.Column="0" Text="System losses"/>
-                                            <TextBox Grid.Row="5" Grid.Column="1" Width="80" HorizontalAlignment="Center" Margin="0,4,0,0" Text="{Binding DataContext.OptimisticLossChangePercent, ElementName=Root}" ToolTip="Percent change applied to baseline loss percentages for the optimistic scenario."/>
-                                            <TextBox Grid.Row="5" Grid.Column="2" Width="80" HorizontalAlignment="Center" Margin="0,4,0,0" Text="{Binding DataContext.PessimisticLossChangePercent, ElementName=Root}" ToolTip="Percent change applied to baseline loss percentages for the pessimistic scenario."/>
+                                            <TextBox Grid.Row="5" Grid.Column="1" MinWidth="90" HorizontalAlignment="Left" Margin="0,4,0,0" Text="{Binding DataContext.OptimisticLossChangePercent, ElementName=Root}" ToolTip="Percent change applied to baseline loss percentages for the optimistic scenario."/>
+                                            <TextBox Grid.Row="5" Grid.Column="2" MinWidth="90" HorizontalAlignment="Left" Margin="0,4,0,0" Text="{Binding DataContext.PessimisticLossChangePercent, ElementName=Root}" ToolTip="Percent change applied to baseline loss percentages for the pessimistic scenario."/>
 
                                             <TextBlock Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="3" Margin="0,10,0,0" FontSize="12" Foreground="#31556F" TextWrapping="Wrap">
                                                 Positive values increase the baseline rate, while negative values decrease it. Changes apply automatically to the Optimistic and Pessimistic tabs without altering the Baseline inputs.


### PR DESCRIPTION
## Summary
- align scenario variation inputs in the Water Demand Forecasting tab
- fix Unit Day Value and Cost Annualization form layouts for consistent spacing
- add labor cost inputs, per-task totals, and total cost rollups to the Gantt planner and export

## Testing
- dotnet build *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68cc99181e808330aecb4e32117bccd0