### PR TITLE
Adjust annualizer calculations for base year offsets

### DIFF
--- a/Models/AnnualizerModel.cs
+++ b/Models/AnnualizerModel.cs
@@ -12,8 +12,9 @@ namespace EconToolbox.Desktop.Models
             double rate,
             double annualOm,
             double annualBenefits,
-            IEnumerable<(double cost, int year)>? futureCosts = null,
+            IEnumerable<(double cost, double yearOffset, double timingOffset)>? futureCosts = null,
             int analysisPeriod = 1,
+            int baseYear = 0,
             int constructionMonths = 12,
             double[]? idcCosts = null,
             string[]? idcTimings = null,
@@ -24,9 +25,10 @@ namespace EconToolbox.Desktop.Models
             double pvFuture = 0.0;
             if (futureCosts != null)
             {
-                foreach (var (cost, year) in futureCosts)
+                foreach (var (cost, yearOffset, timingOffset) in futureCosts)
                 {
-                    double pvFactor = 1.0 / Math.Pow(1.0 + rate, year);
+                    double exponent = yearOffset + timingOffset;
+                    double pvFactor = Math.Pow(1.0 + rate, -exponent);
                     pvFuture += cost * pvFactor;
                 }
             }


### PR DESCRIPTION
## Summary
- extend `AnnualizerModel.Compute` to work with base-year offsets and timing-aware future cost tuples when calculating PV
- update `AnnualizerViewModel` to supply the new offsets, keep displayed PV factors consistent, and recompute when the base year changes

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d2c35318ec8330ae0bbf4edbde2e4d