### PR TITLE
Fix invalid margin resource usage

### DIFF
--- a/Views/AgricultureDepthDamageView.xaml
+++ b/Views/AgricultureDepthDamageView.xaml
@@ -48,7 +48,7 @@
                         BorderThickness="1"
                         CornerRadius="6"
                         Padding="{StaticResource Padding.Content}"
-                        Margin="0,0,{StaticResource Space.MD},0">
+                        Margin="{StaticResource Margin.InlineMedium}">
                     <StackPanel>
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="{StaticResource Margin.Stack}">
                             <TextBlock Text="Custom Region Depth-Damage Inputs"
@@ -191,7 +191,7 @@
                         BorderThickness="1"
                         CornerRadius="6"
                         Padding="{StaticResource Padding.Content}"
-                        Margin="0,{StaticResource Space.MD},0,0">
+                        Margin="{StaticResource Margin.TopLarge}">
                     <StackPanel>
                         <TextBlock Text="Depth-Damage Function"
                                    FontWeight="SemiBold"


### PR DESCRIPTION
## Summary
- replace invalid inline Thickness definitions that referenced double resources with existing Thickness resources in AgricultureDepthDamageView

## Testing
- dotnet build EconToolbox.Desktop.sln *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68d453ab42a88330a741311cff1521a3