### PR TITLE
Allow blank annual exceedance probability editing

### DIFF
--- a/ViewModels/AgricultureDepthDamageViewModel.cs
+++ b/ViewModels/AgricultureDepthDamageViewModel.cs
@@ -671,6 +671,7 @@ namespace EconToolbox.Desktop.ViewModels
             private double _annualExceedanceProbability;
             private int _floodSeasonPeakDay;
             private int _seasonShiftDays;
+            private string _annualExceedanceProbabilityDisplayText;
 
             public RegionDefinition(
                 string name,
@@ -699,6 +700,7 @@ namespace EconToolbox.Desktop.ViewModels
                 {
                     point.PropertyChanged += DepthDurationPoint_PropertyChanged;
                 }
+                _annualExceedanceProbabilityDisplayText = _annualExceedanceProbability.ToString("0.###", CultureInfo.CurrentCulture);
             }
 
             public string Name
@@ -761,6 +763,7 @@ namespace EconToolbox.Desktop.ViewModels
                     }
 
                     _annualExceedanceProbability = adjusted;
+                    _annualExceedanceProbabilityDisplayText = _annualExceedanceProbability.ToString("0.###", CultureInfo.CurrentCulture);
                     OnPropertyChanged();
                     OnPropertyChanged(nameof(AnnualExceedanceProbabilityDisplay));
                 }
@@ -768,10 +771,19 @@ namespace EconToolbox.Desktop.ViewModels
 
             public string AnnualExceedanceProbabilityDisplay
             {
-                get => _annualExceedanceProbability.ToString("0.###", CultureInfo.CurrentCulture);
+                get => _annualExceedanceProbabilityDisplayText;
                 set
                 {
-                    string trimmed = value?.Trim() ?? string.Empty;
+                    string newText = value ?? string.Empty;
+                    if (_annualExceedanceProbabilityDisplayText == newText)
+                    {
+                        return;
+                    }
+
+                    _annualExceedanceProbabilityDisplayText = newText;
+                    OnPropertyChanged();
+
+                    string trimmed = newText.Trim();
                     if (trimmed.Length == 0)
                     {
                         return;


### PR DESCRIPTION
## Summary
- keep the annual exceedance probability display text editable, allowing blank and partial values without snapping back
- synchronize the stored probability text with the numeric value whenever valid input is parsed and raise change notifications for both

## Testing
- Not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d6e9341838833083e8ebb47d6dee68