### PR TITLE
Add agriculture depth-damage module with Monte Carlo visualization

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -22,14 +22,17 @@
     </Window.DataContext>
 
     <Window.Resources>
-        <ResourceDictionary>
-            <BooleanToVisibilityConverter x:Key="BoolToVisibilityConverter"/>
-            <DataTemplate DataType="{x:Type vm:EadViewModel}">
-                <views:EadView/>
-            </DataTemplate>
-            <DataTemplate DataType="{x:Type vm:UpdatedCostViewModel}">
-                <views:UpdatedCostView/>
-            </DataTemplate>
+            <ResourceDictionary>
+                <BooleanToVisibilityConverter x:Key="BoolToVisibilityConverter"/>
+                <DataTemplate DataType="{x:Type vm:EadViewModel}">
+                    <views:EadView/>
+                </DataTemplate>
+                <DataTemplate DataType="{x:Type vm:AgricultureDepthDamageViewModel}">
+                    <views:AgricultureDepthDamageView/>
+                </DataTemplate>
+                <DataTemplate DataType="{x:Type vm:UpdatedCostViewModel}">
+                    <views:UpdatedCostView/>
+                </DataTemplate>
             <DataTemplate DataType="{x:Type vm:AnnualizerViewModel}">
                 <views:AnnualizerView/>
             </DataTemplate>

--- a/ViewModels/AgricultureDepthDamageViewModel.cs
+++ b/ViewModels/AgricultureDepthDamageViewModel.cs
@@ -1,0 +1,382 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Linq;
+using System.Windows;
+using System.Windows.Input;
+
+namespace EconToolbox.Desktop.ViewModels
+{
+    public class AgricultureDepthDamageViewModel : BaseViewModel
+    {
+        private readonly RelayCommand _removeRowCommand;
+        private readonly RelayCommand _computeCommand;
+
+        public ObservableCollection<CustomRegionRow> CustomRegionRows { get; } = new();
+
+        public ObservableCollection<string> MonteCarloInsights { get; } = new();
+
+        private string _monteCarloSummary = "Add at least two probability-depth rows and press Calculate to generate insights.";
+        public string MonteCarloSummary
+        {
+            get => _monteCarloSummary;
+            private set { _monteCarloSummary = value; OnPropertyChanged(); }
+        }
+
+        private PointCollection _depthDamagePoints = new();
+        public PointCollection DepthDamagePoints
+        {
+            get => _depthDamagePoints;
+            private set { _depthDamagePoints = value; OnPropertyChanged(); }
+        }
+
+        public ICommand AddRowCommand { get; }
+
+        public ICommand RemoveRowCommand => _removeRowCommand;
+
+        public ICommand ComputeCommand => _computeCommand;
+
+        public AgricultureDepthDamageViewModel()
+        {
+            AddRowCommand = new RelayCommand(AddRow);
+            _removeRowCommand = new RelayCommand(RemoveRow, () => CustomRegionRows.Count > 1);
+            _computeCommand = new RelayCommand(Compute, CanCompute);
+
+            CustomRegionRows.CollectionChanged += CustomRegionRows_CollectionChanged;
+
+            // Seed with typical agricultural depth-damage points
+            CustomRegionRows.Add(new CustomRegionRow
+            {
+                AnnualExceedanceProbability = 0.5,
+                FloodDepthFeet = 0.0,
+                DamagePercent = 0.0
+            });
+            CustomRegionRows.Add(new CustomRegionRow
+            {
+                AnnualExceedanceProbability = 0.1,
+                FloodDepthFeet = 1.5,
+                DamagePercent = 25.0
+            });
+            CustomRegionRows.Add(new CustomRegionRow
+            {
+                AnnualExceedanceProbability = 0.02,
+                FloodDepthFeet = 3.5,
+                DamagePercent = 75.0
+            });
+
+            Compute();
+        }
+
+        private void CustomRegionRows_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        {
+            if (e.OldItems != null)
+            {
+                foreach (CustomRegionRow row in e.OldItems)
+                {
+                    row.PropertyChanged -= Row_PropertyChanged;
+                }
+            }
+
+            if (e.NewItems != null)
+            {
+                foreach (CustomRegionRow row in e.NewItems)
+                {
+                    row.PropertyChanged += Row_PropertyChanged;
+                }
+            }
+
+            _removeRowCommand.RaiseCanExecuteChanged();
+            _computeCommand.RaiseCanExecuteChanged();
+            MonteCarloSummary = "Inputs updated. Press Calculate to refresh the Monte Carlo results.";
+        }
+
+        private void Row_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            _computeCommand.RaiseCanExecuteChanged();
+            MonteCarloSummary = "Inputs updated. Press Calculate to refresh the Monte Carlo results.";
+        }
+
+        private void AddRow()
+        {
+            CustomRegionRows.Add(new CustomRegionRow
+            {
+                AnnualExceedanceProbability = 0.01,
+                FloodDepthFeet = 4.0,
+                DamagePercent = 90.0
+            });
+        }
+
+        private void RemoveRow()
+        {
+            if (CustomRegionRows.Count <= 1)
+            {
+                return;
+            }
+
+            CustomRegionRows.RemoveAt(CustomRegionRows.Count - 1);
+        }
+
+        private bool CanCompute()
+        {
+            return TryGetValidRows(out var _);
+        }
+
+        private bool TryGetValidRows(out List<CustomRegionRow> rows)
+        {
+            rows = CustomRegionRows
+                .Where(r => double.IsFinite(r.AnnualExceedanceProbability)
+                    && double.IsFinite(r.FloodDepthFeet)
+                    && double.IsFinite(r.DamagePercent))
+                .Where(r => r.AnnualExceedanceProbability >= 0 && r.AnnualExceedanceProbability <= 1)
+                .OrderByDescending(r => r.AnnualExceedanceProbability)
+                .ToList();
+
+            return rows.Count >= 2;
+        }
+
+        private void Compute()
+        {
+            if (!TryGetValidRows(out var rows))
+            {
+                MonteCarloSummary = "Enter at least two rows with valid annual exceedance probabilities to run the simulation.";
+                MonteCarloInsights.Clear();
+                DepthDamagePoints = new PointCollection();
+                return;
+            }
+
+            UpdateDepthDamagePoints(rows);
+            RunMonteCarlo(rows);
+        }
+
+        private void UpdateDepthDamagePoints(IReadOnlyCollection<CustomRegionRow> rows)
+        {
+            var ordered = rows
+                .Where(r => r.FloodDepthFeet >= 0 && r.DamagePercent >= 0)
+                .OrderBy(r => r.FloodDepthFeet)
+                .ToList();
+
+            if (ordered.Count == 0)
+            {
+                DepthDamagePoints = new PointCollection();
+                return;
+            }
+
+            // Ensure the curve starts at zero depth / zero damage
+            if (ordered[0].FloodDepthFeet > 0)
+            {
+                ordered.Insert(0, new CustomRegionRow
+                {
+                    FloodDepthFeet = 0,
+                    DamagePercent = 0,
+                    AnnualExceedanceProbability = ordered[0].AnnualExceedanceProbability
+                });
+            }
+
+            // Ensure the curve extends to the maximum depth provided
+            double maxDepth = ordered.Max(r => r.FloodDepthFeet);
+            double maxDamage = ordered.Max(r => r.DamagePercent);
+
+            PointCollection points = CreatePointCollection(ordered.Select(r => (r.FloodDepthFeet, r.DamagePercent)).ToList(), maxDepth, maxDamage);
+            DepthDamagePoints = points;
+        }
+
+        private static PointCollection CreatePointCollection(List<(double X, double Y)> data, double maxDepth, double maxDamage)
+        {
+            PointCollection points = new();
+            if (data.Count == 0)
+            {
+                return points;
+            }
+
+            double width = 360;
+            double height = 200;
+
+            double minX = data.Min(p => p.X);
+            double maxX = Math.Max(data.Max(p => p.X), Math.Max(minX + 1e-6, maxDepth));
+            double minY = data.Min(p => p.Y);
+            double maxY = Math.Max(data.Max(p => p.Y), Math.Max(minY + 1e-6, maxDamage));
+
+            double xRange = maxX - minX;
+            if (xRange <= 0) xRange = 1;
+            double yRange = maxY - minY;
+            if (yRange <= 0) yRange = 1;
+
+            foreach (var (xValue, yValue) in data)
+            {
+                double x = (xValue - minX) / xRange * width;
+                double y = height - (yValue - minY) / yRange * height;
+                points.Add(new Point(x, y));
+            }
+
+            return points;
+        }
+
+        private void RunMonteCarlo(IReadOnlyList<CustomRegionRow> rows)
+        {
+            var probabilityCurve = BuildProbabilityCurve(rows, r => r.DamagePercent, anchorValue: 0.0, anchorMaxValue: rows.Max(r => r.DamagePercent));
+            var depthCurve = BuildProbabilityCurve(rows, r => r.FloodDepthFeet, anchorValue: 0.0, anchorMaxValue: rows.Max(r => r.FloodDepthFeet));
+
+            int iterations = 5000;
+            List<double> damageSamples = new(iterations);
+            List<double> depthSamples = new(iterations);
+
+            Random random = new();
+            for (int i = 0; i < iterations; i++)
+            {
+                double exceedance = random.NextDouble();
+                double damage = Interpolate(exceedance, probabilityCurve);
+                double depth = Interpolate(exceedance, depthCurve);
+                damageSamples.Add(damage);
+                depthSamples.Add(depth);
+            }
+
+            damageSamples.Sort();
+            depthSamples.Sort();
+
+            double meanDamage = damageSamples.Average();
+            double medianDamage = GetPercentile(damageSamples, 0.5);
+            double p90Damage = GetPercentile(damageSamples, 0.9);
+            double meanDepth = depthSamples.Average();
+            double p90Depth = GetPercentile(depthSamples, 0.9);
+
+            MonteCarloSummary = $"Simulated {iterations:N0} annual events using linear interpolation across the supplied AEP curve.";
+            MonteCarloInsights.Clear();
+            MonteCarloInsights.Add($"Mean damage: {meanDamage:0.##}%");
+            MonteCarloInsights.Add($"Median damage: {medianDamage:0.##}%");
+            MonteCarloInsights.Add($"90th percentile damage: {p90Damage:0.##}%");
+            MonteCarloInsights.Add($"Average inundation depth: {meanDepth:0.##} ft");
+            MonteCarloInsights.Add($"90th percentile depth: {p90Depth:0.##} ft");
+        }
+
+        private static List<(double Probability, double Value)> BuildProbabilityCurve(
+            IEnumerable<CustomRegionRow> rows,
+            Func<CustomRegionRow, double> selector,
+            double anchorValue,
+            double anchorMaxValue)
+        {
+            List<(double Probability, double Value)> curve = rows
+                .Select(r => (Probability: ClampProbability(r.AnnualExceedanceProbability), Value: selector(r)))
+                .OrderByDescending(p => p.Probability)
+                .ToList();
+
+            if (curve.Count == 0)
+            {
+                return curve;
+            }
+
+            if (curve[0].Probability < 1.0)
+            {
+                curve.Insert(0, (1.0, anchorValue));
+            }
+
+            var last = curve[^1];
+            if (last.Probability > 0)
+            {
+                curve.Add((0.0, Math.Max(last.Value, anchorMaxValue)));
+            }
+
+            return curve;
+        }
+
+        private static double Interpolate(double probability, List<(double Probability, double Value)> curve)
+        {
+            if (curve.Count == 0)
+            {
+                return 0.0;
+            }
+
+            probability = ClampProbability(probability);
+
+            for (int i = 0; i < curve.Count - 1; i++)
+            {
+                var (p1, v1) = curve[i];
+                var (p2, v2) = curve[i + 1];
+                if (Math.Abs(p1 - p2) < 1e-9)
+                {
+                    continue;
+                }
+
+                if (probability <= p1 && probability >= p2)
+                {
+                    double t = (probability - p2) / (p1 - p2);
+                    return v2 + t * (v1 - v2);
+                }
+            }
+
+            return curve[^1].Value;
+        }
+
+        private static double GetPercentile(IReadOnlyList<double> sortedValues, double percentile)
+        {
+            if (sortedValues.Count == 0)
+            {
+                return 0.0;
+            }
+
+            percentile = Math.Clamp(percentile, 0, 1);
+            double index = (sortedValues.Count - 1) * percentile;
+            int lowerIndex = (int)Math.Floor(index);
+            int upperIndex = (int)Math.Ceiling(index);
+            if (lowerIndex == upperIndex)
+            {
+                return sortedValues[lowerIndex];
+            }
+
+            double fraction = index - lowerIndex;
+            return sortedValues[lowerIndex] + (sortedValues[upperIndex] - sortedValues[lowerIndex]) * fraction;
+        }
+
+        private static double ClampProbability(double value)
+        {
+            if (double.IsNaN(value))
+            {
+                return 0.0;
+            }
+
+            if (value < 0) return 0;
+            if (value > 1) return 1;
+            return value;
+        }
+
+        public class CustomRegionRow : BaseViewModel
+        {
+            private double _annualExceedanceProbability;
+            public double AnnualExceedanceProbability
+            {
+                get => _annualExceedanceProbability;
+                set
+                {
+                    if (Math.Abs(_annualExceedanceProbability - value) < 1e-9) return;
+                    _annualExceedanceProbability = value;
+                    OnPropertyChanged();
+                }
+            }
+
+            private double _floodDepthFeet;
+            public double FloodDepthFeet
+            {
+                get => _floodDepthFeet;
+                set
+                {
+                    if (Math.Abs(_floodDepthFeet - value) < 1e-9) return;
+                    _floodDepthFeet = value;
+                    OnPropertyChanged();
+                }
+            }
+
+            private double _damagePercent;
+            public double DamagePercent
+            {
+                get => _damagePercent;
+                set
+                {
+                    if (Math.Abs(_damagePercent - value) < 1e-9) return;
+                    _damagePercent = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+    }
+}

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -7,6 +7,7 @@ namespace EconToolbox.Desktop.ViewModels
     public class MainViewModel : BaseViewModel
     {
         public EadViewModel Ead { get; } = new();
+        public AgricultureDepthDamageViewModel AgricultureDepthDamage { get; } = new();
         public UpdatedCostViewModel UpdatedCost { get; } = new();
         public AnnualizerViewModel Annualizer { get; } = new();
         public UdvViewModel Udv { get; } = new();
@@ -73,6 +74,24 @@ namespace EconToolbox.Desktop.ViewModels
                     "Example: The Cedar River levee district pairs 0.5, 0.1, and 0.01 annual exceedance probabilities with $250K, $1.2M, and $6.8M structure damage estimates captured in its 2019 flood study.",
                     Ead,
                     Ead.ComputeCommand),
+                new ModuleDefinition(
+                    "Agriculture Depth-Damage",
+                    "Calibrate crop and structure damages for agricultural assets using custom depth-damage relationships.",
+                    new[]
+                    {
+                        "Enter annual exceedance probabilities as decimal values between 0 and 1 for each point on the curve.",
+                        "Pair each probability with the representative flood depth and percent damage for your custom region.",
+                        "Use Add/Remove Row to adjust the table before running the Monte Carlo simulation."
+                    },
+                    new[]
+                    {
+                        "Runs a Monte Carlo simulation that interpolates across your exceedance probabilities.",
+                        "Summarizes mean, median, and 90th percentile damages alongside inundation depths.",
+                        "Plots the resulting depth-damage function so you can visually confirm curve behavior."
+                    },
+                    "Example: A delta farm pairs 0.5, 0.1, and 0.02 annual exceedance probabilities with 0 ft, 1.5 ft, and 3.5 ft flood depths causing 0%, 25%, and 75% damages respectively.",
+                    AgricultureDepthDamage,
+                    AgricultureDepthDamage.ComputeCommand),
                 new ModuleDefinition(
                     "Updated Cost of Storage",
                     "Update historical costs and allocate joint expenses based on storage recommendations.",

--- a/Views/AgricultureDepthDamageView.xaml
+++ b/Views/AgricultureDepthDamageView.xaml
@@ -1,0 +1,216 @@
+<UserControl x:Class="EconToolbox.Desktop.Views.AgricultureDepthDamageView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:sys="clr-namespace:System;assembly=mscorlib"
+             Background="{StaticResource Brush.SurfaceAlt}"
+             SnapsToDevicePixels="True"
+             UseLayoutRounding="True">
+    <ScrollViewer VerticalScrollBarVisibility="Auto"
+                  HorizontalScrollBarVisibility="Disabled"
+                  Padding="{StaticResource Padding.Card}">
+        <StackPanel>
+            <Border Style="{StaticResource Border.Explainer}">
+                <StackPanel>
+                    <StackPanel Orientation="Horizontal" Margin="{StaticResource Margin.Stack}">
+                        <TextBlock FontFamily="Segoe MDL2 Assets"
+                                   Text=""
+                                   FontSize="22"
+                                   Foreground="{StaticResource Brush.Primary}"
+                                   Margin="{StaticResource Margin.Inline}"/>
+                        <TextBlock Text="Agriculture Depth-Damage Instructions"
+                                   FontWeight="Bold"
+                                   FontSize="16"
+                                   Foreground="{StaticResource Brush.Primary}"/>
+                    </StackPanel>
+                    <TextBlock Style="{StaticResource Text.Body}">
+                        <Run Text="Define annual exceedance probabilities, flood depths, and percent damages for your custom regi"/>
+                        <Run Text="on."/>
+                        <LineBreak/>
+                        <Run Text="Use the Calculate button after editing to refresh Monte Carlo insights and the plotted curve."/>
+                    </TextBlock>
+                </StackPanel>
+            </Border>
+
+            <Grid Margin="{StaticResource Margin.StackLarge}">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="2*" MinWidth="320"/>
+                    <ColumnDefinition Width="*" MinWidth="240"/>
+                </Grid.ColumnDefinitions>
+
+                <Border Grid.Row="0"
+                        Grid.Column="0"
+                        Background="{StaticResource Brush.Surface}"
+                        BorderBrush="{StaticResource Brush.Border}"
+                        BorderThickness="1"
+                        CornerRadius="6"
+                        Padding="{StaticResource Padding.Content}"
+                        Margin="0,0,{StaticResource Space.MD},0">
+                    <StackPanel>
+                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="{StaticResource Margin.Stack}">
+                            <TextBlock Text="Custom Region Depth-Damage Inputs"
+                                       FontWeight="SemiBold"
+                                       FontSize="15"/>
+                            <StackPanel Orientation="Horizontal"
+                                        HorizontalAlignment="Right"
+                                        Margin="{StaticResource Margin.InlineLarge}">
+                                <Button Command="{Binding AddRowCommand}" Width="Auto" Margin="{StaticResource Margin.Inline}" HorizontalAlignment="Left">
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Margin="0,0,6,0"/>
+                                        <TextBlock Text="Add Row"/>
+                                    </StackPanel>
+                                </Button>
+                                <Button Command="{Binding RemoveRowCommand}" Width="Auto" Margin="{StaticResource Margin.Inline}" HorizontalAlignment="Left">
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Margin="0,0,6,0"/>
+                                        <TextBlock Text="Remove Row"/>
+                                    </StackPanel>
+                                </Button>
+                            </StackPanel>
+                        </StackPanel>
+                        <DataGrid ItemsSource="{Binding CustomRegionRows}"
+                                  AutoGenerateColumns="False"
+                                  CanUserAddRows="False"
+                                  CanUserDeleteRows="False"
+                                  HeadersVisibility="Column"
+                                  Margin="0">
+                            <DataGrid.Resources>
+                                <Style TargetType="TextBlock">
+                                    <Setter Property="Margin" Value="2"/>
+                                    <Setter Property="HorizontalAlignment" Value="Stretch"/>
+                                    <Setter Property="VerticalAlignment" Value="Center"/>
+                                </Style>
+                                <Style TargetType="TextBox">
+                                    <Setter Property="Margin" Value="2"/>
+                                    <Setter Property="Padding" Value="4"/>
+                                    <Setter Property="HorizontalContentAlignment" Value="Right"/>
+                                </Style>
+                            </DataGrid.Resources>
+                            <DataGrid.Columns>
+                                <DataGridTextColumn Binding="{Binding AnnualExceedanceProbability, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, StringFormat={}{0:0.###}}"
+                                                    Width="*">
+                                    <DataGridTextColumn.Header>
+                                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                            <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                                            ToolTip="Annual Exceedance Probability (0 to 1) associated with the flood depth and damage."/>
+                                            <TextBlock Text="Annual Exceedance Probability"
+                                                       Margin="4,0,0,0"/>
+                                        </StackPanel>
+                                    </DataGridTextColumn.Header>
+                                    <DataGridTextColumn.ElementStyle>
+                                        <Style TargetType="TextBlock">
+                                            <Setter Property="TextAlignment" Value="Right"/>
+                                        </Style>
+                                    </DataGridTextColumn.ElementStyle>
+                                    <DataGridTextColumn.EditingElementStyle>
+                                        <Style TargetType="TextBox">
+                                            <Setter Property="HorizontalContentAlignment" Value="Right"/>
+                                        </Style>
+                                    </DataGridTextColumn.EditingElementStyle>
+                                </DataGridTextColumn>
+                                <DataGridTextColumn Binding="{Binding FloodDepthFeet, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, StringFormat={}{0:0.##}}"
+                                                    Width="*">
+                                    <DataGridTextColumn.Header>
+                                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                            <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                                            ToolTip="Expected flood depth in feet for the event."/>
+                                            <TextBlock Text="Flood Depth (ft)" Margin="4,0,0,0"/>
+                                        </StackPanel>
+                                    </DataGridTextColumn.Header>
+                                    <DataGridTextColumn.ElementStyle>
+                                        <Style TargetType="TextBlock">
+                                            <Setter Property="TextAlignment" Value="Right"/>
+                                        </Style>
+                                    </DataGridTextColumn.ElementStyle>
+                                    <DataGridTextColumn.EditingElementStyle>
+                                        <Style TargetType="TextBox">
+                                            <Setter Property="HorizontalContentAlignment" Value="Right"/>
+                                        </Style>
+                                    </DataGridTextColumn.EditingElementStyle>
+                                </DataGridTextColumn>
+                                <DataGridTextColumn Binding="{Binding DamagePercent, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, StringFormat={}{0:0.##}}"
+                                                    Width="*">
+                                    <DataGridTextColumn.Header>
+                                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                            <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                                            ToolTip="Percent damage relative to total agricultural value."/>
+                                            <TextBlock Text="Damage (%)" Margin="4,0,0,0"/>
+                                        </StackPanel>
+                                    </DataGridTextColumn.Header>
+                                    <DataGridTextColumn.ElementStyle>
+                                        <Style TargetType="TextBlock">
+                                            <Setter Property="TextAlignment" Value="Right"/>
+                                        </Style>
+                                    </DataGridTextColumn.ElementStyle>
+                                    <DataGridTextColumn.EditingElementStyle>
+                                        <Style TargetType="TextBox">
+                                            <Setter Property="HorizontalContentAlignment" Value="Right"/>
+                                        </Style>
+                                    </DataGridTextColumn.EditingElementStyle>
+                                </DataGridTextColumn>
+                            </DataGrid.Columns>
+                        </DataGrid>
+                    </StackPanel>
+                </Border>
+
+                <Border Grid.Row="0"
+                        Grid.Column="1"
+                        Background="{StaticResource Brush.Surface}"
+                        BorderBrush="{StaticResource Brush.Border}"
+                        BorderThickness="1"
+                        CornerRadius="6"
+                        Padding="{StaticResource Padding.Content}">
+                    <StackPanel>
+                        <TextBlock Text="Monte Carlo Insights"
+                                   FontWeight="SemiBold"
+                                   FontSize="15"
+                                   Margin="{StaticResource Margin.Stack}"/>
+                        <TextBlock Text="{Binding MonteCarloSummary}"
+                                   Style="{StaticResource Text.Body}"
+                                   Margin="{StaticResource Margin.Stack}"/>
+                        <ItemsControl ItemsSource="{Binding MonteCarloInsights}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <StackPanel Orientation="Horizontal" Margin="{StaticResource Margin.StackSmall}">
+                                        <TextBlock Text="•" Margin="0,0,6,0" FontWeight="Bold"/>
+                                        <TextBlock Text="{Binding}" Style="{StaticResource Text.Body}"/>
+                                    </StackPanel>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </StackPanel>
+                </Border>
+
+                <Border Grid.Row="1"
+                        Grid.ColumnSpan="2"
+                        Background="{StaticResource Brush.Surface}"
+                        BorderBrush="{StaticResource Brush.Border}"
+                        BorderThickness="1"
+                        CornerRadius="6"
+                        Padding="{StaticResource Padding.Content}"
+                        Margin="0,{StaticResource Space.MD},0,0">
+                    <StackPanel>
+                        <TextBlock Text="Depth-Damage Function"
+                                   FontWeight="SemiBold"
+                                   FontSize="15"
+                                   Margin="{StaticResource Margin.Stack}"/>
+                        <Canvas Height="220" Margin="{StaticResource Margin.Stack}">
+                            <Polyline Points="{Binding DepthDamagePoints}"
+                                      Stroke="{StaticResource Brush.Accent}"
+                                      StrokeThickness="3"
+                                      StrokeLineJoin="Round"/>
+                        </Canvas>
+                        <TextBlock Style="{StaticResource Text.Caption}" TextWrapping="Wrap">
+                            The plotted curve shows damage percent as a function of inundation depth using your custom inputs. Run
+                            <Run Text=" Calculate"/>
+                            <Run Text=" to refresh the visualization after edits."/>
+                        </TextBlock>
+                    </StackPanel>
+                </Border>
+            </Grid>
+        </StackPanel>
+    </ScrollViewer>
+</UserControl>

--- a/Views/AgricultureDepthDamageView.xaml.cs
+++ b/Views/AgricultureDepthDamageView.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows.Controls;
+
+namespace EconToolbox.Desktop.Views
+{
+    public partial class AgricultureDepthDamageView : UserControl
+    {
+        public AgricultureDepthDamageView()
+        {
+            InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated Agriculture Depth-Damage module with decimal annual exceedance probability inputs and Monte Carlo analysis
- expose Monte Carlo metrics and a depth-damage curve visualization alongside configurable custom region rows
- register the new view/model pair inside the main window module catalog

## Testing
- `dotnet build` *(fails: `command not found: dotnet` in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d422af20bc8330af528b7d37b52888