### PR TITLE
Enable tabular pasting for UDV historical data

### DIFF
--- a/Models/HistoricalVisitationRow.cs
+++ b/Models/HistoricalVisitationRow.cs
@@ -1,0 +1,34 @@
+namespace EconToolbox.Desktop.Models
+{
+    public class HistoricalVisitationRow : ObservableObject
+    {
+        private string? _label;
+        private string _visitationText = string.Empty;
+
+        public string? Label
+        {
+            get => _label;
+            set
+            {
+                if (_label != value)
+                {
+                    _label = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public string VisitationText
+        {
+            get => _visitationText;
+            set
+            {
+                if (_visitationText != value)
+                {
+                    _visitationText = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+    }
+}

--- a/Themes/Design.xaml
+++ b/Themes/Design.xaml
@@ -207,6 +207,7 @@
         <Setter Property="BorderThickness" Value="1"/>
         <Setter Property="Margin" Value="{StaticResource Margin.StackLarge}"/>
         <Setter Property="SelectionUnit" Value="CellOrRowHeader"/>
+        <Setter Property="ClipboardPasteMode" Value="Cell"/>
         <Setter Property="SnapsToDevicePixels" Value="True"/>
         <Setter Property="EnableRowVirtualization" Value="True"/>
         <Setter Property="ScrollViewer.CanContentScroll" Value="True"/>

--- a/Views/UdvView.xaml
+++ b/Views/UdvView.xaml
@@ -156,14 +156,36 @@
             <StackPanel>
                 <TextBlock Text="Historical Visitation Data" FontWeight="Bold"/>
                 <TextBlock TextWrapping="Wrap" Margin="{StaticResource Margin.TopXSmall}">
-                    Provide historic visitation observations separated by commas or line breaks. The median of these values will replace the visitation input above.
+                    Provide historic visitation observations in the table. You can type directly or paste multiple rows from a spreadsheet. The median of these values will replace the visitation input above.
                 </TextBlock>
-                <TextBox Text="{Binding HistoricalVisitationEntries, UpdateSourceTrigger=PropertyChanged}" 
-                         AcceptsReturn="True"
-                         TextWrapping="Wrap"
-                         VerticalScrollBarVisibility="Auto"
-                         MinHeight="80"
-                         HorizontalAlignment="Stretch"/>
+                <DataGrid ItemsSource="{Binding HistoricalVisitationRows}"
+                          AutoGenerateColumns="False"
+                          CanUserAddRows="True"
+                          CanUserDeleteRows="True"
+                          ClipboardPasteMode="Cell"
+                          HeadersVisibility="Column"
+                          Margin="0,8,0,8"
+                          ScrollViewer.VerticalScrollBarVisibility="Auto"
+                          ScrollViewer.HorizontalScrollBarVisibility="Auto">
+                    <DataGrid.Columns>
+                        <DataGridTextColumn Binding="{Binding Label, UpdateSourceTrigger=PropertyChanged}"
+                                            Width="2*">
+                            <DataGridTextColumn.Header>
+                                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                    <TextBlock Text="Label (optional)"/>
+                                </StackPanel>
+                            </DataGridTextColumn.Header>
+                        </DataGridTextColumn>
+                        <DataGridTextColumn Binding="{Binding VisitationText, UpdateSourceTrigger=PropertyChanged}"
+                                            Width="*">
+                            <DataGridTextColumn.Header>
+                                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                    <TextBlock Text="Visitation"/>
+                                </StackPanel>
+                            </DataGridTextColumn.Header>
+                        </DataGridTextColumn>
+                    </DataGrid.Columns>
+                </DataGrid>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <Button Content="Calculate Median" Command="{Binding ComputeMedianCommand}" Width="180"/>
                     <TextBlock Margin="12,0,0,0"


### PR DESCRIPTION
## Summary
- replace the UDV historical visitation textbox with a spreadsheet-friendly DataGrid
- add view model support for parsing pasted visitation rows and keeping validation feedback in sync
- set the default DataGrid style to enable cell-based clipboard pasting across the app

## Testing
- dotnet build (fails: `dotnet` not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d6ebaef54883308e780347b8fc9889