### PR TITLE
Fix future cost tuple types for annualizer computation

### DIFF
--- a/ViewModels/AnnualizerViewModel.cs
+++ b/ViewModels/AnnualizerViewModel.cs
@@ -207,7 +207,7 @@ namespace EconToolbox.Desktop.ViewModels
             try
             {
                 List<(double cost, double yearOffset, double timingOffset)> future = FutureCosts
-                    .Select(f => (f.Cost, f.Year - BaseYear, GetTimingOffset(f.Timing)))
+                    .Select(f => (f.Cost, (double)(f.Year - BaseYear), GetTimingOffset(f.Timing)))
                     .ToList();
 
                 double[]? costArr = null;


### PR DESCRIPTION
## Summary
- cast the computed year offset for future costs to double so it matches the AnnualizerModel.Compute signature

## Testing
- unable to run `dotnet build EconToolbox.Desktop.csproj -c Debug` (dotnet CLI not installed in container)


------
https://chatgpt.com/codex/tasks/task_e_68d2c7b972988330a5117af6d2ce6156