### PR TITLE
Remove unsupported DataGrid ClipboardPasteMode setter

### DIFF
--- a/Themes/Design.xaml
+++ b/Themes/Design.xaml
@@ -207,7 +207,6 @@
         <Setter Property="BorderThickness" Value="1"/>
         <Setter Property="Margin" Value="{StaticResource Margin.StackLarge}"/>
         <Setter Property="SelectionUnit" Value="CellOrRowHeader"/>
-        <Setter Property="ClipboardPasteMode" Value="Cell"/>
         <Setter Property="SnapsToDevicePixels" Value="True"/>
         <Setter Property="EnableRowVirtualization" Value="True"/>
         <Setter Property="ScrollViewer.CanContentScroll" Value="True"/>


### PR DESCRIPTION
## Summary
- remove the ClipboardPasteMode setter from the shared DataGrid style so the XAML build passes on platforms where the property is unavailable

## Testing
- Not run (dotnet CLI is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d6ef15bd4883308b19eaf62ba87a8a