### PR TITLE
Fix future cost tuple types

### DIFF
--- a/ViewModels/AnnualizerViewModel.cs
+++ b/ViewModels/AnnualizerViewModel.cs
@@ -207,7 +207,7 @@ namespace EconToolbox.Desktop.ViewModels
             try
             {
                 List<(double cost, double yearOffset, double timingOffset)> future = FutureCosts
-                    .Select(f => (f.Cost, f.Year - BaseYear, GetTimingOffset(f.Timing)))
+                    .Select(f => (f.Cost, (double)(f.Year - BaseYear), GetTimingOffset(f.Timing)))
                     .ToList();
 
                 double[]? costArr = null;


### PR DESCRIPTION
## Summary
- Cast the year offset to double when preparing future cost tuples so they match the AnnualizerModel signature.

## Testing
- dotnet build EconToolbox.Desktop.csproj *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68d4523b627c83309e260077332a039f