### PR TITLE
Adjust annualizer label spacing for wide layout

### DIFF
--- a/Views/AnnualizerView.xaml
+++ b/Views/AnnualizerView.xaml
@@ -123,6 +123,10 @@
                               <Setter Property="VerticalAlignment" Value="Center"/>
                               <Style.Triggers>
                                   <DataTrigger Binding="{Binding ActualWidth, RelativeSource={RelativeSource AncestorType=UserControl}, Converter={StaticResource WidthToLayoutModeConverter}}"
+                                               Value="Wide">
+                                      <Setter Property="Margin" Value="0,0,12,4"/>
+                                  </DataTrigger>
+                                  <DataTrigger Binding="{Binding ActualWidth, RelativeSource={RelativeSource AncestorType=UserControl}, Converter={StaticResource WidthToLayoutModeConverter}}"
                                                Value="Narrow">
                                       <Setter Property="Grid.ColumnSpan" Value="3"/>
                                       <Setter Property="Margin" Value="0,16,0,4"/>


### PR DESCRIPTION
## Summary
- add a layout-mode trigger so annualizer field labels use a smaller top margin in wide mode
- keep the existing narrow-mode behavior for stacked layouts

## Testing
- dotnet build EconToolbox.Desktop.sln *(fails: `dotnet` CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68daf2b898288330985095bce6ebc951