### PR TITLE
Revamp agricultural depth damage region inputs

### DIFF
--- a/Views/AgricultureDepthDamageView.xaml
+++ b/Views/AgricultureDepthDamageView.xaml
@@ -53,6 +53,10 @@
                                    FontWeight="SemiBold"
                                    FontSize="15"
                                    Margin="{StaticResource Margin.Stack}"/>
+                        <TextBlock Text="Pick the USACE hydrologic region that best matches watershed timing. The selection shifts planting windows and flood season sampling."
+                                   Style="{StaticResource Text.Body}"
+                                   TextWrapping="Wrap"
+                                   Margin="{StaticResource Margin.Stack}"/>
                         <ComboBox ItemsSource="{Binding Regions}"
                                   SelectedItem="{Binding SelectedRegion}"
                                   DisplayMemberPath="Name"
@@ -71,53 +75,98 @@
                                 Padding="{StaticResource Padding.Content}"
                                 Margin="{StaticResource Margin.Stack}">
                             <StackPanel>
-                                <TextBlock Text="Region parameters"
+                                <TextBlock Text="Custom region inputs"
                                            FontWeight="SemiBold"
                                            FontSize="14"
                                            Margin="{StaticResource Margin.StackSmall}"/>
-                                <TextBlock Text="Review or adjust the name, description, impact modifier, and depth-duration anchor points for the selected region."
+                                <TextBlock Text="Adjust flood season timing, growing season shift, and annual probability to reflect local watershed conditions."
                                            Style="{StaticResource Text.Caption}"
                                            TextWrapping="Wrap"
                                            Margin="{StaticResource Margin.StackSmall}"/>
-                                <TextBox Text="{Binding SelectedRegion.Name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                         Margin="{StaticResource Margin.StackSmall}"
-                                         ToolTip="Display name for the selected region shown in the drop-down list."/>
-                                <TextBox Text="{Binding SelectedRegion.Description, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                         Margin="{StaticResource Margin.StackSmall}"
-                                         AcceptsReturn="True"
-                                         TextWrapping="Wrap"
-                                         MinHeight="60"
-                                         ToolTip="Narrative description that will appear beneath the region selector."/>
-                                <StackPanel Orientation="Horizontal"
-                                            Margin="{StaticResource Margin.StackSmall}">
-                                    <StackPanel Width="140"
-                                                Margin="{StaticResource Margin.Inline}">
-                                        <TextBlock Text="Impact modifier"
+                                <Grid Margin="{StaticResource Margin.StackSmall}">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="*"/>
+                                    </Grid.ColumnDefinitions>
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                    </Grid.RowDefinitions>
+
+                                    <StackPanel Grid.Row="0"
+                                                Grid.Column="0"
+                                                Margin="{StaticResource Margin.StackSmall}">
+                                        <TextBlock Text="Region name"
                                                    Style="{StaticResource Text.Caption}"/>
-                                        <TextBox Text="{Binding SelectedRegion.ImpactModifier, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, StringFormat={}{0:0.###}}"
-                                                 HorizontalContentAlignment="Right"
-                                                 ToolTip="Multiplier that scales the modeled impact probability for this region."/>
+                                        <TextBox Text="{Binding SelectedRegion.Name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                 ToolTip="Display name for the selected region shown in the drop-down list."/>
                                     </StackPanel>
-                                    <StackPanel Width="140"
-                                                Margin="{StaticResource Margin.Inline}">
-                                        <TextBlock Text="Flood window start (day)"
+
+                                    <StackPanel Grid.Row="0"
+                                                Grid.Column="1"
+                                                Margin="{StaticResource Margin.StackSmall}">
+                                        <TextBlock Text="Annual Exceedance Probability"
+                                                   Style="{StaticResource Text.Caption}"/>
+                                        <TextBox Text="{Binding SelectedRegion.AnnualExceedanceProbability, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, StringFormat={}{0:0.###}}"
+                                                 HorizontalContentAlignment="Right"
+                                                 ToolTip="Probability that a damaging flood occurs in an average year (0–1)."/>
+                                    </StackPanel>
+
+                                    <StackPanel Grid.Row="1"
+                                                Grid.Column="0"
+                                                Margin="{StaticResource Margin.StackSmall}">
+                                        <TextBlock Text="Flood season start (day)"
                                                    Style="{StaticResource Text.Caption}"/>
                                         <TextBox Text="{Binding SelectedRegion.FloodWindowStartDay, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                                  HorizontalContentAlignment="Right"
                                                  ToolTip="First day of year when flooding typically begins for the selected region."/>
                                     </StackPanel>
-                                    <StackPanel Width="140"
-                                                Margin="{StaticResource Margin.Inline}">
-                                        <TextBlock Text="Flood window end (day)"
+
+                                    <StackPanel Grid.Row="1"
+                                                Grid.Column="1"
+                                                Margin="{StaticResource Margin.StackSmall}">
+                                        <TextBlock Text="Flood season peak (day)"
+                                                   Style="{StaticResource Text.Caption}"/>
+                                        <TextBox Text="{Binding SelectedRegion.FloodSeasonPeakDay, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                 HorizontalContentAlignment="Right"
+                                                 ToolTip="Day of year when flood likelihood typically peaks for the selected region."/>
+                                    </StackPanel>
+
+                                    <StackPanel Grid.Row="2"
+                                                Grid.Column="0"
+                                                Margin="{StaticResource Margin.StackSmall}">
+                                        <TextBlock Text="Flood season end (day)"
                                                    Style="{StaticResource Text.Caption}"/>
                                         <TextBox Text="{Binding SelectedRegion.FloodWindowEndDay, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                                  HorizontalContentAlignment="Right"
                                                  ToolTip="Last day of year when flooding commonly occurs for the selected region."/>
                                     </StackPanel>
-                                </StackPanel>
-                                <TextBlock Text="{Binding SelectedRegion.FloodWindowRangeDisplay}"
-                                           Style="{StaticResource Text.Caption}"
-                                           Margin="{StaticResource Margin.StackSmall}"/>
+
+                                    <StackPanel Grid.Row="2"
+                                                Grid.Column="1"
+                                                Margin="{StaticResource Margin.StackSmall}">
+                                        <TextBlock Text="Season shift (days)"
+                                                   Style="{StaticResource Text.Caption}"/>
+                                        <TextBox Text="{Binding SelectedRegion.SeasonShiftDays, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                 HorizontalContentAlignment="Right"
+                                                 ToolTip="Shifts the growing season timeline relative to the flood season (negative = earlier)."/>
+                                    </StackPanel>
+
+                                    <StackPanel Grid.Row="3"
+                                                Grid.Column="0"
+                                                Grid.ColumnSpan="2"
+                                                Margin="{StaticResource Margin.StackSmall}">
+                                        <TextBlock Text="Description"
+                                                   Style="{StaticResource Text.Caption}"/>
+                                        <TextBox Text="{Binding SelectedRegion.Description, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                 AcceptsReturn="True"
+                                                 TextWrapping="Wrap"
+                                                 MinHeight="60"
+                                                 ToolTip="Narrative description that will appear beneath the region selector."/>
+                                    </StackPanel>
+                                </Grid>
                                 <DataGrid ItemsSource="{Binding SelectedRegion.DepthDuration}"
                                           SelectedItem="{Binding SelectedRegionPoint}"
                                           AutoGenerateColumns="False"


### PR DESCRIPTION
## Summary
- add annual exceedance probability, flood season peak, and season shift fields to agricultural region definitions with sensible defaults and validation
- redesign the region inputs card to match the latest guidance, including updated helper copy and an "Annual Exceedance Probability" input label

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d599dba0ec8330bd9c7e8cb4488e6a