### PR TITLE
Rebuild agriculture depth damage workflow

### DIFF
--- a/Views/AgricultureDepthDamageView.xaml
+++ b/Views/AgricultureDepthDamageView.xaml
@@ -1,7 +1,6 @@
 <UserControl x:Class="EconToolbox.Desktop.Views.AgricultureDepthDamageView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:sys="clr-namespace:System;assembly=mscorlib"
              Background="{StaticResource Brush.SurfaceAlt}"
              SnapsToDevicePixels="True"
              UseLayoutRounding="True">
@@ -17,16 +16,15 @@
                                    FontSize="22"
                                    Foreground="{StaticResource Brush.Primary}"
                                    Margin="{StaticResource Margin.Inline}"/>
-                        <TextBlock Text="Agriculture Depth-Damage Instructions"
+                        <TextBlock Text="Agricultural Depth-Duration Damage Guidance"
                                    FontWeight="Bold"
                                    FontSize="16"
                                    Foreground="{StaticResource Brush.Primary}"/>
                     </StackPanel>
                     <TextBlock Style="{StaticResource Text.Body}">
-                        <Run Text="Define annual exceedance probabilities, flood depths, and percent damages for your custom regi"/>
-                        <Run Text="on."/>
+                        <Run Text="Use these prompts to translate crop stage, regional flood timing, and acreage risk into a depth-duration damage estimate tailored for CE/ICA studies."/>
                         <LineBreak/>
-                        <Run Text="Use the Calculate button after editing to refresh Monte Carlo insights and the plotted curve."/>
+                        <Run Text="Update the exposure assumptions below, then select Calculate to refresh the modeled curve and summary outputs."/>
                     </TextBlock>
                 </StackPanel>
             </Border>
@@ -35,10 +33,11 @@
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="2*" MinWidth="320"/>
-                    <ColumnDefinition Width="*" MinWidth="240"/>
+                    <ColumnDefinition Width="2*" MinWidth="360"/>
+                    <ColumnDefinition Width="*" MinWidth="260"/>
                 </Grid.ColumnDefinitions>
 
                 <Border Grid.Row="0"
@@ -50,109 +49,130 @@
                         Padding="{StaticResource Padding.Content}"
                         Margin="{StaticResource Margin.InlineMedium}">
                     <StackPanel>
-                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="{StaticResource Margin.Stack}">
-                            <TextBlock Text="Custom Region Depth-Damage Inputs"
-                                       FontWeight="SemiBold"
-                                       FontSize="15"/>
-                            <StackPanel Orientation="Horizontal"
-                                        HorizontalAlignment="Right"
-                                        Margin="{StaticResource Margin.InlineLarge}">
-                                <Button Command="{Binding AddRowCommand}" Width="Auto" Margin="{StaticResource Margin.Inline}" HorizontalAlignment="Left">
-                                    <StackPanel Orientation="Horizontal">
-                                        <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Margin="0,0,6,0"/>
-                                        <TextBlock Text="Add Row"/>
-                                    </StackPanel>
-                                </Button>
-                                <Button Command="{Binding RemoveRowCommand}" Width="Auto" Margin="{StaticResource Margin.Inline}" HorizontalAlignment="Left">
-                                    <StackPanel Orientation="Horizontal">
-                                        <TextBlock FontFamily="Segoe MDL2 Assets" Text="" Margin="0,0,6,0"/>
-                                        <TextBlock Text="Remove Row"/>
-                                    </StackPanel>
-                                </Button>
+                        <TextBlock Text="Where is the field located?"
+                                   FontWeight="SemiBold"
+                                   FontSize="15"
+                                   Margin="{StaticResource Margin.Stack}"/>
+                        <ComboBox ItemsSource="{Binding Regions}"
+                                  SelectedItem="{Binding SelectedRegion}"
+                                  DisplayMemberPath="Name"
+                                  Margin="{StaticResource Margin.Stack}"
+                                  MinWidth="220"/>
+                        <TextBlock Text="{Binding SelectedRegionDescription}"
+                                   Style="{StaticResource Text.Body}"
+                                   TextWrapping="Wrap"
+                                   Margin="{StaticResource Margin.Stack}"/>
+
+                        <Separator Margin="{StaticResource Margin.Stack}"/>
+
+                        <TextBlock Text="What crop is planted on the acre?"
+                                   FontWeight="SemiBold"
+                                   FontSize="15"
+                                   Margin="{StaticResource Margin.Stack}"/>
+                        <ComboBox ItemsSource="{Binding Crops}"
+                                  SelectedItem="{Binding SelectedCrop}"
+                                  DisplayMemberPath="Name"
+                                  Margin="{StaticResource Margin.Stack}"
+                                  MinWidth="220"/>
+                        <TextBlock Text="{Binding SelectedCropDescription}"
+                                   Style="{StaticResource Text.Body}"
+                                   TextWrapping="Wrap"
+                                   Margin="{StaticResource Margin.Stack}"/>
+
+                        <Separator Margin="{StaticResource Margin.Stack}"/>
+
+                        <TextBlock Text="How resilient is the field during the season?"
+                                   FontWeight="SemiBold"
+                                   FontSize="15"
+                                   Margin="{StaticResource Margin.Stack}"/>
+
+                        <ItemsControl ItemsSource="{Binding StageExposures}"
+                                      Margin="{StaticResource Margin.StackSmall}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <Border BorderBrush="{StaticResource Brush.Border}"
+                                            BorderThickness="1"
+                                            CornerRadius="4"
+                                            Padding="{StaticResource Padding.Content}"
+                                            Margin="{StaticResource Margin.StackSmall}"
+                                            Background="{StaticResource Brush.SurfaceAlt}">
+                                        <StackPanel>
+                                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch">
+                                                <StackPanel Width="220">
+                                                    <TextBlock Text="{Binding StageName}"
+                                                               FontWeight="SemiBold"
+                                                               FontSize="14"/>
+                                                    <TextBlock Text="{Binding StageWindow}"
+                                                               Style="{StaticResource Text.Caption}"/>
+                                                </StackPanel>
+                                                <StackPanel Orientation="Horizontal"
+                                                            HorizontalAlignment="Right"
+                                                            Margin="{StaticResource Margin.InlineLarge}"
+                                                            VerticalAlignment="Center">
+                                                    <StackPanel Margin="{StaticResource Margin.Inline}">
+                                                        <TextBlock Text="Exposure (days)"
+                                                                   Style="{StaticResource Text.Caption}"/>
+                                                        <TextBox Text="{Binding ExposureDays, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, StringFormat={}{0:0.##}}"
+                                                                 HorizontalContentAlignment="Right"
+                                                                 MinWidth="80"/>
+                                                    </StackPanel>
+                                                    <StackPanel Margin="{StaticResource Margin.Inline}">
+                                                        <TextBlock Text="Flood tolerance (days)"
+                                                                   Style="{StaticResource Text.Caption}"/>
+                                                        <TextBox Text="{Binding FloodToleranceDays, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, StringFormat={}{0:0.##}}"
+                                                                 HorizontalContentAlignment="Right"
+                                                                 MinWidth="80"/>
+                                                    </StackPanel>
+                                                    <StackPanel Margin="{StaticResource Margin.Inline}">
+                                                        <Button Content="Reset"
+                                                                Command="{Binding ResetCommand}"/>
+                                                    </StackPanel>
+                                                </StackPanel>
+                                            </StackPanel>
+                                            <TextBlock Text="{Binding StageGuidance}"
+                                                       Style="{StaticResource Text.Body}"
+                                                       TextWrapping="Wrap"
+                                                       Margin="{StaticResource Margin.StackSmall}"/>
+                                            <TextBlock Text="{Binding DefaultToleranceDisplay}"
+                                                       Style="{StaticResource Text.Caption}"/>
+                                        </StackPanel>
+                                    </Border>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+
+                        <Separator Margin="{StaticResource Margin.Stack}"/>
+
+                        <Grid Margin="{StaticResource Margin.Stack}">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+                            <StackPanel Grid.Column="0"
+                                        Margin="{StaticResource Margin.Inline}">
+                                <TextBlock Text="Average response"
+                                           Style="{StaticResource Text.Caption}"/>
+                                <TextBox Text="{Binding AverageResponse, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, StringFormat={}{0:0.##}}"
+                                         HorizontalContentAlignment="Right"
+                                         MinWidth="120"/>
+                                <TextBlock Text="Scales the seasonal exposure severity."
+                                           Style="{StaticResource Text.Caption}"
+                                           TextWrapping="Wrap"
+                                           Margin="{StaticResource Margin.StackSmall}"/>
                             </StackPanel>
-                        </StackPanel>
-                        <DataGrid ItemsSource="{Binding CustomRegionRows}"
-                                  AutoGenerateColumns="False"
-                                  CanUserAddRows="False"
-                                  CanUserDeleteRows="False"
-                                  HeadersVisibility="Column"
-                                  Margin="0">
-                            <DataGrid.Resources>
-                                <Style TargetType="TextBlock">
-                                    <Setter Property="Margin" Value="2"/>
-                                    <Setter Property="HorizontalAlignment" Value="Stretch"/>
-                                    <Setter Property="VerticalAlignment" Value="Center"/>
-                                </Style>
-                                <Style TargetType="TextBox">
-                                    <Setter Property="Margin" Value="2"/>
-                                    <Setter Property="Padding" Value="4"/>
-                                    <Setter Property="HorizontalContentAlignment" Value="Right"/>
-                                </Style>
-                            </DataGrid.Resources>
-                            <DataGrid.Columns>
-                                <DataGridTextColumn Binding="{Binding AnnualExceedanceProbability, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, StringFormat={}{0:0.###}}"
-                                                    Width="*">
-                                    <DataGridTextColumn.Header>
-                                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                            <ContentControl Style="{StaticResource Content.InfoIcon}"
-                                                            ToolTip="Annual Exceedance Probability (0 to 1) associated with the flood depth and damage."/>
-                                            <TextBlock Text="Annual Exceedance Probability"
-                                                       Margin="4,0,0,0"/>
-                                        </StackPanel>
-                                    </DataGridTextColumn.Header>
-                                    <DataGridTextColumn.ElementStyle>
-                                        <Style TargetType="TextBlock">
-                                            <Setter Property="TextAlignment" Value="Right"/>
-                                        </Style>
-                                    </DataGridTextColumn.ElementStyle>
-                                    <DataGridTextColumn.EditingElementStyle>
-                                        <Style TargetType="TextBox">
-                                            <Setter Property="HorizontalContentAlignment" Value="Right"/>
-                                        </Style>
-                                    </DataGridTextColumn.EditingElementStyle>
-                                </DataGridTextColumn>
-                                <DataGridTextColumn Binding="{Binding FloodDepthFeet, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, StringFormat={}{0:0.##}}"
-                                                    Width="*">
-                                    <DataGridTextColumn.Header>
-                                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                            <ContentControl Style="{StaticResource Content.InfoIcon}"
-                                                            ToolTip="Expected flood depth in feet for the event."/>
-                                            <TextBlock Text="Flood Depth (ft)" Margin="4,0,0,0"/>
-                                        </StackPanel>
-                                    </DataGridTextColumn.Header>
-                                    <DataGridTextColumn.ElementStyle>
-                                        <Style TargetType="TextBlock">
-                                            <Setter Property="TextAlignment" Value="Right"/>
-                                        </Style>
-                                    </DataGridTextColumn.ElementStyle>
-                                    <DataGridTextColumn.EditingElementStyle>
-                                        <Style TargetType="TextBox">
-                                            <Setter Property="HorizontalContentAlignment" Value="Right"/>
-                                        </Style>
-                                    </DataGridTextColumn.EditingElementStyle>
-                                </DataGridTextColumn>
-                                <DataGridTextColumn Binding="{Binding DamagePercent, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, StringFormat={}{0:0.##}}"
-                                                    Width="*">
-                                    <DataGridTextColumn.Header>
-                                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                            <ContentControl Style="{StaticResource Content.InfoIcon}"
-                                                            ToolTip="Percent damage relative to total agricultural value."/>
-                                            <TextBlock Text="Damage (%)" Margin="4,0,0,0"/>
-                                        </StackPanel>
-                                    </DataGridTextColumn.Header>
-                                    <DataGridTextColumn.ElementStyle>
-                                        <Style TargetType="TextBlock">
-                                            <Setter Property="TextAlignment" Value="Right"/>
-                                        </Style>
-                                    </DataGridTextColumn.ElementStyle>
-                                    <DataGridTextColumn.EditingElementStyle>
-                                        <Style TargetType="TextBox">
-                                            <Setter Property="HorizontalContentAlignment" Value="Right"/>
-                                        </Style>
-                                    </DataGridTextColumn.EditingElementStyle>
-                                </DataGridTextColumn>
-                            </DataGrid.Columns>
-                        </DataGrid>
+                            <StackPanel Grid.Column="1"
+                                        Margin="{StaticResource Margin.Inline}">
+                                <TextBlock Text="Simulation years"
+                                           Style="{StaticResource Text.Caption}"/>
+                                <TextBox Text="{Binding SimulationYears, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                         HorizontalContentAlignment="Right"
+                                         MinWidth="120"/>
+                                <TextBlock Text="Used in the narrative to describe modeled seasons."
+                                           Style="{StaticResource Text.Caption}"
+                                           TextWrapping="Wrap"
+                                           Margin="{StaticResource Margin.StackSmall}"/>
+                            </StackPanel>
+                        </Grid>
                     </StackPanel>
                 </Border>
 
@@ -164,50 +184,37 @@
                         CornerRadius="6"
                         Padding="{StaticResource Padding.Content}">
                     <StackPanel>
-                        <TextBlock Text="Monte Carlo Insights"
+                        <TextBlock Text="Modeled impact probability"
                                    FontWeight="SemiBold"
                                    FontSize="15"
                                    Margin="{StaticResource Margin.Stack}"/>
-                        <TextBlock Text="{Binding MonteCarloSummary}"
+                        <TextBlock Text="{Binding ModeledImpactProbabilityDisplay}"
+                                   FontSize="32"
+                                   FontWeight="Bold"
+                                   Foreground="{StaticResource Brush.Primary}"
+                                   Margin="{StaticResource Margin.Stack}"/>
+                        <TextBlock Text="{Binding ImpactSummary}"
                                    Style="{StaticResource Text.Body}"
+                                   TextWrapping="Wrap"
                                    Margin="{StaticResource Margin.Stack}"/>
-                        <ItemsControl ItemsSource="{Binding MonteCarloInsights}">
-                            <ItemsControl.ItemTemplate>
-                                <DataTemplate>
-                                    <StackPanel Orientation="Horizontal" Margin="{StaticResource Margin.StackSmall}">
-                                        <TextBlock Text="•" Margin="0,0,6,0" FontWeight="Bold"/>
-                                        <TextBlock Text="{Binding}" Style="{StaticResource Text.Body}"/>
-                                    </StackPanel>
-                                </DataTemplate>
-                            </ItemsControl.ItemTemplate>
-                        </ItemsControl>
                         <Separator Margin="{StaticResource Margin.Stack}"/>
-                        <TextBlock Text="Return period checkpoints"
+                        <TextBlock Text="Mean crop insight"
                                    FontWeight="SemiBold"
+                                   FontSize="15"
                                    Margin="{StaticResource Margin.Stack}"/>
-                        <ItemsControl ItemsSource="{Binding ReturnPeriodInsights}">
-                            <ItemsControl.ItemTemplate>
-                                <DataTemplate>
-                                    <Grid Margin="{StaticResource Margin.StackSmall}">
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="*"/>
-                                            <ColumnDefinition Width="Auto"/>
-                                            <ColumnDefinition Width="Auto"/>
-                                        </Grid.ColumnDefinitions>
-                                        <TextBlock Text="{Binding Label}"
-                                                   Style="{StaticResource Text.Body}"/>
-                                        <TextBlock Grid.Column="1"
-                                                   Text="{Binding DamageDisplay}"
-                                                   Margin="12,0,0,0"
-                                                   Style="{StaticResource Text.Body}"/>
-                                        <TextBlock Grid.Column="2"
-                                                   Text="{Binding DepthDisplay}"
-                                                   Margin="12,0,0,0"
-                                                   Style="{StaticResource Text.Body}"/>
-                                    </Grid>
-                                </DataTemplate>
-                            </ItemsControl.ItemTemplate>
-                        </ItemsControl>
+                        <TextBlock Text="{Binding CropInsight}"
+                                   Style="{StaticResource Text.Body}"
+                                   TextWrapping="Wrap"
+                                   Margin="{StaticResource Margin.Stack}"/>
+                        <Separator Margin="{StaticResource Margin.Stack}"/>
+                        <StackPanel Orientation="Horizontal" Margin="{StaticResource Margin.Stack}">
+                            <TextBlock Text="Average damage across scenarios:"
+                                       Style="{StaticResource Text.Body}"/>
+                            <TextBlock Text="{Binding MeanDamageDisplay}"
+                                       FontWeight="SemiBold"
+                                       Foreground="{StaticResource Brush.Primary}"
+                                       Margin="{StaticResource Margin.Inline}"/>
+                        </StackPanel>
                     </StackPanel>
                 </Border>
 
@@ -220,23 +227,52 @@
                         Padding="{StaticResource Padding.Content}"
                         Margin="{StaticResource Margin.TopLarge}">
                     <StackPanel>
-                        <TextBlock Text="Depth-Damage Function"
+                        <TextBlock Text="Depth-duration-damage table"
                                    FontWeight="SemiBold"
                                    FontSize="15"
                                    Margin="{StaticResource Margin.Stack}"/>
-                        <Canvas Height="220" Margin="{StaticResource Margin.Stack}">
-                            <Polyline Points="{Binding DepthDamagePoints}"
-                                      Stroke="{StaticResource Brush.Accent}"
-                                      StrokeThickness="3"
-                                      StrokeLineJoin="Round"/>
-                        </Canvas>
-                        <TextBlock Style="{StaticResource Text.Caption}" TextWrapping="Wrap">
-                            The plotted curve shows damage percent as a function of inundation depth using your custom inputs. Run
-                            <Run Text=" Calculate"/>
-                            <Run Text=" to refresh the visualization after edits."/>
-                        </TextBlock>
+                        <DataGrid ItemsSource="{Binding DepthDurationRows}"
+                                  AutoGenerateColumns="False"
+                                  CanUserAddRows="False"
+                                  CanUserDeleteRows="False"
+                                  HeadersVisibility="Column"
+                                  Margin="0"
+                                  IsReadOnly="True">
+                            <DataGrid.Resources>
+                                <Style TargetType="TextBlock">
+                                    <Setter Property="Margin" Value="2"/>
+                                    <Setter Property="VerticalAlignment" Value="Center"/>
+                                </Style>
+                            </DataGrid.Resources>
+                            <DataGrid.Columns>
+                                <DataGridTextColumn Binding="{Binding DepthFeet, StringFormat={}{0:0.##}}"
+                                                    Width="*"
+                                                    Header="Depth (ft)"/>
+                                <DataGridTextColumn Binding="{Binding DurationDays, StringFormat={}{0:0.##}}"
+                                                    Width="*"
+                                                    Header="Duration (days)"/>
+                                <DataGridTextColumn Binding="{Binding DamagePercent, StringFormat={}{0:0.##}}" Width="*">
+                                    <DataGridTextColumn.Header>
+                                        <TextBlock Text="Damage (%)"/>
+                                    </DataGridTextColumn.Header>
+                                </DataGridTextColumn>
+                            </DataGrid.Columns>
+                        </DataGrid>
                     </StackPanel>
                 </Border>
+
+                <StackPanel Grid.Row="2"
+                            Grid.ColumnSpan="2"
+                            Orientation="Horizontal"
+                            HorizontalAlignment="Right"
+                            Margin="{StaticResource Margin.StackLarge}">
+                    <Button Content="Calculate"
+                            Command="{Binding ComputeCommand}"
+                            Margin="{StaticResource Margin.Inline}"/>
+                    <Button Content="CSV Export"
+                            Command="{Binding ExportCommand}"
+                            Margin="{StaticResource Margin.Inline}"/>
+                </StackPanel>
             </Grid>
         </StackPanel>
     </ScrollViewer>


### PR DESCRIPTION
## Summary
- rebuild the agriculture depth damage view model with regional profiles, crop definitions, stage resilience inputs, and CSV export support
- redesign the agriculture depth damage view to match the legacy layout with region/crop selectors, stage editors, summary cards, and a depth-duration damage table

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d477f993b8833083c0ed12b68e7dab