### PR TITLE
Allow decimal AEP input

### DIFF
--- a/ViewModels/AgricultureDepthDamageViewModel.cs
+++ b/ViewModels/AgricultureDepthDamageViewModel.cs
@@ -579,6 +579,33 @@ namespace EconToolbox.Desktop.ViewModels
 
                     _annualExceedanceProbability = adjusted;
                     OnPropertyChanged();
+                    OnPropertyChanged(nameof(AnnualExceedanceProbabilityDisplay));
+                }
+            }
+
+            public string AnnualExceedanceProbabilityDisplay
+            {
+                get => _annualExceedanceProbability.ToString("0.###", CultureInfo.CurrentCulture);
+                set
+                {
+                    string trimmed = value?.Trim() ?? string.Empty;
+                    if (trimmed.Length == 0)
+                    {
+                        return;
+                    }
+
+                    var numberFormat = CultureInfo.CurrentCulture.NumberFormat;
+                    if (trimmed.EndsWith(numberFormat.NumberDecimalSeparator, StringComparison.Ordinal) ||
+                        trimmed == numberFormat.NegativeSign ||
+                        trimmed == numberFormat.PositiveSign)
+                    {
+                        return;
+                    }
+
+                    if (double.TryParse(trimmed, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.CurrentCulture, out double parsed))
+                    {
+                        AnnualExceedanceProbability = parsed;
+                    }
                 }
             }
 

--- a/Views/AgricultureDepthDamageView.xaml
+++ b/Views/AgricultureDepthDamageView.xaml
@@ -109,7 +109,7 @@
                                                 Margin="{StaticResource Margin.StackSmall}">
                                         <TextBlock Text="Annual Exceedance Probability"
                                                    Style="{StaticResource Text.Caption}"/>
-                                        <TextBox Text="{Binding SelectedRegion.AnnualExceedanceProbability, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, StringFormat={}{0:0.###}}"
+                                        <TextBox Text="{Binding SelectedRegion.AnnualExceedanceProbabilityDisplay, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                                  HorizontalContentAlignment="Right"
                                                  ToolTip="Probability that a damaging flood occurs in an average year (0–1)."/>
                                     </StackPanel>


### PR DESCRIPTION
## Summary
- add a formatted string proxy property for Annual Exceedance Probability so partial decimal input is preserved
- update the agriculture depth-duration view to bind to the new display property for editable text

## Testing
- ⚠️ `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d59f56c0b48330aa1fe369474ffed5