### PR TITLE
Ensure historical median bindings are one-way

### DIFF
--- a/Views/UdvView.xaml
+++ b/Views/UdvView.xaml
@@ -169,9 +169,9 @@
                     <TextBlock Margin="12,0,0,0"
                                Visibility="{Binding HasHistoricalMedian, Converter={StaticResource BoolToVisibilityConverter}}">
                         <Run Text="Median: "/>
-                        <Run Text="{Binding HistoricalMedianVisitation, StringFormat={}{0:N0}}"/>
+                        <Run Text="{Binding HistoricalMedianVisitation, Mode=OneWay, StringFormat={}{0:N0}}"/>
                         <Run Text=" visitors"/>
-                        <Run Text="{Binding HistoricalObservationCount, StringFormat=  ({0} values)}"/>
+                        <Run Text="{Binding HistoricalObservationCount, Mode=OneWay, StringFormat=  ({0} values)}"/>
                     </TextBlock>
                 </StackPanel>
                 <TextBlock Margin="0,4,0,0"


### PR DESCRIPTION
## Summary
- update historical visitation Run bindings to explicitly use one-way mode
- prevent WPF from attempting to write back to read-only historical statistics properties

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6ea699b048330a6b469a4109e5403