### PR TITLE
Improve UI styling and guidance across economic tools

### DIFF
--- a/Themes/Design.xaml
+++ b/Themes/Design.xaml
@@ -3,13 +3,13 @@
                     xmlns:sys="clr-namespace:System;assembly=System.Runtime"
                     xmlns:converters="clr-namespace:EconToolbox.Desktop.Converters">
     <!-- Color palette -->
-    <Color x:Key="Color.Primary">#2D6A8E</Color>
-    <Color x:Key="Color.Accent">#1ABC9C</Color>
+    <Color x:Key="Color.Primary">#164A75</Color>
+    <Color x:Key="Color.Accent">#00A189</Color>
     <Color x:Key="Color.Surface">#FFFFFFFF</Color>
-    <Color x:Key="Color.SurfaceAlt">#F4F7FB</Color>
-    <Color x:Key="Color.Border">#D0E4F2</Color>
-    <Color x:Key="Color.TextPrimary">#12212F</Color>
-    <Color x:Key="Color.TextSecondary">#31556F</Color>
+    <Color x:Key="Color.SurfaceAlt">#F2F6FA</Color>
+    <Color x:Key="Color.Border">#CBD9E6</Color>
+    <Color x:Key="Color.TextPrimary">#102337</Color>
+    <Color x:Key="Color.TextSecondary">#3B5B75</Color>
 
     <!-- Brushes -->
     <SolidColorBrush x:Key="Brush.Primary" Color="{StaticResource Color.Primary}"/>
@@ -19,10 +19,12 @@
     <SolidColorBrush x:Key="Brush.Border" Color="{StaticResource Color.Border}"/>
     <SolidColorBrush x:Key="Brush.TextPrimary" Color="{StaticResource Color.TextPrimary}"/>
     <SolidColorBrush x:Key="Brush.TextSecondary" Color="{StaticResource Color.TextSecondary}"/>
-    <Color x:Key="Color.HighlightBackground">#E6F2F8</Color>
-    <Color x:Key="Color.HighlightBorder">#AFCDE0</Color>
+    <Color x:Key="Color.HighlightBackground">#E6F3F7</Color>
+    <Color x:Key="Color.HighlightBorder">#9CC7D5</Color>
     <SolidColorBrush x:Key="Brush.HighlightBackground" Color="{StaticResource Color.HighlightBackground}"/>
     <SolidColorBrush x:Key="Brush.HighlightBorder" Color="{StaticResource Color.HighlightBorder}"/>
+    <SolidColorBrush x:Key="Brush.ChartGrid" Color="#DCE7F1"/>
+    <SolidColorBrush x:Key="Brush.ChartFill" Color="#F7FBFF"/>
     <converters:OffsetConverter x:Key="OffsetConverter"/>
     <converters:DayToPixelConverter x:Key="DayToPixelConverter"/>
     <converters:DayToPixelConverter x:Key="RowToPixelConverter" Scale="44"/>
@@ -75,6 +77,7 @@
         <Setter Property="FontSize" Value="12"/>
         <Setter Property="FontWeight" Value="SemiBold"/>
         <Setter Property="Foreground" Value="{StaticResource Brush.TextSecondary}"/>
+        <Setter Property="TextWrapping" Value="Wrap"/>
     </Style>
 
     <Style x:Key="Text.Body" TargetType="TextBlock">
@@ -82,6 +85,7 @@
         <Setter Property="FontSize" Value="14"/>
         <Setter Property="Foreground" Value="{StaticResource Brush.TextPrimary}"/>
         <Setter Property="TextWrapping" Value="Wrap"/>
+        <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
     </Style>
 
     <Style x:Key="Text.Title" TargetType="TextBlock">
@@ -110,34 +114,156 @@
     <Style TargetType="Button">
         <Setter Property="Background" Value="{StaticResource Brush.Primary}"/>
         <Setter Property="Foreground" Value="White"/>
-        <Setter Property="Padding" Value="12,6"/>
+        <Setter Property="Padding" Value="12,8"/>
         <Setter Property="Margin" Value="{StaticResource Margin.Stack}"/>
         <Setter Property="BorderThickness" Value="0"/>
         <Setter Property="FontWeight" Value="SemiBold"/>
         <Setter Property="HorizontalAlignment" Value="Stretch"/>
+        <Setter Property="Cursor" Value="Hand"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="border"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{StaticResource Brush.Primary}"
+                            BorderThickness="1"
+                            CornerRadius="8"
+                            SnapsToDevicePixels="True">
+                        <ContentPresenter Margin="{TemplateBinding Padding}"
+                                          HorizontalAlignment="Center"
+                                          VerticalAlignment="Center"/>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter TargetName="border" Property="Opacity" Value="0.55"/>
+                        </Trigger>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="border" Property="Background" Value="{StaticResource Brush.Accent}"/>
+                            <Setter TargetName="border" Property="BorderBrush" Value="{StaticResource Brush.Accent}"/>
+                        </Trigger>
+                        <Trigger Property="IsPressed" Value="True">
+                            <Setter TargetName="border" Property="Background" Value="#0C344F"/>
+                            <Setter TargetName="border" Property="BorderBrush" Value="#0C344F"/>
+                        </Trigger>
+                        <Trigger Property="IsKeyboardFocused" Value="True">
+                            <Setter TargetName="border" Property="BorderThickness" Value="2"/>
+                            <Setter TargetName="border" Property="BorderBrush" Value="{StaticResource Brush.Accent}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <Style TargetType="TextBox">
         <Setter Property="Margin" Value="{StaticResource Margin.Stack}"/>
-        <Setter Property="Padding" Value="6"/>
+        <Setter Property="Padding" Value="8,6"/>
         <Setter Property="MinWidth" Value="120"/>
         <Setter Property="BorderBrush" Value="{StaticResource Brush.Border}"/>
         <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="Background" Value="{StaticResource Brush.Surface}"/>
+        <Setter Property="VerticalContentAlignment" Value="Center"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="TextBox">
+                    <Border x:Name="border"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="6"
+                            SnapsToDevicePixels="True">
+                        <ScrollViewer x:Name="PART_ContentHost"/>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsKeyboardFocused" Value="True">
+                            <Setter TargetName="border" Property="BorderBrush" Value="{StaticResource Brush.Accent}"/>
+                            <Setter TargetName="border" Property="BorderThickness" Value="2"/>
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter TargetName="border" Property="Opacity" Value="0.6"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <Style TargetType="ComboBox">
         <Setter Property="Margin" Value="{StaticResource Margin.Stack}"/>
         <Setter Property="MinWidth" Value="160"/>
+        <Setter Property="Padding" Value="6"/>
+        <Setter Property="BorderBrush" Value="{StaticResource Brush.Border}"/>
+        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="Background" Value="{StaticResource Brush.Surface}"/>
+        <Setter Property="ScrollViewer.CanContentScroll" Value="True"/>
     </Style>
 
     <Style TargetType="DataGrid">
         <Setter Property="RowBackground" Value="{StaticResource Brush.Surface}"/>
-        <Setter Property="AlternatingRowBackground" Value="#F0F5FA"/>
-        <Setter Property="GridLinesVisibility" Value="None"/>
+        <Setter Property="AlternatingRowBackground" Value="#EEF4F9"/>
+        <Setter Property="GridLinesVisibility" Value="Horizontal"/>
+        <Setter Property="HorizontalGridLinesBrush" Value="{StaticResource Brush.Border}"/>
         <Setter Property="BorderBrush" Value="{StaticResource Brush.Border}"/>
         <Setter Property="BorderThickness" Value="1"/>
         <Setter Property="Margin" Value="{StaticResource Margin.StackLarge}"/>
         <Setter Property="SelectionUnit" Value="CellOrRowHeader"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+        <Setter Property="EnableRowVirtualization" Value="True"/>
+        <Setter Property="ScrollViewer.CanContentScroll" Value="True"/>
+        <Setter Property="VirtualizingPanel.IsVirtualizing" Value="True"/>
+        <Setter Property="VirtualizingPanel.VirtualizationMode" Value="Recycling"/>
+        <Setter Property="RowHeaderWidth" Value="0"/>
+        <Setter Property="ColumnHeaderHeight" Value="32"/>
+        <Setter Property="RowHeight" Value="32"/>
+        <Setter Property="ColumnHeaderStyle" Value="{DynamicResource DataGridColumnHeaderStyle}"/>
+        <Setter Property="CellStyle" Value="{DynamicResource DataGridCellStyle}"/>
+        <Setter Property="RowStyle" Value="{DynamicResource DataGridRowStyle}"/>
+    </Style>
+
+    <Style x:Key="DataGridColumnHeaderStyle" TargetType="DataGridColumnHeader">
+        <Setter Property="Background" Value="{StaticResource Brush.SurfaceAlt}"/>
+        <Setter Property="Foreground" Value="{StaticResource Brush.TextSecondary}"/>
+        <Setter Property="Padding" Value="10,6"/>
+        <Setter Property="BorderBrush" Value="{StaticResource Brush.Border}"/>
+        <Setter Property="BorderThickness" Value="0,0,0,1"/>
+        <Setter Property="FontWeight" Value="SemiBold"/>
+        <Setter Property="HorizontalContentAlignment" Value="Left"/>
+    </Style>
+
+    <Style x:Key="DataGridCellStyle" TargetType="DataGridCell">
+        <Setter Property="Padding" Value="8,4"/>
+        <Setter Property="BorderBrush" Value="Transparent"/>
+        <Setter Property="BorderThickness" Value="0"/>
+        <Setter Property="Background" Value="Transparent"/>
+        <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
+        <Style.Triggers>
+            <Trigger Property="IsSelected" Value="True">
+                <Setter Property="Background" Value="#D1F0EA"/>
+                <Setter Property="BorderBrush" Value="#00A189"/>
+                <Setter Property="BorderThickness" Value="1"/>
+            </Trigger>
+            <Trigger Property="IsKeyboardFocusWithin" Value="True">
+                <Setter Property="BorderBrush" Value="{StaticResource Brush.Accent}"/>
+                <Setter Property="BorderThickness" Value="1"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style x:Key="DataGridRowStyle" TargetType="DataGridRow">
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+        <Setter Property="MinHeight" Value="32"/>
+        <Setter Property="Margin" Value="0,0,0,2"/>
+        <Setter Property="BorderBrush" Value="Transparent"/>
+        <Setter Property="BorderThickness" Value="0"/>
+        <Setter Property="Background" Value="Transparent"/>
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="Background" Value="#E3F7F2"/>
+            </Trigger>
+            <Trigger Property="IsSelected" Value="True">
+                <Setter Property="Background" Value="#C4EDE4"/>
+            </Trigger>
+        </Style.Triggers>
     </Style>
 
     <Style TargetType="TabControl">

--- a/Views/AnnualizerView.xaml
+++ b/Views/AnnualizerView.xaml
@@ -83,21 +83,39 @@
                                          FontSize="16"
                                          Foreground="{StaticResource Brush.Primary}"/>
                           </StackPanel>
-                          <TextBlock TextWrapping="Wrap">
-                              1. Document upfront investments, financing assumptions, and the analysis period.
-                              2. Capture the construction cash flow in the IDC schedule and list all future costs in the year they occur.
-                              3. Provide annual O&amp;M and annual benefits so the tool can translate capital outlays into comparable annual metrics.
-                              Use the Calculate button at the bottom of the window whenever you update inputs.
+                          <TextBlock Style="{StaticResource Text.Body}">
+                              <Run Text="• Document upfront investments, financing assumptions, and the analysis period."/>
+                              <LineBreak/>
+                              <Run Text="• Capture construction cash flow in the IDC schedule and list future costs in the year they occur."/>
+                              <LineBreak/>
+                              <Run Text="• Provide annual O&amp;M and annual benefits so the tool can translate capital outlays into comparable annual metrics."/>
+                              <LineBreak/>
+                              <Run Text="• Select Calculate after any edits so the tables, charts, and exports remain synchronized."/>
                           </TextBlock>
                       </StackPanel>
                   </Border>
 
-                  <Grid Grid.Row="1"
-                        Grid.RowSpan="14"
-                        Grid.ColumnSpan="2"
-                        Margin="0,16,0,0"
-                        Grid.IsSharedSizeScope="True">
-                      <Grid.Resources>
+                  <Border Grid.Row="1"
+                          Grid.RowSpan="14"
+                          Grid.ColumnSpan="2"
+                          Background="{StaticResource Brush.Surface}"
+                          CornerRadius="10"
+                          Padding="{StaticResource Padding.Card}"
+                          BorderBrush="{StaticResource Brush.Border}"
+                          BorderThickness="1"
+                          Margin="0,16,0,0">
+                      <Grid>
+                          <Grid.RowDefinitions>
+                              <RowDefinition Height="Auto"/>
+                              <RowDefinition Height="*"/>
+                          </Grid.RowDefinitions>
+                          <TextBlock Grid.Row="0"
+                                     Text="Financial Inputs"
+                                     FontSize="15"
+                                     FontWeight="SemiBold"
+                                     Margin="0,0,0,12"/>
+                          <Grid Grid.Row="1" Grid.IsSharedSizeScope="True">
+                       <Grid.Resources>
                           <Style x:Key="AnnualizerFieldLabelStyle" TargetType="TextBlock">
                               <Setter Property="Grid.Column" Value="0"/>
                               <Setter Property="Grid.ColumnSpan" Value="1"/>
@@ -216,7 +234,9 @@
                           <Run Text="Construction Months"/>
                       </TextBlock>
                       <TextBox Grid.Row="12" Text="{Binding ConstructionMonths}" Tag="13" Style="{StaticResource AnnualizerFieldInputStyle}"/>
-                  </Grid>
+                          </Grid>
+                      </Grid>
+                  </Border>
 
                   <TextBlock Grid.Row="15">
                       <TextBlock.Style>
@@ -251,7 +271,7 @@
                           <RowDefinition Height="Auto"/>
                           <RowDefinition Height="Auto"/>
                       </Grid.RowDefinitions>
-                      <Border Background="White" BorderBrush="{StaticResource Brush.Border}" BorderThickness="1" CornerRadius="6" Padding="6">
+                      <Border Background="{StaticResource Brush.Surface}" BorderBrush="{StaticResource Brush.Border}" BorderThickness="1" CornerRadius="6" Padding="6">
                           <DataGrid ItemsSource="{Binding IdcEntries}" AutoGenerateColumns="False" Margin="0" HeadersVisibility="All">
                               <DataGrid.Columns>
                                   <DataGridTextColumn Binding="{Binding Cost}">
@@ -335,7 +355,7 @@
                           <RowDefinition Height="Auto"/>
                           <RowDefinition Height="Auto"/>
                       </Grid.RowDefinitions>
-                      <Border Background="White" BorderBrush="{StaticResource Brush.Border}" BorderThickness="1" CornerRadius="6" Padding="6">
+                      <Border Background="{StaticResource Brush.Surface}" BorderBrush="{StaticResource Brush.Border}" BorderThickness="1" CornerRadius="6" Padding="6">
                           <DataGrid ItemsSource="{Binding FutureCosts}" AutoGenerateColumns="False" Margin="0">
                               <DataGrid.Columns>
                                   <DataGridTextColumn Binding="{Binding Cost}">

--- a/Views/EadView.xaml
+++ b/Views/EadView.xaml
@@ -34,11 +34,11 @@
                                        Foreground="{StaticResource Brush.Primary}"/>
                         </StackPanel>
                         <TextBlock Style="{StaticResource Text.Body}">
-                            <Run Text="List probability-damage pairs for each category. The tool auto-completes the curve by inserting 0% and 100% points using the trapezoidal method."/>
+                            <Run Text="• List probability and damage values for each category. The curve automatically includes 0% and 100% anchors using trapezoidal interpolation."/>
                             <LineBreak/>
-                            <Run Text="Toggle Include Stage if you have stage data aligned with the same probabilities."/>
+                            <Run Text="• Toggle Include Stage to capture paired stage values that align with the same probabilities."/>
                             <LineBreak/>
-                            <Run Text="After editing the grid, use the Calculate button at the bottom of the window so charts and statistics capture your latest entries."/>
+                            <Run Text="• Select Calculate after making edits so the charts, summary results, and exports refresh with your latest data."/>
                         </TextBlock>
                     </StackPanel>
                 </Border>
@@ -100,7 +100,7 @@
                     </UniformGrid.Style>
 
                     <Border Background="{StaticResource Brush.Surface}"
-                            CornerRadius="6"
+                            CornerRadius="10"
                             Padding="{StaticResource Padding.Content}"
                             BorderBrush="{StaticResource Brush.Border}"
                             BorderThickness="1">
@@ -115,16 +115,22 @@
                                 </Style.Triggers>
                             </Style>
                         </Border.Style>
-                        <DataGrid ItemsSource="{Binding Rows}"
-                                  AutoGenerateColumns="False"
-                                  CanUserAddRows="True"
-                                  CanUserDeleteRows="True"
-                                  ScrollViewer.HorizontalScrollBarVisibility="Auto"
-                                  behaviors:DataGridColumnsBehavior.ColumnsSource="{Binding ColumnDefinitions}"/>
+                        <StackPanel>
+                            <TextBlock Text="Probability and Damage Inputs"
+                                       FontWeight="SemiBold"
+                                       Margin="0,0,0,12"/>
+                            <DataGrid ItemsSource="{Binding Rows}"
+                                      AutoGenerateColumns="False"
+                                      CanUserAddRows="True"
+                                      CanUserDeleteRows="True"
+                                      ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                                      Margin="0"
+                                      behaviors:DataGridColumnsBehavior.ColumnsSource="{Binding ColumnDefinitions}"/>
+                        </StackPanel>
                     </Border>
 
                     <Border Background="{StaticResource Brush.Surface}"
-                            CornerRadius="6"
+                            CornerRadius="10"
                             Padding="{StaticResource Padding.Content}"
                             BorderBrush="{StaticResource Brush.Border}"
                             BorderThickness="1">
@@ -143,16 +149,37 @@
                             <TextBlock Text="Visualize Your Curve"
                                        FontWeight="SemiBold"
                                        Margin="{StaticResource Margin.Stack}"/>
-                            <Canvas Height="160" Margin="{StaticResource Margin.Stack}">
-                                <Polyline Points="{Binding FrequencyDamagePoints}"
-                                          Stroke="{StaticResource Brush.Accent}"
-                                          StrokeThickness="2"/>
-                                <Polyline Points="{Binding StageDamagePoints}"
-                                          Stroke="{StaticResource Brush.Primary}"
-                                          StrokeThickness="2"/>
-                            </Canvas>
+                            <Border Background="{StaticResource Brush.ChartFill}"
+                                    BorderBrush="{StaticResource Brush.Border}"
+                                    BorderThickness="1"
+                                    CornerRadius="12"
+                                    Padding="16"
+                                    Margin="{StaticResource Margin.Stack}">
+                                <Grid ClipToBounds="True">
+                                    <Canvas x:Name="CurveCanvas" Width="300" Height="150" SnapsToDevicePixels="True">
+                                        <Rectangle Width="300"
+                                                   Height="150"
+                                                   Fill="Transparent"
+                                                   StrokeThickness="0"/>
+                                        <Line X1="0" Y1="150" X2="300" Y2="150" Stroke="{StaticResource Brush.Border}" StrokeThickness="1"/>
+                                        <Line X1="0" Y1="0" X2="0" Y2="150" Stroke="{StaticResource Brush.Border}" StrokeThickness="1"/>
+                                        <Line X1="0" Y1="100" X2="300" Y2="100" Stroke="{StaticResource Brush.ChartGrid}" StrokeThickness="1" StrokeDashArray="4 6"/>
+                                        <Line X1="0" Y1="50" X2="300" Y2="50" Stroke="{StaticResource Brush.ChartGrid}" StrokeThickness="1" StrokeDashArray="4 6"/>
+                                        <Polyline Points="{Binding FrequencyDamagePoints}"
+                                                  Stroke="{StaticResource Brush.Accent}"
+                                                  StrokeThickness="3"
+                                                  StrokeEndLineCap="Round"
+                                                  StrokeStartLineCap="Round"/>
+                                        <Polyline Points="{Binding StageDamagePoints}"
+                                                  Stroke="{StaticResource Brush.Primary}"
+                                                  StrokeThickness="3"
+                                                  StrokeEndLineCap="Round"
+                                                  StrokeStartLineCap="Round"/>
+                                    </Canvas>
+                                </Grid>
+                            </Border>
                             <TextBlock Style="{StaticResource Text.Caption}" TextWrapping="Wrap">
-                                The teal line plots damages against exceedance probability, while the navy line (when stage is supplied) shows the paired stage-damage curve. Smoother, monotonic inputs yield clearer charts.
+                                The aqua line plots damages against exceedance probability. When stage values are provided, the navy line displays the paired stage-damage curve so you can verify consistency between datasets.
                             </TextBlock>
                         </StackPanel>
                     </Border>

--- a/Views/UpdatedCostView.xaml
+++ b/Views/UpdatedCostView.xaml
@@ -57,8 +57,14 @@
                         </Style>
                     </StackPanel.Style>
                     <TextBlock Text="Updated Cost Workflow" FontSize="18" FontWeight="Bold" Foreground="{StaticResource Brush.Primary}"/>
-                    <TextBlock TextWrapping="Wrap" Margin="0,6,0,0">
-                        Work through each sub-tab from left to right. Start with storage capacity, capture annual joint costs, update historical line items, then evaluate RR&amp;R/mitigation and total annual cost scenarios. Press Compute within each section before leaving the tab so downstream values stay synchronized.
+                    <TextBlock Style="{StaticResource Text.Body}" Margin="0,6,0,0">
+                        <Run Text="• Work through each sub-tab from left to right so dependent calculations stay aligned."/>
+                        <LineBreak/>
+                        <Run Text="• Start with storage capacity, capture annual joint costs, then update historical line items."/>
+                        <LineBreak/>
+                        <Run Text="• Evaluate RR&amp;R, mitigation, and total annual cost scenarios once upstream inputs are finalized."/>
+                        <LineBreak/>
+                        <Run Text="• Press Compute within each section before leaving the tab to keep downstream values synchronized."/>
                     </TextBlock>
                 </StackPanel>
                 <Canvas Width="80" Height="60">
@@ -103,8 +109,10 @@
                                        FontWeight="Bold"
                                        Foreground="{StaticResource Brush.Primary}"/>
                         </StackPanel>
-                        <TextBlock TextWrapping="Wrap" Margin="0,6,0,0">
-                            Record the full system storage and the recommended storage allocation for your study. The compute action scales other sections by this proportion, so double-check the recommendation before proceeding.
+                        <TextBlock Style="{StaticResource Text.Body}" Margin="0,6,0,0">
+                            <Run Text="• Record the full system storage and the recommended allocation for your study."/>
+                            <LineBreak/>
+                            <Run Text="• Use Compute to scale the remaining sections by this proportion before moving forward."/>
                         </TextBlock>
                     </StackPanel>
                 </Border>
@@ -167,8 +175,10 @@
                                        FontWeight="Bold"
                                        Foreground="{StaticResource Brush.Primary}"/>
                         </StackPanel>
-                        <TextBlock TextWrapping="Wrap" Margin="0,6,0,0">
-                            Enter the system-wide joint operating and maintenance costs on an annual basis. The compute step keeps a running total that is later scaled by the storage percentage.
+                        <TextBlock Style="{StaticResource Text.Body}" Margin="0,6,0,0">
+                            <Run Text="• Enter system-wide joint operating and maintenance costs on an annual basis."/>
+                            <LineBreak/>
+                            <Run Text="• Use Compute to capture the running total that will later be scaled by the storage percentage."/>
                         </TextBlock>
                     </StackPanel>
                 </Border>

--- a/Views/WaterDemandView.xaml
+++ b/Views/WaterDemandView.xaml
@@ -16,23 +16,29 @@
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
-            <Border Grid.Row="0" Background="#E6F5FF" BorderBrush="#7DC2E8" BorderThickness="1" CornerRadius="10" Padding="14" Margin="0,0,0,10">
-                <Grid>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="*"/>
-                    </Grid.ColumnDefinitions>
-                    <Canvas Width="60" Height="60">
-                        <Path Data="M30,5 C16,20 8,32 8,41 C8,52 17,60 30,60 C43,60 52,52 52,41 C52,32 44,20 30,5 Z" Fill="#7DC2E8"/>
-                        <Path Data="M30,12 C21,23 16,32 16,41 C16,48 22,53 30,53 C38,53 44,48 44,41 C44,32 39,23 30,12 Z" Fill="White" Opacity="0.6"/>
-                    </Canvas>
-                    <StackPanel Grid.Column="1" Margin="12,0,0,0">
-                        <TextBlock Text="Water Demand Forecast Instructions" FontSize="18" FontWeight="Bold" Foreground="#1F6AB0"/>
-                        <TextBlock TextWrapping="Wrap" Margin="0,6,0,0">
-                            Enter historic data first, choose or add scenarios, then specify forecast horizon and demographic assumptions. Use the Calculate and Export buttons at the bottom of the window to refresh forecasts or download your workbook.
-                        </TextBlock>
+            <Border Grid.Row="0"
+                    Style="{StaticResource Border.Explainer}"
+                    Margin="0,0,0,12">
+                <StackPanel>
+                    <StackPanel Orientation="Horizontal" Margin="{StaticResource Margin.Stack}">
+                        <TextBlock FontFamily="Segoe MDL2 Assets"
+                                   Text=""
+                                   FontSize="22"
+                                   Foreground="{StaticResource Brush.Primary}"
+                                   Margin="{StaticResource Margin.Inline}"/>
+                        <TextBlock Text="Water Demand Forecast Workflow"
+                                   FontWeight="Bold"
+                                   FontSize="16"
+                                   Foreground="{StaticResource Brush.Primary}"/>
                     </StackPanel>
-                </Grid>
+                    <TextBlock Style="{StaticResource Text.Body}">
+                        <Run Text="• Enter historic demand records first to calibrate the baseline."/>
+                        <LineBreak/>
+                        <Run Text="• Choose or add scenarios, then set the forecast horizon and demographic assumptions."/>
+                        <LineBreak/>
+                        <Run Text="• Use Calculate and Export after edits so scenario charts, tables, and workbooks stay current."/>
+                    </TextBlock>
+                </StackPanel>
             </Border>
             <TabControl Grid.Row="1" ItemsSource="{Binding Scenarios}" SelectedItem="{Binding SelectedScenario}" HorizontalContentAlignment="Stretch">
                 <TabControl.ItemTemplate>
@@ -57,9 +63,25 @@
                                     <RowDefinition Height="Auto"/>
                                     <RowDefinition Height="*"/>
                                 </Grid.RowDefinitions>
-                                <Border Grid.Row="0" Background="White" CornerRadius="4" Padding="5" Margin="0,0,0,5">
-                                    <DataGrid ItemsSource="{Binding DataContext.HistoricalData, ElementName=Root}" AutoGenerateColumns="False" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" ScrollViewer.VerticalScrollBarVisibility="Auto" ScrollViewer.HorizontalScrollBarVisibility="Auto">
-                                        <DataGrid.Columns>
+                                <Border Grid.Row="0"
+                                        Background="{StaticResource Brush.Surface}"
+                                        BorderBrush="{StaticResource Brush.Border}"
+                                        BorderThickness="1"
+                                        CornerRadius="10"
+                                        Padding="12"
+                                        Margin="0,0,0,8">
+                                    <StackPanel>
+                                        <TextBlock Text="Historical Demand"
+                                                   FontWeight="SemiBold"
+                                                   Margin="0,0,0,12"/>
+                                        <DataGrid ItemsSource="{Binding DataContext.HistoricalData, ElementName=Root}"
+                                                  AutoGenerateColumns="False"
+                                                  HorizontalAlignment="Stretch"
+                                                  VerticalAlignment="Stretch"
+                                                  ScrollViewer.VerticalScrollBarVisibility="Auto"
+                                                  ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                                                  Margin="0">
+                                            <DataGrid.Columns>
                                             <DataGridTextColumn Binding="{Binding Year}">
                                                 <DataGridTextColumn.Header>
                                                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
@@ -79,7 +101,8 @@
                                                 </DataGridTextColumn.Header>
                                             </DataGridTextColumn>
                                         </DataGrid.Columns>
-                                    </DataGrid>
+                                        </DataGrid>
+                                    </StackPanel>
                                 </Border>
                                 <Grid Grid.Row="1" Margin="0,0,0,5" VerticalAlignment="Top" HorizontalAlignment="Stretch">
                                     <Grid.RowDefinitions>
@@ -230,7 +253,7 @@
                                         </Grid>
                                     </Expander>
 
-                                    <Border Grid.Row="8" Grid.ColumnSpan="3" Background="#F7FBFF" BorderBrush="#C6DBF4" BorderThickness="1" CornerRadius="6" Padding="10" Margin="0,8,0,0">
+                                    <Border Grid.Row="8" Grid.ColumnSpan="3" Background="{StaticResource Brush.ChartFill}" BorderBrush="{StaticResource Brush.Border}" BorderThickness="1" CornerRadius="8" Padding="12" Margin="0,8,0,0">
                                         <Border.Style>
                                             <Style TargetType="Border">
                                                 <Setter Property="Visibility" Value="Collapsed"/>
@@ -256,10 +279,10 @@
                                                 <ColumnDefinition Width="Auto" SharedSizeGroup="ScenarioValue"/>
                                                 <ColumnDefinition Width="Auto" SharedSizeGroup="ScenarioValue"/>
                                             </Grid.ColumnDefinitions>
-                                            <TextBlock Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="3" FontWeight="SemiBold" Foreground="#1F6AB0" Margin="0,0,0,8" Text="Scenario Variations (% change applied to baseline rates)"/>
-                                            <TextBlock Grid.Row="1" Grid.Column="0" FontWeight="SemiBold" Foreground="#31556F" Text="Parameter"/>
-                                            <TextBlock Grid.Row="1" Grid.Column="1" FontWeight="SemiBold" Foreground="#31556F" Margin="16,0,16,0" Text="Optimistic" HorizontalAlignment="Left"/>
-                                            <TextBlock Grid.Row="1" Grid.Column="2" FontWeight="SemiBold" Foreground="#31556F" Text="Pessimistic" HorizontalAlignment="Left"/>
+                                            <TextBlock Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="3" FontWeight="SemiBold" Foreground="{StaticResource Brush.Primary}" Margin="0,0,0,8" Text="Scenario Variations (% change applied to baseline rates)"/>
+                                            <TextBlock Grid.Row="1" Grid.Column="0" FontWeight="SemiBold" Foreground="{StaticResource Brush.TextSecondary}" Text="Parameter"/>
+                                            <TextBlock Grid.Row="1" Grid.Column="1" FontWeight="SemiBold" Foreground="{StaticResource Brush.TextSecondary}" Margin="16,0,16,0" Text="Optimistic" HorizontalAlignment="Left"/>
+                                            <TextBlock Grid.Row="1" Grid.Column="2" FontWeight="SemiBold" Foreground="{StaticResource Brush.TextSecondary}" Text="Pessimistic" HorizontalAlignment="Left"/>
 
                                             <TextBlock Grid.Row="2" Grid.Column="0" Text="Population growth"/>
                                             <TextBox Grid.Row="2" Grid.Column="1" MinWidth="90" HorizontalAlignment="Left" Text="{Binding DataContext.OptimisticPopulationGrowthChangePercent, ElementName=Root}" ToolTip="Percent change applied to the baseline population growth rate for the optimistic scenario."/>
@@ -277,14 +300,14 @@
                                             <TextBox Grid.Row="5" Grid.Column="1" MinWidth="90" HorizontalAlignment="Left" Margin="0,4,0,0" Text="{Binding DataContext.OptimisticLossChangePercent, ElementName=Root}" ToolTip="Percent change applied to baseline loss percentages for the optimistic scenario."/>
                                             <TextBox Grid.Row="5" Grid.Column="2" MinWidth="90" HorizontalAlignment="Left" Margin="0,4,0,0" Text="{Binding DataContext.PessimisticLossChangePercent, ElementName=Root}" ToolTip="Percent change applied to baseline loss percentages for the pessimistic scenario."/>
 
-                                            <TextBlock Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="3" Margin="0,10,0,0" FontSize="12" Foreground="#31556F" TextWrapping="Wrap">
+                                            <TextBlock Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="3" Margin="0,10,0,0" FontSize="12" Foreground="{StaticResource Brush.TextSecondary}" TextWrapping="Wrap">
                                                 Positive values increase the baseline rate, while negative values decrease it. Changes apply automatically to the Optimistic and Pessimistic tabs without altering the Baseline inputs.
                                             </TextBlock>
                                         </Grid>
                                     </Border>
                                 </Grid>
-                                <Border Grid.Row="2" Background="White" CornerRadius="4" Padding="5">
-                                    <DataGrid ItemsSource="{Binding Results}" AutoGenerateColumns="False" FontWeight="Bold" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" ScrollViewer.VerticalScrollBarVisibility="Auto" ScrollViewer.HorizontalScrollBarVisibility="Auto">
+                                <Border Grid.Row="2" Background="{StaticResource Brush.Surface}" CornerRadius="10" Padding="12" BorderBrush="{StaticResource Brush.Border}" BorderThickness="1">
+                                    <DataGrid ItemsSource="{Binding Results}" AutoGenerateColumns="False" FontWeight="Bold" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" ScrollViewer.VerticalScrollBarVisibility="Auto" ScrollViewer.HorizontalScrollBarVisibility="Auto" Margin="0">
                                         <DataGrid.Columns>
                                             <DataGridTextColumn Header="Year" Binding="{Binding Year}"/>
                                             <DataGridTextColumn Header="Growth Rate" Binding="{Binding GrowthRate, Mode=TwoWay, StringFormat={}{0:N2}}">
@@ -347,7 +370,7 @@
                                     </DataGrid>
                                 </Border>
                             </Grid>
-                            <Border Background="White" CornerRadius="4" Padding="12">
+                            <Border Background="{StaticResource Brush.Surface}" CornerRadius="12" Padding="16" BorderBrush="{StaticResource Brush.Border}" BorderThickness="1">
                                 <Border.Style>
                                     <Style TargetType="Border">
                                         <Setter Property="Grid.Column" Value="1"/>
@@ -369,19 +392,19 @@
                                         <RowDefinition Height="*"/>
                                     </Grid.RowDefinitions>
                                     <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,10">
-                                        <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="18" Foreground="#1F6AB0" Margin="0,0,8,0"/>
-                                        <TextBlock Text="Forecast Demand Trend" FontWeight="SemiBold" Foreground="#1F6AB0"/>
+                                        <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="18" Foreground="{StaticResource Brush.Primary}" Margin="0,0,8,0"/>
+                                        <TextBlock Text="Forecast Demand Trend" FontWeight="SemiBold" Foreground="{StaticResource Brush.Primary}"/>
                                     </StackPanel>
                                     <Viewbox Grid.Row="1" Stretch="Uniform" HorizontalAlignment="Stretch" MinHeight="220">
                                         <Grid Width="360" Height="220">
-                                            <Border Background="#F7FBFF" BorderBrush="#CCE0F5" BorderThickness="1.5" CornerRadius="10"/>
+                                            <Border Background="{StaticResource Brush.ChartFill}" BorderBrush="{StaticResource Brush.Border}" BorderThickness="1" CornerRadius="12"/>
                                             <Canvas Width="360" Height="220" IsHitTestVisible="False">
-                                                <Line X1="36" Y1="20" X2="36" Y2="200" Stroke="#B6CCE5" StrokeThickness="1.2" StrokeEndLineCap="Round"/>
-                                                <Line X1="36" Y1="200" X2="340" Y2="200" Stroke="#B6CCE5" StrokeThickness="1.2" StrokeEndLineCap="Round"/>
-                                                <Line X1="36" Y1="140" X2="340" Y2="140" Stroke="#E0EBF5" StrokeThickness="1" StrokeDashArray="2 4"/>
-                                                <Line X1="36" Y1="80" X2="340" Y2="80" Stroke="#E0EBF5" StrokeThickness="1" StrokeDashArray="2 4"/>
-                                                <Line X1="130" Y1="20" X2="130" Y2="200" Stroke="#E0EBF5" StrokeThickness="1" StrokeDashArray="2 4"/>
-                                                <Line X1="220" Y1="20" X2="220" Y2="200" Stroke="#E0EBF5" StrokeThickness="1" StrokeDashArray="2 4"/>
+                                                <Line X1="36" Y1="20" X2="36" Y2="200" Stroke="{StaticResource Brush.Border}" StrokeThickness="1.2" StrokeEndLineCap="Round"/>
+                                                <Line X1="36" Y1="200" X2="340" Y2="200" Stroke="{StaticResource Brush.Border}" StrokeThickness="1.2" StrokeEndLineCap="Round"/>
+                                                <Line X1="36" Y1="140" X2="340" Y2="140" Stroke="{StaticResource Brush.ChartGrid}" StrokeThickness="1" StrokeDashArray="2 4"/>
+                                                <Line X1="36" Y1="80" X2="340" Y2="80" Stroke="{StaticResource Brush.ChartGrid}" StrokeThickness="1" StrokeDashArray="2 4"/>
+                                                <Line X1="130" Y1="20" X2="130" Y2="200" Stroke="{StaticResource Brush.ChartGrid}" StrokeThickness="1" StrokeDashArray="2 4"/>
+                                                <Line X1="220" Y1="20" X2="220" Y2="200" Stroke="{StaticResource Brush.ChartGrid}" StrokeThickness="1" StrokeDashArray="2 4"/>
                                             </Canvas>
                                             <ItemsControl Margin="36,20,20,32"
                                                           ItemsSource="{Binding DataContext.Scenarios, ElementName=Root}"
@@ -405,13 +428,13 @@
                                                 </ItemsControl.ItemTemplate>
                                             </ItemsControl>
                                             <TextBlock Text="Year"
-                                                       Foreground="#31556F"
+                                                       Foreground="{StaticResource Brush.TextSecondary}"
                                                        FontSize="12"
                                                        HorizontalAlignment="Center"
                                                        VerticalAlignment="Bottom"
                                                        Margin="0,0,0,6"/>
                                             <TextBlock Text="Adjusted Demand (gallons/day)"
-                                                       Foreground="#31556F"
+                                                       Foreground="{StaticResource Brush.TextSecondary}"
                                                        FontSize="12"
                                                        RenderTransformOrigin="0.5,0.5"
                                                        HorizontalAlignment="Left"
@@ -429,29 +452,29 @@
                     </DataTemplate>
                 </TabControl.ContentTemplate>
             </TabControl>
-            <Border Grid.Row="2" Background="#F0F7FE" BorderBrush="#A6C4EB" BorderThickness="1" CornerRadius="8" Padding="12" Margin="0,10,0,0">
+            <Border Grid.Row="2" Style="{StaticResource Border.ResultInfo}" Margin="0,12,0,0">
                 <StackPanel>
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                        <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="18" Foreground="#1F6AB0" Margin="0,0,8,0"/>
-                        <TextBlock Text="Scenario Summary" FontWeight="Bold" Foreground="#1F6AB0"/>
+                        <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="18" Foreground="{StaticResource Brush.Primary}" Margin="0,0,8,0"/>
+                        <TextBlock Text="Scenario Summary" FontWeight="Bold" Foreground="{StaticResource Brush.Primary}"/>
                     </StackPanel>
                     <TextBlock Text="{Binding SelectedScenario.Description}" TextWrapping="Wrap" Margin="0,6,0,0"/>
                 </StackPanel>
             </Border>
-            <Border Grid.Row="3" Background="#FDF5E6" BorderBrush="#E8C97D" BorderThickness="1" CornerRadius="8" Padding="12" Margin="0,10,0,0">
+            <Border Grid.Row="3" Style="{StaticResource Border.ResultInfo}" Margin="0,12,0,0">
                 <StackPanel>
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                        <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="18" Foreground="#B58900" Margin="0,0,8,0"/>
-                        <TextBlock Text="Forecast Logic" FontWeight="Bold" Foreground="#B58900"/>
+                        <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="18" Foreground="{StaticResource Brush.Primary}" Margin="0,0,8,0"/>
+                        <TextBlock Text="Forecast Logic" FontWeight="Bold" Foreground="{StaticResource Brush.Primary}"/>
                     </StackPanel>
                     <TextBlock Text="{Binding Explanation}" TextWrapping="Wrap" Margin="0,6,0,0"/>
                 </StackPanel>
             </Border>
-            <Border Grid.Row="4" Background="#F6FFED" BorderBrush="#9CD06F" BorderThickness="1" CornerRadius="8" Padding="12" Margin="0,10,0,0">
+            <Border Grid.Row="4" Style="{StaticResource Border.ResultInfo}" Margin="0,12,0,0">
                 <StackPanel>
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                        <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="18" Foreground="#417505" Margin="0,0,8,0"/>
-                        <TextBlock Text="How to Read the Results" FontWeight="Bold" Foreground="#417505"/>
+                        <TextBlock FontFamily="Segoe MDL2 Assets" Text="" FontSize="18" Foreground="{StaticResource Brush.Primary}" Margin="0,0,8,0"/>
+                        <TextBlock Text="How to Read the Results" FontWeight="Bold" Foreground="{StaticResource Brush.Primary}"/>
                     </StackPanel>
                     <TextBlock TextWrapping="Wrap" Margin="0,6,0,0">
                         • Growth Rate reflects the year-over-year percent change driven by your population and per-capita assumptions. Higher growth inputs raise this column.


### PR DESCRIPTION
## Summary
- refresh the shared theme with updated colors plus button, textbox, and data grid styling
- polish the EAD, Annualizer, Water Demand, and Updated Cost views with clearer instructions and card-based layouts
- enhance embedded charts with consistent backgrounds, gridlines, and typography adjustments

## Testing
- dotnet build *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6bb14580083309c6ac0b93ecf78e0