### PR TITLE
Add period-based IDC calculation options

### DIFF
--- a/Models/AnnualizerModel.cs
+++ b/Models/AnnualizerModel.cs
@@ -19,9 +19,13 @@ namespace EconToolbox.Desktop.Models
             double[]? idcCosts = null,
             string[]? idcTimings = null,
             int[]? idcMonths = null,
-            string? defaultIdcTiming = null)
+            string? defaultIdcTiming = null,
+            bool calculateInterestAtPeriod = false,
+            string? firstPaymentTiming = null,
+            string? lastPaymentTiming = null)
         {
-            double idc = ComputeIdc(firstCost, rate, constructionMonths, idcCosts, idcTimings, idcMonths, defaultIdcTiming);
+            double idc = ComputeIdc(firstCost, rate, constructionMonths, idcCosts, idcTimings, idcMonths, defaultIdcTiming,
+                calculateInterestAtPeriod, firstPaymentTiming, lastPaymentTiming);
 
             double pvFuture = 0.0;
             if (futureCosts != null)
@@ -51,7 +55,10 @@ namespace EconToolbox.Desktop.Models
             double[]? costs,
             string[]? timings,
             int[]? monthIndices,
-            string? defaultTiming)
+            string? defaultTiming,
+            bool calculateAtPeriod,
+            string? firstPaymentTiming,
+            string? lastPaymentTiming)
         {
             if (months <= 0)
                 return 0.0;
@@ -63,6 +70,7 @@ namespace EconToolbox.Desktop.Models
             int[] scheduleMonths;
 
             string normalizedDefaultTiming = NormalizeTiming(defaultTiming);
+            string defaultTimingForSchedule = calculateAtPeriod ? "beginning" : normalizedDefaultTiming;
 
             if (costs == null || costs.Length == 0)
             {
@@ -75,40 +83,129 @@ namespace EconToolbox.Desktop.Models
                 {
                     scheduleCosts[i] = monthlyCost;
                     scheduleMonths[i] = i;
-                    scheduleTimings[i] = normalizedDefaultTiming;
+                    scheduleTimings[i] = defaultTimingForSchedule;
                 }
             }
             else
             {
                 scheduleCosts = costs;
-                scheduleTimings = NormalizeTimings(timings, costs.Length);
+                scheduleTimings = NormalizeTimings(timings, costs.Length, defaultTimingForSchedule);
                 scheduleMonths = NormalizeMonths(monthIndices, costs.Length);
             }
 
+            return calculateAtPeriod
+                ? ComputePeriodBasedIdc(scheduleCosts, scheduleTimings, scheduleMonths, months, monthlyRate,
+                    firstPaymentTiming, lastPaymentTiming)
+                : ComputeMonthlyIdc(scheduleCosts, scheduleTimings, scheduleMonths, months, monthlyRate);
+        }
+
+        private static double ComputeMonthlyIdc(double[] costs, string[] timings, int[] months, int totalMonths, double monthlyRate)
+        {
             double idc = 0.0;
-            for (int i = 0; i < scheduleCosts.Length; i++)
+            for (int i = 0; i < costs.Length; i++)
             {
-                double timingOffset = NormalizeTiming(scheduleTimings[i]) switch
-                {
-                    "beginning" => 0.0,
-                    "end" => 1.0,
-                    "middle" => 0.5,
-                    "midpoint" => 0.5,
-                    _ => 1.0
-                };
+                double timingOffset = GetTimingOffset(timings[i]);
 
-                int monthIndex = scheduleMonths[i];
-                if (monthIndex < 0)
-                    monthIndex = 0;
-                if (monthIndex >= months)
-                    monthIndex = months - 1;
-
+                int monthIndex = ClampMonthIndex(months[i], totalMonths);
                 double eventMonth = monthIndex + timingOffset;
-                double remaining = Math.Max(0.0, months - eventMonth);
-                idc += scheduleCosts[i] * monthlyRate * remaining;
+                double remaining = Math.Max(0.0, totalMonths - eventMonth);
+                idc += costs[i] * monthlyRate * remaining;
             }
 
             return idc;
+        }
+
+        private static double ComputePeriodBasedIdc(
+            double[] costs,
+            string[] timings,
+            int[] months,
+            int totalMonths,
+            double monthlyRate,
+            string? firstPaymentTiming,
+            string? lastPaymentTiming)
+        {
+            if (costs.Length == 0)
+                return 0.0;
+
+            double[] eventTimes = new double[costs.Length];
+            for (int i = 0; i < costs.Length; i++)
+            {
+                int monthIndex = ClampMonthIndex(months[i], totalMonths);
+                double timingOffset = GetTimingOffset(timings[i]);
+                eventTimes[i] = monthIndex + timingOffset;
+            }
+
+            int firstIndex = 0;
+            int lastIndex = 0;
+            for (int i = 1; i < eventTimes.Length; i++)
+            {
+                if (eventTimes[i] < eventTimes[firstIndex])
+                    firstIndex = i;
+                if (eventTimes[i] > eventTimes[lastIndex])
+                    lastIndex = i;
+            }
+
+            int clampedFirstMonth = ClampMonthIndex(months[firstIndex], totalMonths);
+            double normalizedFirstOffset = NormalizeFirstPayment(firstPaymentTiming);
+            eventTimes[firstIndex] = clampedFirstMonth + normalizedFirstOffset;
+
+            int clampedLastMonth = ClampMonthIndex(months[lastIndex], totalMonths);
+            int maxConstructionMonth = totalMonths > 0 ? totalMonths - 1 : 0;
+            clampedLastMonth = Math.Max(clampedLastMonth, maxConstructionMonth);
+            double normalizedLastOffset = NormalizeLastPayment(lastPaymentTiming);
+            double lastBoundary = Math.Max(eventTimes[lastIndex], clampedLastMonth + normalizedLastOffset);
+
+            double idc = 0.0;
+            for (int i = 0; i < costs.Length; i++)
+            {
+                double eventTime = eventTimes[i];
+                double remaining = Math.Max(0.0, lastBoundary - eventTime);
+                idc += costs[i] * monthlyRate * remaining;
+            }
+
+            return idc;
+        }
+
+        private static double GetTimingOffset(string? timing)
+        {
+            return NormalizeTiming(timing) switch
+            {
+                "beginning" => 0.0,
+                "end" => 1.0,
+                "middle" => 0.5,
+                "midpoint" => 0.5,
+                _ => 1.0
+            };
+        }
+
+        private static int ClampMonthIndex(int monthIndex, int totalMonths)
+        {
+            if (monthIndex < 0)
+                return 0;
+            if (totalMonths <= 0)
+                return 0;
+            if (monthIndex >= totalMonths)
+                return totalMonths - 1;
+            return monthIndex;
+        }
+
+        private static double NormalizeFirstPayment(string? timing)
+        {
+            return NormalizeTiming(timing) switch
+            {
+                "end" => 1.0,
+                _ => 0.0
+            };
+        }
+
+        private static double NormalizeLastPayment(string? timing)
+        {
+            return NormalizeTiming(timing) switch
+            {
+                "beginning" => 0.0,
+                "end" => 1.0,
+                _ => 0.5
+            };
         }
 
         private static string NormalizeTiming(string? timing)
@@ -127,13 +224,13 @@ namespace EconToolbox.Desktop.Models
             };
         }
 
-        private static string[] NormalizeTimings(string[]? timings, int length)
+        private static string[] NormalizeTimings(string[]? timings, int length, string fallback)
         {
             var normalized = new string[length];
             for (int i = 0; i < length; i++)
             {
                 string? timing = timings != null && i < timings.Length ? timings[i] : null;
-                normalized[i] = string.IsNullOrWhiteSpace(timing) ? "midpoint" : timing.Trim();
+                normalized[i] = string.IsNullOrWhiteSpace(timing) ? fallback : timing.Trim();
             }
 
             return normalized;

--- a/ViewModels/AnnualizerViewModel.cs
+++ b/ViewModels/AnnualizerViewModel.cs
@@ -23,6 +23,9 @@ namespace EconToolbox.Desktop.ViewModels
         private ObservableCollection<FutureCostEntry> _idcEntries = new();
         private ObservableCollection<string> _results = new();
         private string _idcTimingBasis = "Middle";
+        private bool _calculateInterestAtPeriod;
+        private string _idcFirstPaymentTiming = "Beginning";
+        private string _idcLastPaymentTiming = "Middle";
 
         private double _idc;
         private double _totalInvestment;
@@ -94,6 +97,8 @@ namespace EconToolbox.Desktop.ViewModels
         }
 
         public IReadOnlyList<string> IdcTimingOptions { get; } = new[] { "Beginning", "Middle", "End" };
+        public IReadOnlyList<string> IdcFirstPaymentOptions { get; } = new[] { "Beginning", "End" };
+        public IReadOnlyList<string> IdcLastPaymentOptions { get; } = new[] { "Beginning", "Middle", "End" };
 
         public string IdcTimingBasis
         {
@@ -103,6 +108,48 @@ namespace EconToolbox.Desktop.ViewModels
                 if (_idcTimingBasis != value)
                 {
                     _idcTimingBasis = value;
+                    OnPropertyChanged();
+                    Compute();
+                }
+            }
+        }
+
+        public bool CalculateInterestAtPeriod
+        {
+            get => _calculateInterestAtPeriod;
+            set
+            {
+                if (_calculateInterestAtPeriod != value)
+                {
+                    _calculateInterestAtPeriod = value;
+                    OnPropertyChanged();
+                    Compute();
+                }
+            }
+        }
+
+        public string IdcFirstPaymentTiming
+        {
+            get => _idcFirstPaymentTiming;
+            set
+            {
+                if (_idcFirstPaymentTiming != value)
+                {
+                    _idcFirstPaymentTiming = value;
+                    OnPropertyChanged();
+                    Compute();
+                }
+            }
+        }
+
+        public string IdcLastPaymentTiming
+        {
+            get => _idcLastPaymentTiming;
+            set
+            {
+                if (_idcLastPaymentTiming != value)
+                {
+                    _idcLastPaymentTiming = value;
                     OnPropertyChanged();
                     Compute();
                 }
@@ -256,7 +303,8 @@ namespace EconToolbox.Desktop.ViewModels
 
                 var result = AnnualizerModel.Compute(FirstCost, Rate / 100.0, AnnualOm, AnnualBenefits, future,
                     AnalysisPeriod, BaseYear, ConstructionMonths, costArr, timingArr, monthArr,
-                    NormalizeTimingChoice(IdcTimingBasis));
+                    NormalizeTimingChoice(IdcTimingBasis), CalculateInterestAtPeriod,
+                    NormalizeFirstPaymentChoice(IdcFirstPaymentTiming), NormalizeLastPaymentChoice(IdcLastPaymentTiming));
                 Idc = result.Idc;
                 TotalInvestment = result.TotalInvestment;
                 Crf = result.Crf;
@@ -312,6 +360,34 @@ namespace EconToolbox.Desktop.ViewModels
         }
 
         private static string NormalizeTimingChoice(string? choice)
+        {
+            if (string.IsNullOrWhiteSpace(choice))
+                return "midpoint";
+
+            return choice.Trim().ToLowerInvariant() switch
+            {
+                "beginning" => "beginning",
+                "middle" => "midpoint",
+                "midpoint" => "midpoint",
+                "end" => "end",
+                _ => "midpoint"
+            };
+        }
+
+        private static string NormalizeFirstPaymentChoice(string? choice)
+        {
+            if (string.IsNullOrWhiteSpace(choice))
+                return "beginning";
+
+            return choice.Trim().ToLowerInvariant() switch
+            {
+                "beginning" => "beginning",
+                "end" => "end",
+                _ => "beginning"
+            };
+        }
+
+        private static string NormalizeLastPaymentChoice(string? choice)
         {
             if (string.IsNullOrWhiteSpace(choice))
                 return "midpoint";

--- a/Views/AnnualizerView.xaml
+++ b/Views/AnnualizerView.xaml
@@ -158,6 +158,20 @@
                                   </DataTrigger>
                               </Style.Triggers>
                           </Style>
+                          <Style x:Key="AnnualizerFieldToggleStyle" TargetType="CheckBox">
+                              <Setter Property="Grid.Column" Value="2"/>
+                              <Setter Property="Grid.ColumnSpan" Value="1"/>
+                              <Setter Property="Margin" Value="0,0,0,16"/>
+                              <Setter Property="HorizontalAlignment" Value="Left"/>
+                              <Style.Triggers>
+                                  <DataTrigger Binding="{Binding ActualWidth, RelativeSource={RelativeSource AncestorType=UserControl}, Converter={StaticResource WidthToLayoutModeConverter}}"
+                                               Value="Narrow">
+                                      <Setter Property="Grid.Column" Value="0"/>
+                                      <Setter Property="Grid.ColumnSpan" Value="3"/>
+                                      <Setter Property="Margin" Value="0,4,0,16"/>
+                                  </DataTrigger>
+                              </Style.Triggers>
+                          </Style>
                       </Grid.Resources>
                       <Grid.ColumnDefinitions>
                           <ColumnDefinition Width="Auto" SharedSizeGroup="AnnualizerLabel"/>
@@ -165,6 +179,9 @@
                           <ColumnDefinition Width="*" SharedSizeGroup="AnnualizerInput"/>
                       </Grid.ColumnDefinitions>
                       <Grid.RowDefinitions>
+                          <RowDefinition Height="Auto"/>
+                          <RowDefinition Height="Auto"/>
+                          <RowDefinition Height="Auto"/>
                           <RowDefinition Height="Auto"/>
                           <RowDefinition Height="Auto"/>
                           <RowDefinition Height="Auto"/>
@@ -258,9 +275,75 @@
                           <Run Text="IDC Timing Assumption"/>
                       </TextBlock>
                       <ComboBox Grid.Row="14"
-                                Style="{StaticResource AnnualizerFieldComboStyle}"
                                 ItemsSource="{Binding IdcTimingOptions}"
-                                SelectedItem="{Binding IdcTimingBasis}"/>
+                                SelectedItem="{Binding IdcTimingBasis}">
+                          <ComboBox.Style>
+                              <Style TargetType="ComboBox" BasedOn="{StaticResource AnnualizerFieldComboStyle}">
+                                  <Setter Property="IsEnabled" Value="True"/>
+                                  <Style.Triggers>
+                                      <DataTrigger Binding="{Binding CalculateInterestAtPeriod}" Value="True">
+                                          <Setter Property="IsEnabled" Value="False"/>
+                                      </DataTrigger>
+                                  </Style.Triggers>
+                              </Style>
+                          </ComboBox.Style>
+                      </ComboBox>
+
+                      <TextBlock Grid.Row="15" Style="{StaticResource AnnualizerFieldLabelStyle}">
+                          <InlineUIContainer BaselineAlignment="Center">
+                              <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                              ToolTip="Toggle to calculate IDC using period-based first and last payment assumptions."/>
+                          </InlineUIContainer>
+                          <Run Text="Calculate Interest at Period"/>
+                      </TextBlock>
+                      <CheckBox Grid.Row="15"
+                                Content="Enable"
+                                IsChecked="{Binding CalculateInterestAtPeriod}"
+                                Style="{StaticResource AnnualizerFieldToggleStyle}"/>
+
+                      <TextBlock Grid.Row="16" Style="{StaticResource AnnualizerFieldLabelStyle}">
+                          <InlineUIContainer BaselineAlignment="Center">
+                              <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                              ToolTip="Choose when the first payment occurs within the construction period for period-based IDC."/>
+                          </InlineUIContainer>
+                          <Run Text="First Payment Timing"/>
+                      </TextBlock>
+                      <ComboBox Grid.Row="16"
+                                ItemsSource="{Binding IdcFirstPaymentOptions}"
+                                SelectedItem="{Binding IdcFirstPaymentTiming}">
+                          <ComboBox.Style>
+                              <Style TargetType="ComboBox" BasedOn="{StaticResource AnnualizerFieldComboStyle}">
+                                  <Setter Property="IsEnabled" Value="False"/>
+                                  <Style.Triggers>
+                                      <DataTrigger Binding="{Binding CalculateInterestAtPeriod}" Value="True">
+                                          <Setter Property="IsEnabled" Value="True"/>
+                                      </DataTrigger>
+                                  </Style.Triggers>
+                              </Style>
+                          </ComboBox.Style>
+                      </ComboBox>
+
+                      <TextBlock Grid.Row="17" Style="{StaticResource AnnualizerFieldLabelStyle}">
+                          <InlineUIContainer BaselineAlignment="Center">
+                              <ContentControl Style="{StaticResource Content.InfoIcon}"
+                                              ToolTip="Define the timing of the final payment when using period-based IDC."/>
+                          </InlineUIContainer>
+                          <Run Text="Last Payment Timing"/>
+                      </TextBlock>
+                      <ComboBox Grid.Row="17"
+                                ItemsSource="{Binding IdcLastPaymentOptions}"
+                                SelectedItem="{Binding IdcLastPaymentTiming}">
+                          <ComboBox.Style>
+                              <Style TargetType="ComboBox" BasedOn="{StaticResource AnnualizerFieldComboStyle}">
+                                  <Setter Property="IsEnabled" Value="False"/>
+                                  <Style.Triggers>
+                                      <DataTrigger Binding="{Binding CalculateInterestAtPeriod}" Value="True">
+                                          <Setter Property="IsEnabled" Value="True"/>
+                                      </DataTrigger>
+                                  </Style.Triggers>
+                              </Style>
+                          </ComboBox.Style>
+                      </ComboBox>
                           </Grid>
                       </Grid>
                   </Border>


### PR DESCRIPTION
## Summary
- add UI controls to enable period-based IDC calculation along with first and last payment timing selections
- extend the annualizer view model to expose the new options and pass them into the computation pipeline
- update the IDC computation logic to support the new period-based timing parameters while keeping the monthly approach intact

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dad82d71708330a2cc26eed2a3a89d