### PR TITLE
Fix DateOnly usage for formatting day

### DIFF
--- a/ViewModels/AgriculturalDamageViewModel.cs
+++ b/ViewModels/AgriculturalDamageViewModel.cs
@@ -428,7 +428,7 @@ namespace EconToolbox.Desktop.ViewModels
         private static string FormatDay(int dayOfYear)
         {
             dayOfYear = Math.Clamp(dayOfYear, 1, 365);
-            var date = DateOnly.FromDayOfYear(dayOfYear, 2021);
+            var date = DateOnly.FromDateTime(new DateTime(2021, 1, 1).AddDays(dayOfYear - 1));
             return date.ToString("MMM d", CultureInfo.InvariantCulture);
         }
 


### PR DESCRIPTION
## Summary
- replace `DateOnly.FromDayOfYear` with an equivalent `DateOnly.FromDateTime` implementation to resolve build compatibility issues

## Testing
- dotnet build *(fails: `dotnet` command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2df1181508330a3eebe17db6339e8