### PR TITLE
Restore agriculture depth-damage functionality

### DIFF
--- a/Views/AgricultureDepthDamageView.xaml
+++ b/Views/AgricultureDepthDamageView.xaml
@@ -181,6 +181,33 @@
                                 </DataTemplate>
                             </ItemsControl.ItemTemplate>
                         </ItemsControl>
+                        <Separator Margin="{StaticResource Margin.Stack}"/>
+                        <TextBlock Text="Return period checkpoints"
+                                   FontWeight="SemiBold"
+                                   Margin="{StaticResource Margin.Stack}"/>
+                        <ItemsControl ItemsSource="{Binding ReturnPeriodInsights}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <Grid Margin="{StaticResource Margin.StackSmall}">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock Text="{Binding Label}"
+                                                   Style="{StaticResource Text.Body}"/>
+                                        <TextBlock Grid.Column="1"
+                                                   Text="{Binding DamageDisplay}"
+                                                   Margin="12,0,0,0"
+                                                   Style="{StaticResource Text.Body}"/>
+                                        <TextBlock Grid.Column="2"
+                                                   Text="{Binding DepthDisplay}"
+                                                   Margin="12,0,0,0"
+                                                   Style="{StaticResource Text.Body}"/>
+                                    </Grid>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
                     </StackPanel>
                 </Border>
 


### PR DESCRIPTION
## Summary
- rebuild the agriculture depth-damage view model to validate inputs, regenerate the chart, and rerun the Monte Carlo analysis using the tab instructions as guidance
- add return-period checkpoint insights alongside the Monte Carlo results
- improve Add Row defaults so newly added probabilities, depths, and damages follow the expected descending curve

## Testing
- dotnet build *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d474b4c7d0833099f3127d20723913