### PR TITLE
Add unique colors and tooltips to Gantt chart tasks

### DIFF
--- a/Models/GanttTask.cs
+++ b/Models/GanttTask.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Windows.Media;
 
 namespace EconToolbox.Desktop.Models
 {
@@ -13,6 +14,9 @@ namespace EconToolbox.Desktop.Models
         private double _percentComplete;
         private bool _isMilestone;
         private double _laborCostPerDay;
+        private Color _color = Colors.Transparent;
+        private SolidColorBrush _colorBrush = CreateFrozenBrush(Colors.Transparent);
+        private SolidColorBrush _borderBrush = CreateFrozenBrush(Colors.Transparent);
 
         public string Name
         {
@@ -127,5 +131,42 @@ namespace EconToolbox.Desktop.Models
         }
 
         public double TotalCost => Math.Max(0, _durationDays) * _laborCostPerDay;
+
+        public Color Color
+        {
+            get => _color;
+            set
+            {
+                if (_color == value)
+                    return;
+                _color = value;
+                _colorBrush = CreateFrozenBrush(value);
+                _borderBrush = CreateFrozenBrush(DarkenColor(value, 0.25));
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(ColorBrush));
+                OnPropertyChanged(nameof(BorderBrush));
+            }
+        }
+
+        public Brush ColorBrush => _colorBrush;
+
+        public Brush BorderBrush => _borderBrush;
+
+        private static SolidColorBrush CreateFrozenBrush(Color color)
+        {
+            var brush = new SolidColorBrush(color);
+            if (brush.CanFreeze)
+                brush.Freeze();
+            return brush;
+        }
+
+        private static Color DarkenColor(Color color, double amount)
+        {
+            amount = Math.Clamp(amount, 0, 1);
+            byte r = (byte)Math.Clamp(color.R * (1 - amount), 0, 255);
+            byte g = (byte)Math.Clamp(color.G * (1 - amount), 0, 255);
+            byte b = (byte)Math.Clamp(color.B * (1 - amount), 0, 255);
+            return Color.FromRgb(r, g, b);
+        }
     }
 }

--- a/Views/GanttView.xaml
+++ b/Views/GanttView.xaml
@@ -55,6 +55,19 @@
                                       Margin="0,0,0,8">
                                 <DataGrid.Columns>
                                     <DataGridTextColumn Header="Task" Binding="{Binding Name, Mode=TwoWay}" Width="160"/>
+                                    <DataGridTemplateColumn Header="Color" Width="70" IsReadOnly="True">
+                                        <DataGridTemplateColumn.CellTemplate>
+                                            <DataTemplate>
+                                                <Border Background="{Binding ColorBrush}"
+                                                        BorderBrush="{Binding BorderBrush}"
+                                                        BorderThickness="1"
+                                                        CornerRadius="4"
+                                                        Height="18"
+                                                        Width="36"
+                                                        HorizontalAlignment="Center"/>
+                                            </DataTemplate>
+                                        </DataGridTemplateColumn.CellTemplate>
+                                    </DataGridTemplateColumn>
                                     <DataGridTextColumn Header="Workstream" Binding="{Binding Workstream, Mode=TwoWay}" Width="110"/>
                                     <DataGridTemplateColumn Header="Start" Width="120">
                                         <DataGridTemplateColumn.CellTemplate>
@@ -143,13 +156,25 @@
                                         <ItemsControl.ItemTemplate>
                                             <DataTemplate>
                                                 <Grid>
+                                                    <Grid.ToolTip>
+                                                        <ToolTip Placement="Mouse" Padding="8">
+                                                            <StackPanel MaxWidth="260">
+                                                                <TextBlock Text="{Binding Task.Name}" FontWeight="SemiBold" TextWrapping="Wrap"/>
+                                                                <TextBlock Text="{Binding Task.StartDate, StringFormat=Start: {0:d}}"
+                                                                           Margin="0,6,0,0"
+                                                                           FontSize="11"/>
+                                                                <TextBlock Text="{Binding Task.EndDate, StringFormat=Finish: {0:d}}"
+                                                                           FontSize="11"/>
+                                                            </StackPanel>
+                                                        </ToolTip>
+                                                    </Grid.ToolTip>
                                                     <Rectangle Height="28"
                                                                Width="{Binding CanvasDurationDays, Converter={StaticResource DayToPixelConverter}}"
                                                                RadiusX="4"
                                                                RadiusY="4"
-                                                               Fill="#4F6EB8"
+                                                               Fill="{Binding Task.ColorBrush}"
                                                                Opacity="{Binding Task.PercentComplete, Converter={StaticResource PercentToOpacityConverter}}"
-                                                               Stroke="#233B70"
+                                                               Stroke="{Binding Task.BorderBrush}"
                                                                StrokeThickness="1.2">
                                                         <Rectangle.Style>
                                                             <Style TargetType="Rectangle">
@@ -163,8 +188,8 @@
                                                         </Rectangle.Style>
                                                     </Rectangle>
                                                     <Polygon Points="0,14 12,0 24,14 12,28"
-                                                             Fill="#4F6EB8"
-                                                             Stroke="#233B70"
+                                                             Fill="{Binding Task.ColorBrush}"
+                                                             Stroke="{Binding Task.BorderBrush}"
                                                              StrokeThickness="1.2">
                                                         <Polygon.Style>
                                                             <Style TargetType="Polygon">
@@ -177,22 +202,6 @@
                                                             </Style>
                                                         </Polygon.Style>
                                                     </Polygon>
-                                                    <TextBlock Text="{Binding Task.Name}"
-                                                               Foreground="White"
-                                                               FontSize="11"
-                                                               Margin="6,0,4,0"
-                                                               VerticalAlignment="Center">
-                                                        <TextBlock.Style>
-                                                            <Style TargetType="TextBlock">
-                                                                <Setter Property="Visibility" Value="Visible"/>
-                                                                <Style.Triggers>
-                                                                    <DataTrigger Binding="{Binding IsMilestone}" Value="True">
-                                                                        <Setter Property="Visibility" Value="Collapsed"/>
-                                                                    </DataTrigger>
-                                                                </Style.Triggers>
-                                                            </Style>
-                                                        </TextBlock.Style>
-                                                    </TextBlock>
                                                 </Grid>
                                             </DataTemplate>
                                         </ItemsControl.ItemTemplate>


### PR DESCRIPTION
## Summary
- assign each Gantt task a generated color with matching brushes for bindings
- generate deterministic colors for default and user-created tasks and surface the swatch in the work breakdown grid
- replace in-bar task labels with tooltips while keeping milestone and bar visuals color coordinated

## Testing
- dotnet build *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d16646cb348330bf50319638e55fb4