### PR TITLE
Ensure main window resources include theme dictionary

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -23,6 +23,9 @@
 
     <Window.Resources>
             <ResourceDictionary>
+                <ResourceDictionary.MergedDictionaries>
+                    <ResourceDictionary Source="Themes/Design.xaml"/>
+                </ResourceDictionary.MergedDictionaries>
                 <BooleanToVisibilityConverter x:Key="BoolToVisibilityConverter"/>
                 <DataTemplate DataType="{x:Type vm:EadViewModel}">
                     <views:EadView/>


### PR DESCRIPTION
## Summary
- merge the shared Themes/Design.xaml dictionary into MainWindow resources so StaticResource lookups succeed

## Testing
- dotnet build *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d43988d2688330abbb569ab7de7b9a