### PR TITLE
Add configurable IDC timing assumption

### DIFF
--- a/ViewModels/AnnualizerViewModel.cs
+++ b/ViewModels/AnnualizerViewModel.cs
@@ -22,6 +22,7 @@ namespace EconToolbox.Desktop.ViewModels
         private ObservableCollection<FutureCostEntry> _futureCosts = new();
         private ObservableCollection<FutureCostEntry> _idcEntries = new();
         private ObservableCollection<string> _results = new();
+        private string _idcTimingBasis = "Middle";
 
         private double _idc;
         private double _totalInvestment;
@@ -90,6 +91,22 @@ namespace EconToolbox.Desktop.ViewModels
         {
             get => _idcEntries;
             set { _idcEntries = value; OnPropertyChanged(); }
+        }
+
+        public IReadOnlyList<string> IdcTimingOptions { get; } = new[] { "Beginning", "Middle", "End" };
+
+        public string IdcTimingBasis
+        {
+            get => _idcTimingBasis;
+            set
+            {
+                if (_idcTimingBasis != value)
+                {
+                    _idcTimingBasis = value;
+                    OnPropertyChanged();
+                    Compute();
+                }
+            }
         }
 
         public double Idc
@@ -238,7 +255,8 @@ namespace EconToolbox.Desktop.ViewModels
                 }
 
                 var result = AnnualizerModel.Compute(FirstCost, Rate / 100.0, AnnualOm, AnnualBenefits, future,
-                    AnalysisPeriod, BaseYear, ConstructionMonths, costArr, timingArr, monthArr);
+                    AnalysisPeriod, BaseYear, ConstructionMonths, costArr, timingArr, monthArr,
+                    NormalizeTimingChoice(IdcTimingBasis));
                 Idc = result.Idc;
                 TotalInvestment = result.TotalInvestment;
                 Crf = result.Crf;
@@ -291,6 +309,21 @@ namespace EconToolbox.Desktop.ViewModels
             foreach (var entry in FutureCosts.ToList())
                 entry.PropertyChanged -= EntryOnPropertyChanged;
             FutureCosts.Clear();
+        }
+
+        private static string NormalizeTimingChoice(string? choice)
+        {
+            if (string.IsNullOrWhiteSpace(choice))
+                return "midpoint";
+
+            return choice.Trim().ToLowerInvariant() switch
+            {
+                "beginning" => "beginning",
+                "middle" => "midpoint",
+                "midpoint" => "midpoint",
+                "end" => "end",
+                _ => "midpoint"
+            };
         }
     }
 }

--- a/Views/AnnualizerView.xaml
+++ b/Views/AnnualizerView.xaml
@@ -115,7 +115,7 @@
                                      FontWeight="SemiBold"
                                      Margin="0,0,0,12"/>
                           <Grid Grid.Row="1" Grid.IsSharedSizeScope="True">
-                       <Grid.Resources>
+                      <Grid.Resources>
                           <Style x:Key="AnnualizerFieldLabelStyle" TargetType="TextBlock">
                               <Setter Property="Grid.Column" Value="0"/>
                               <Setter Property="Grid.ColumnSpan" Value="1"/>
@@ -144,6 +144,20 @@
                                   </DataTrigger>
                               </Style.Triggers>
                           </Style>
+                          <Style x:Key="AnnualizerFieldComboStyle" TargetType="ComboBox">
+                              <Setter Property="Grid.Column" Value="2"/>
+                              <Setter Property="Grid.ColumnSpan" Value="1"/>
+                              <Setter Property="Margin" Value="0,0,0,16"/>
+                              <Setter Property="HorizontalAlignment" Value="Stretch"/>
+                              <Style.Triggers>
+                                  <DataTrigger Binding="{Binding ActualWidth, RelativeSource={RelativeSource AncestorType=UserControl}, Converter={StaticResource WidthToLayoutModeConverter}}"
+                                               Value="Narrow">
+                                      <Setter Property="Grid.Column" Value="0"/>
+                                      <Setter Property="Grid.ColumnSpan" Value="3"/>
+                                      <Setter Property="Margin" Value="0,4,0,16"/>
+                                  </DataTrigger>
+                              </Style.Triggers>
+                          </Style>
                       </Grid.Resources>
                       <Grid.ColumnDefinitions>
                           <ColumnDefinition Width="Auto" SharedSizeGroup="AnnualizerLabel"/>
@@ -151,6 +165,7 @@
                           <ColumnDefinition Width="*" SharedSizeGroup="AnnualizerInput"/>
                       </Grid.ColumnDefinitions>
                       <Grid.RowDefinitions>
+                          <RowDefinition Height="Auto"/>
                           <RowDefinition Height="Auto"/>
                           <RowDefinition Height="Auto"/>
                           <RowDefinition Height="Auto"/>
@@ -234,6 +249,18 @@
                           <Run Text="Construction Months"/>
                       </TextBlock>
                       <TextBox Grid.Row="12" Text="{Binding ConstructionMonths}" Tag="13" Style="{StaticResource AnnualizerFieldInputStyle}"/>
+
+                      <TextBlock Grid.Row="14" Style="{StaticResource AnnualizerFieldLabelStyle}">
+                          <InlineUIContainer BaselineAlignment="Center">
+                              <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                              ToolTip="Select whether IDC accrues from the beginning, middle, or end of each construction month when no detailed schedule is provided."/>
+                          </InlineUIContainer>
+                          <Run Text="IDC Timing Assumption"/>
+                      </TextBlock>
+                      <ComboBox Grid.Row="14"
+                                Style="{StaticResource AnnualizerFieldComboStyle}"
+                                ItemsSource="{Binding IdcTimingOptions}"
+                                SelectedItem="{Binding IdcTimingBasis}"/>
                           </Grid>
                       </Grid>
                   </Border>


### PR DESCRIPTION
## Summary
- add an IDC timing assumption selector to the cost annualization inputs so users can choose beginning, middle, or end of period treatment
- allow the annualizer computation to respect the selected default timing when no detailed IDC schedule is provided

## Testing
- dotnet build *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dad1c2cca48330b6bec6af740a6731