### PR TITLE
Add seasonal timing overlap adjustments for agriculture stages

### DIFF
--- a/Views/AgricultureDepthDamageView.xaml
+++ b/Views/AgricultureDepthDamageView.xaml
@@ -331,6 +331,9 @@
                                                                FontSize="14"/>
                                                     <TextBlock Text="{Binding StageWindow}"
                                                                Style="{StaticResource Text.Caption}"/>
+                                                    <TextBlock Text="{Binding TimingWindowDisplay}"
+                                                               Style="{StaticResource Text.Caption}"
+                                                               TextWrapping="Wrap"/>
                                                 </StackPanel>
                                                 <StackPanel Orientation="Horizontal"
                                                             HorizontalAlignment="Right"
@@ -361,6 +364,9 @@
                                             <TextBlock Text="{Binding StageGuidance}"
                                                        Style="{StaticResource Text.Body}"
                                                        TextWrapping="Wrap"
+                                                       Margin="{StaticResource Margin.StackSmall}"/>
+                                            <TextBlock Text="{Binding TimingModifierDisplay}"
+                                                       Style="{StaticResource Text.Caption}"
                                                        Margin="{StaticResource Margin.StackSmall}"/>
                                             <TextBlock Text="{Binding DefaultToleranceDisplay}"
                                                        Style="{StaticResource Text.Caption}"/>


### PR DESCRIPTION
## Summary
- compute timing overlap between each growth stage and the selected region's flood window, and scale stress ratios accordingly
- surface day-of-year metadata and shifted timing guidance for each stage, including UI updates for overlap modifiers
- auto-recompute results when flood-window inputs change and expand summary/insight messaging to explain the timing effect

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5a9ab3f448330a4a480f232529348