### PR TITLE
Update UDV visitation options and output layout

### DIFF
--- a/Services/ExcelExporter.cs
+++ b/Services/ExcelExporter.cs
@@ -359,7 +359,7 @@ namespace EconToolbox.Desktop.Services
                 {"Visitation Input", udv.VisitationInput},
                 {"Visitation Cadence", udv.VisitationPeriod},
                 {"Total User Days", udv.TotalUserDays},
-                {"Result", udv.Result}
+                {"Annual Recreation Benefit", udv.AnnualRecreationBenefit}
             };
             rowIdx = 1;
             foreach (var kv in udvData)
@@ -600,7 +600,7 @@ namespace EconToolbox.Desktop.Services
                 ("Season Length (days)", udv.SeasonDays, "0.0", "Number of operating days considered in the season.", false),
                 ("Visitation Input", udv.VisitationInput, "#,##0.##", $"Value provided on a {udv.VisitationPeriod.ToLowerInvariant()} basis.", false),
                 ("Total User Days", udv.TotalUserDays, "#,##0.##", "Season days adjusted for visitation input.", false),
-                ("Season Recreation Benefit", recreationBenefit, "$#,##0.00", "Unit Day Value × Total User Days.", true)
+                ("Annual Recreation Benefit", recreationBenefit, "$#,##0.00", "Unit Day Value × Total User Days.", true)
             };
 
             var mindMapRows = new List<(string Label, object Value, string? Format, string? Comment, bool Highlight)>

--- a/ViewModels/UdvViewModel.cs
+++ b/ViewModels/UdvViewModel.cs
@@ -16,16 +16,16 @@ namespace EconToolbox.Desktop.ViewModels
         private double _unitDayValue;
         private double _seasonDays = 120.0;
         private double _visitationInput;
-        private string _visitationPeriod = "Daily";
+        private string _visitationPeriod = "Per Day";
         private double _totalUserDays;
-        private string _result = string.Empty;
+        private double _annualRecreationBenefit;
         private PointCollection _chartPoints = new();
 
         public ObservableCollection<PointValueRow> Table { get; } = UdvModel.CreateDefaultTable();
 
         public ObservableCollection<string> RecreationTypes { get; } = new(new[] { "General", "Specialized" });
         public ObservableCollection<string> ActivityTypes { get; } = new();
-        public ObservableCollection<string> VisitationPeriods { get; } = new(new[] { "Daily", "Monthly", "Total Season" });
+        public ObservableCollection<string> VisitationPeriods { get; } = new(new[] { "Per Day", "Per Month", "Per Year" });
 
         public string RecreationType
         {
@@ -112,19 +112,10 @@ namespace EconToolbox.Desktop.ViewModels
                 {
                     _visitationPeriod = value;
                     OnPropertyChanged();
-                    OnPropertyChanged(nameof(VisitationUnitLabel));
                     RecalculateUserDays();
                 }
             }
         }
-
-        public string VisitationUnitLabel => VisitationPeriod switch
-        {
-            "Daily" => "per day",
-            "Monthly" => "per month",
-            "Total Season" => "total",
-            _ => "per day",
-        };
 
         public double TotalUserDays
         {
@@ -139,10 +130,17 @@ namespace EconToolbox.Desktop.ViewModels
             }
         }
 
-        public string Result
+        public double AnnualRecreationBenefit
         {
-            get => _result;
-            set { _result = value; OnPropertyChanged(); }
+            get => _annualRecreationBenefit;
+            private set
+            {
+                if (_annualRecreationBenefit != value)
+                {
+                    _annualRecreationBenefit = value;
+                    OnPropertyChanged();
+                }
+            }
         }
 
         public PointCollection ChartPoints
@@ -236,11 +234,12 @@ namespace EconToolbox.Desktop.ViewModels
         private void RecalculateUserDays()
         {
             const double averageDaysPerMonth = 30.4375;
+            const double daysPerYear = 365.0;
             double total = VisitationPeriod switch
             {
-                "Daily" => SeasonDays * VisitationInput,
-                "Monthly" => (SeasonDays / averageDaysPerMonth) * VisitationInput,
-                "Total Season" => VisitationInput,
+                "Per Day" => SeasonDays * VisitationInput,
+                "Per Month" => (SeasonDays / averageDaysPerMonth) * VisitationInput,
+                "Per Year" => (SeasonDays / daysPerYear) * VisitationInput,
                 _ => SeasonDays * VisitationInput,
             };
             TotalUserDays = double.IsFinite(total) ? Math.Max(0.0, total) : 0.0;
@@ -250,7 +249,7 @@ namespace EconToolbox.Desktop.ViewModels
         {
             RecalculateUserDays();
             double benefit = UdvModel.ComputeBenefit(UnitDayValue, TotalUserDays);
-            Result = $"Season Recreation Benefit: {benefit:F2}";
+            AnnualRecreationBenefit = double.IsFinite(benefit) ? benefit : 0.0;
         }
     }
 }

--- a/Views/UdvView.xaml
+++ b/Views/UdvView.xaml
@@ -72,28 +72,18 @@
               Margin="{StaticResource Margin.Stack}"
               Grid.IsSharedSizeScope="True">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="Auto" SharedSizeGroup="UdvIcon"/>
                 <ColumnDefinition Width="Auto" SharedSizeGroup="UdvLabel"/>
                 <ColumnDefinition Width="Auto" SharedSizeGroup="UdvValue"/>
-                <ColumnDefinition Width="Auto" SharedSizeGroup="UdvUnit"/>
             </Grid.ColumnDefinitions>
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
 
-            <TextBlock Grid.Row="0"
-                       Grid.Column="0"
-                       FontFamily="Segoe MDL2 Assets"
-                       Text=""
-                       Foreground="{StaticResource Brush.Primary}"
-                       Margin="{StaticResource Margin.Inline}"
-                       VerticalAlignment="Center"/>
             <StackPanel Grid.Row="0"
-                        Grid.Column="1"
+                        Grid.Column="0"
                         Orientation="Horizontal"
                         VerticalAlignment="Center"
                         Margin="{StaticResource Margin.Inline}">
@@ -102,79 +92,39 @@
                 <TextBlock Text="Point Value" Margin="4,0,0,0" VerticalAlignment="Center"/>
             </StackPanel>
             <TextBox Grid.Row="0"
-                     Grid.Column="2"
+                     Grid.Column="1"
                      Text="{Binding Points, UpdateSourceTrigger=PropertyChanged}"
                      MinWidth="80"
                      Margin="12,0,0,0"
                      TextAlignment="Right"/>
 
-            <TextBlock Grid.Row="1"
-                       Grid.Column="0"
-                       FontFamily="Segoe MDL2 Assets"
-                       Text=""
-                       Foreground="{StaticResource Brush.Primary}"
-                       Margin="{StaticResource Margin.Inline}"
-                       VerticalAlignment="Center"/>
-            <TextBlock Grid.Row="1"
-                       Grid.Column="1"
-                       Text="Unit Day Value"
-                       Margin="{StaticResource Margin.Inline}"
-                       VerticalAlignment="Center"/>
-            <TextBlock Grid.Row="1"
-                       Grid.Column="2"
-                       Grid.ColumnSpan="2"
-                       Text="{Binding UnitDayValue, StringFormat={}{0:F2}}"
-                       Margin="12,0,0,0"
-                       VerticalAlignment="Center"
-                       FontWeight="SemiBold"/>
-
-            <TextBlock Grid.Row="2"
-                       Grid.Column="0"
-                       FontFamily="Segoe MDL2 Assets"
-                       Text=""
-                       Foreground="{StaticResource Brush.Primary}"
-                       Margin="{StaticResource Margin.Inline}"
-                       VerticalAlignment="Center"/>
-            <StackPanel Grid.Row="2"
-                        Grid.Column="1"
+            <StackPanel Grid.Row="1"
+                        Grid.Column="0"
                         Orientation="Horizontal"
                         VerticalAlignment="Center"
                         Margin="{StaticResource Margin.Inline}">
                 <ContentControl Style="{StaticResource Content.InfoIcon}"
                                 ToolTip="Provide the number of days in the recreation season that will host visitors."/>
-                <TextBlock Text="Season Length" Margin="4,0,0,0" VerticalAlignment="Center"/>
+                <TextBlock Text="Season Length (days)" Margin="4,0,0,0" VerticalAlignment="Center"/>
             </StackPanel>
-            <TextBox Grid.Row="2"
-                     Grid.Column="2"
+            <TextBox Grid.Row="1"
+                     Grid.Column="1"
                      Text="{Binding SeasonDays, UpdateSourceTrigger=PropertyChanged}"
                      MinWidth="100"
                      Margin="12,0,0,0"
                      TextAlignment="Right"/>
-            <TextBlock Grid.Row="2"
-                       Grid.Column="3"
-                       Text="days"
-                       Margin="12,0,0,0"
-                       VerticalAlignment="Center"
-                       Foreground="{StaticResource Brush.TextSecondary}"/>
 
-            <TextBlock Grid.Row="3"
-                       Grid.Column="0"
-                       FontFamily="Segoe MDL2 Assets"
-                       Text=""
-                       Foreground="{StaticResource Brush.Primary}"
-                       Margin="{StaticResource Margin.Inline}"
-                       VerticalAlignment="Center"/>
-            <StackPanel Grid.Row="3"
-                        Grid.Column="1"
+            <StackPanel Grid.Row="2"
+                        Grid.Column="0"
                         Orientation="Horizontal"
                         VerticalAlignment="Center"
                         Margin="{StaticResource Margin.Inline}">
                 <ContentControl Style="{StaticResource Content.InfoIcon}"
-                                ToolTip="Enter visitation as daily, monthly, or total season figures. Adjust the selector to match your data cadence."/>
+                                ToolTip="Enter visitation as daily, monthly, or yearly figures. Adjust the selector to match your data cadence."/>
                 <TextBlock Text="Visitation Input" Margin="4,0,0,0" VerticalAlignment="Center"/>
             </StackPanel>
-            <StackPanel Grid.Row="3"
-                        Grid.Column="2"
+            <StackPanel Grid.Row="2"
+                        Grid.Column="1"
                         Orientation="Horizontal"
                         Margin="12,0,0,0"
                         VerticalAlignment="Center">
@@ -186,22 +136,9 @@
                           Margin="8,0,0,0"
                           MinWidth="120"/>
             </StackPanel>
-            <TextBlock Grid.Row="3"
-                       Grid.Column="3"
-                       Text="{Binding VisitationUnitLabel}"
-                       Margin="12,0,0,0"
-                       VerticalAlignment="Center"
-                       Foreground="{StaticResource Brush.TextSecondary}"/>
 
-            <TextBlock Grid.Row="4"
-                       Grid.Column="0"
-                       FontFamily="Segoe MDL2 Assets"
-                       Text=""
-                       Foreground="{StaticResource Brush.Primary}"
-                       Margin="{StaticResource Margin.Inline}"
-                       VerticalAlignment="Center"/>
-            <StackPanel Grid.Row="4"
-                        Grid.Column="1"
+            <StackPanel Grid.Row="3"
+                        Grid.Column="0"
                         Orientation="Horizontal"
                         VerticalAlignment="Center"
                         Margin="{StaticResource Margin.Inline}">
@@ -209,22 +146,23 @@
                                 ToolTip="Calculated total user days for the season based on visitation settings."/>
                 <TextBlock Text="Total User Days" Margin="4,0,0,0" VerticalAlignment="Center"/>
             </StackPanel>
-            <TextBlock Grid.Row="4"
-                       Grid.Column="2"
+            <TextBlock Grid.Row="3"
+                       Grid.Column="1"
                        Text="{Binding TotalUserDays, StringFormat={}{0:N0}}"
                        Margin="12,0,0,0"
                        VerticalAlignment="Center"
                        FontWeight="SemiBold"/>
-            <TextBlock Grid.Row="4"
-                       Grid.Column="3"
-                       Text="days"
-                       Margin="12,0,0,0"
-                       VerticalAlignment="Center"
-                       Foreground="{StaticResource Brush.TextSecondary}"/>
         </Grid>
         <Border Grid.Row="4" Background="#FFF7F0" BorderBrush="#E9C28E" BorderThickness="1" CornerRadius="8" Padding="{StaticResource Padding.Content}" Margin="{StaticResource Margin.Stack}">
             <StackPanel>
-                <TextBlock Text="{Binding Result}" FontWeight="Bold"/>
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                    <TextBlock Text="Unit Day Value:" FontWeight="Bold"/>
+                    <TextBlock Text="{Binding UnitDayValue, StringFormat={}{0:C2}}" Margin="6,0,0,0" FontWeight="SemiBold"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="0,4,0,0">
+                    <TextBlock Text="Annual Recreation Benefit:" FontWeight="Bold"/>
+                    <TextBlock Text="{Binding AnnualRecreationBenefit, StringFormat={}{0:C2}}" Margin="6,0,0,0" FontWeight="SemiBold"/>
+                </StackPanel>
                 <TextBlock TextWrapping="Wrap" Margin="{StaticResource Margin.TopXSmall}">
                     This total monetizes recreation by multiplying the unit day value with the total user days derived from your season length and visitation cadence. Raising the point score moves you to a higher value tier, while longer seasons or higher visitation proportionally increase the benefit.
                 </TextBlock>


### PR DESCRIPTION
## Summary
- update the UDV visitation cadence options to day, month, or year and adjust the user-day calculation accordingly
- refresh the UDV input grid by removing decorative icons, trimming unit labels, and showing the formatted Unit Day Value and Annual Recreation Benefit together in the results callout
- align the Excel export with the new Annual Recreation Benefit field and visitation cadence names

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d1727198848330b85e3e0e5a4d978d