### PR TITLE
Replace unsupported StackPanel spacing in AgriculturalDamageView

### DIFF
--- a/Views/AgriculturalDamageView.xaml
+++ b/Views/AgriculturalDamageView.xaml
@@ -117,12 +117,12 @@
                                                 <TextBlock Text="{Binding CalendarWindow}"
                                                            Foreground="#4B5563"/>
                                                 <StackPanel Orientation="Horizontal"
-                                                            Margin="0,4,0,0"
-                                                            Spacing="12">
+                                                            Margin="0,4,0,0">
                                                     <TextBlock Text="{Binding VulnerabilityText}"
                                                                Foreground="#1F5134"/>
                                                     <TextBlock Text="{Binding ToleranceText}"
-                                                               Foreground="#1F5134"/>
+                                                               Foreground="#1F5134"
+                                                               Margin="12,0,0,0"/>
                                                 </StackPanel>
                                             </StackPanel>
                                         </Border>


### PR DESCRIPTION
## Summary
- remove the unsupported `Spacing` attribute from the growth stage summary StackPanel
- apply an equivalent left margin to the tolerance text so spacing remains consistent

## Testing
- `dotnet build EconToolbox.Desktop.csproj -c Debug` *(fails: dotnet CLI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2de0be28883308ae61828604fc1ee