### PR TITLE
Align financial input controls vertically

### DIFF
--- a/Views/AnnualizerView.xaml
+++ b/Views/AnnualizerView.xaml
@@ -134,6 +134,8 @@
                               <Setter Property="Grid.ColumnSpan" Value="1"/>
                               <Setter Property="Margin" Value="0,0,0,16"/>
                               <Setter Property="HorizontalAlignment" Value="Stretch"/>
+                              <Setter Property="VerticalAlignment" Value="Center"/>
+                              <Setter Property="VerticalContentAlignment" Value="Center"/>
                               <Style.Triggers>
                                   <DataTrigger Binding="{Binding ActualWidth, RelativeSource={RelativeSource AncestorType=UserControl}, Converter={StaticResource WidthToLayoutModeConverter}}"
                                                Value="Narrow">
@@ -149,6 +151,7 @@
                               <Setter Property="Grid.ColumnSpan" Value="1"/>
                               <Setter Property="Margin" Value="0,0,0,16"/>
                               <Setter Property="HorizontalAlignment" Value="Stretch"/>
+                              <Setter Property="VerticalAlignment" Value="Center"/>
                               <Style.Triggers>
                                   <DataTrigger Binding="{Binding ActualWidth, RelativeSource={RelativeSource AncestorType=UserControl}, Converter={StaticResource WidthToLayoutModeConverter}}"
                                                Value="Narrow">
@@ -163,6 +166,7 @@
                               <Setter Property="Grid.ColumnSpan" Value="1"/>
                               <Setter Property="Margin" Value="0,0,0,16"/>
                               <Setter Property="HorizontalAlignment" Value="Left"/>
+                              <Setter Property="VerticalAlignment" Value="Center"/>
                               <Style.Triggers>
                                   <DataTrigger Binding="{Binding ActualWidth, RelativeSource={RelativeSource AncestorType=UserControl}, Converter={StaticResource WidthToLayoutModeConverter}}"
                                                Value="Narrow">


### PR DESCRIPTION
## Summary
- center the financial input text boxes, combo boxes, and toggle within their grid rows to align with labels

## Testing
- dotnet build *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68dadd69f84883308b2b1bd4f0f60a4b