### PR TITLE
Fix invalid thickness resource usage in agriculture view

### DIFF
--- a/Views/AgricultureDepthDamageView.xaml
+++ b/Views/AgricultureDepthDamageView.xaml
@@ -48,7 +48,7 @@
                         BorderThickness="1"
                         CornerRadius="6"
                         Padding="{StaticResource Padding.Content}"
-                        Margin="0,0,{StaticResource Space.MD},0">
+                        Margin="{StaticResource Margin.InlineMedium}">
                     <StackPanel>
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="{StaticResource Margin.Stack}">
                             <TextBlock Text="Custom Region Depth-Damage Inputs"
@@ -191,7 +191,7 @@
                         BorderThickness="1"
                         CornerRadius="6"
                         Padding="{StaticResource Padding.Content}"
-                        Margin="0,{StaticResource Space.MD},0,0">
+                        Margin="{StaticResource Margin.TopLarge}">
                     <StackPanel>
                         <TextBlock Text="Depth-Damage Function"
                                    FontWeight="SemiBold"


### PR DESCRIPTION
## Summary
- update the AgricultureDepthDamageView margins to use thickness resources directly instead of embedding spacing doubles
- prevent runtime Thickness conversion failures when the view is materialized

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d44af6a9dc83309378f5b34a64a98e