### PR TITLE
Enhance water demand defaults and reset tables

### DIFF
--- a/ViewModels/UpdatedCostViewModel.cs
+++ b/ViewModels/UpdatedCostViewModel.cs
@@ -207,6 +207,8 @@ namespace EconToolbox.Desktop.ViewModels
         public ICommand ComputeUpdatedStorageCommand { get; }
         public ICommand ComputeRrrCommand { get; }
         public ICommand ComputeTotalCommand { get; }
+        public ICommand ResetUpdatedCostItemsCommand { get; }
+        public ICommand ResetRrrItemsCommand { get; }
         public ICommand ComputeCommand { get; }
 
         public UpdatedCostViewModel()
@@ -216,6 +218,8 @@ namespace EconToolbox.Desktop.ViewModels
             ComputeUpdatedStorageCommand = new RelayCommand(ComputeUpdatedStorage);
             ComputeRrrCommand = new RelayCommand(ComputeRrr);
             ComputeTotalCommand = new RelayCommand(ComputeTotal);
+            ResetUpdatedCostItemsCommand = new RelayCommand(ResetUpdatedCostItems);
+            ResetRrrItemsCommand = new RelayCommand(ResetRrrCostItems);
             ComputeCommand = new RelayCommand(() =>
             {
                 ComputeStorage();
@@ -274,6 +278,28 @@ namespace EconToolbox.Desktop.ViewModels
             double crf2 = CapitalRecoveryModel.Calculate(DiscountRate2 / 100.0, AnalysisPeriod2);
             Capital2 = TotalUpdatedCost * Percent * crf2;
             Total2 = Capital2 + OmScaled;
+        }
+
+        private void ResetUpdatedCostItems()
+        {
+            foreach (var item in UpdatedCostItems)
+            {
+                item.ActualCost = 0;
+                item.UpdateFactor = 0;
+                item.UpdatedCost = 0;
+            }
+
+            TotalUpdatedCost = 0;
+            ComputeTotal();
+        }
+
+        private void ResetRrrCostItems()
+        {
+            RrrCostItems.Clear();
+            RrrTotalPv = 0;
+            RrrUpdatedCost = 0;
+            RrrAnnualized = 0;
+            ComputeTotal();
         }
     }
 }

--- a/Views/UpdatedCostView.xaml
+++ b/Views/UpdatedCostView.xaml
@@ -278,6 +278,12 @@
                         <DataGridTextColumn Header="Updated Cost" Binding="{Binding UpdatedCost}" IsReadOnly="True"/>
                     </DataGrid.Columns>
                 </DataGrid>
+                <Button Margin="0,4,0,4" Command="{Binding ResetUpdatedCostItemsCommand}" HorizontalAlignment="Right">
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                        <TextBlock FontFamily="Segoe MDL2 Assets" Text="&#xE72C;" FontSize="16" Margin="0,0,6,0"/>
+                        <TextBlock Text="Reset Table"/>
+                    </StackPanel>
+                </Button>
                 <Button Margin="0,5,0,5" Command="{Binding ComputeUpdatedStorageCommand}">
                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
                         <TextBlock FontFamily="Segoe MDL2 Assets"
@@ -324,6 +330,7 @@
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="*"/>
+                        <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
                     </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
@@ -395,7 +402,13 @@
                             <DataGridTextColumn Header="Present Value" Binding="{Binding PresentValue}" IsReadOnly="True"/>
                         </DataGrid.Columns>
                     </DataGrid>
-                    <Button Grid.Row="5" Grid.ColumnSpan="2" Margin="0,5,0,5" Command="{Binding ComputeRrrCommand}">
+                    <Button Grid.Row="5" Grid.ColumnSpan="2" Margin="0,4,0,4" Command="{Binding ResetRrrItemsCommand}" HorizontalAlignment="Right">
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                            <TextBlock FontFamily="Segoe MDL2 Assets" Text="&#xE72C;" FontSize="16" Margin="0,0,6,0"/>
+                            <TextBlock Text="Reset Table"/>
+                        </StackPanel>
+                    </Button>
+                    <Button Grid.Row="6" Grid.ColumnSpan="2" Margin="0,5,0,5" Command="{Binding ComputeRrrCommand}">
                         <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
                             <TextBlock FontFamily="Segoe MDL2 Assets"
                                        Text="&#xE8EF;"
@@ -404,7 +417,7 @@
                             <TextBlock Text="Compute"/>
                         </StackPanel>
                     </Button>
-                    <StackPanel Grid.Row="6" Grid.ColumnSpan="2">
+                    <StackPanel Grid.Row="7" Grid.ColumnSpan="2">
                         <TextBlock Text="{Binding RrrUpdatedCost, StringFormat=Updated Cost: {0:C2}}" ToolTip="Updated Cost = Present Value × CWCCI" FontWeight="Bold" Margin="0,0,0,4"/>
                         <TextBlock Text="{Binding RrrAnnualized, StringFormat=Annualized: {0:C2}}" ToolTip="Annualized = Updated Cost × CRF" FontWeight="Bold"/>
                     </StackPanel>

--- a/Views/WaterDemandView.xaml
+++ b/Views/WaterDemandView.xaml
@@ -310,49 +310,49 @@
                                     <DataGrid ItemsSource="{Binding Results}" AutoGenerateColumns="False" FontWeight="Bold" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" ScrollViewer.VerticalScrollBarVisibility="Auto" ScrollViewer.HorizontalScrollBarVisibility="Auto" Margin="0">
                                         <DataGrid.Columns>
                                             <DataGridTextColumn Header="Year" Binding="{Binding Year}"/>
-                                            <DataGridTextColumn Header="Growth Rate" Binding="{Binding GrowthRate, Mode=TwoWay, StringFormat={}{0:N2}}">
+                                            <DataGridTextColumn Header="Growth Rate (%)" Binding="{Binding GrowthRate, Mode=TwoWay, StringFormat={}{0:N2}}">
                                                 <DataGridTextColumn.ElementStyle>
                                                     <Style TargetType="TextBlock">
                                                         <Setter Property="ToolTip" Value="Growth Rate = (Current Demand - Previous Demand) / Previous Demand"/>
                                                     </Style>
                                                 </DataGridTextColumn.ElementStyle>
                                             </DataGridTextColumn>
-                                            <DataGridTextColumn Header="Demand" Binding="{Binding Demand, StringFormat={}{0:N2}}">
+                                            <DataGridTextColumn Header="Demand (gallons/day)" Binding="{Binding Demand, StringFormat={}{0:N2}}">
                                                 <DataGridTextColumn.ElementStyle>
                                                     <Style TargetType="TextBlock">
                                                         <Setter Property="ToolTip" Value="Demand = Prior Demand × (1 + Growth Rate)"/>
                                                     </Style>
                                                 </DataGridTextColumn.ElementStyle>
                                             </DataGridTextColumn>
-                                            <DataGridTextColumn Header="Residential" Binding="{Binding ResidentialDemand, StringFormat={}{0:N2}}">
+                                            <DataGridTextColumn Header="Residential (gallons/day)" Binding="{Binding ResidentialDemand, StringFormat={}{0:N2}}">
                                                 <DataGridTextColumn.ElementStyle>
                                                     <Style TargetType="TextBlock">
                                                         <Setter Property="ToolTip" Value="Residential = Demand × Residential %"/>
                                                     </Style>
                                                 </DataGridTextColumn.ElementStyle>
                                             </DataGridTextColumn>
-                                            <DataGridTextColumn Header="Commercial" Binding="{Binding CommercialDemand, StringFormat={}{0:N2}}">
+                                            <DataGridTextColumn Header="Commercial (gallons/day)" Binding="{Binding CommercialDemand, StringFormat={}{0:N2}}">
                                                 <DataGridTextColumn.ElementStyle>
                                                     <Style TargetType="TextBlock">
                                                         <Setter Property="ToolTip" Value="Commercial = Demand × Commercial %"/>
                                                     </Style>
                                                 </DataGridTextColumn.ElementStyle>
                                             </DataGridTextColumn>
-                                            <DataGridTextColumn Header="Industrial" Binding="{Binding IndustrialDemand, StringFormat={}{0:N2}}">
+                                            <DataGridTextColumn Header="Industrial (gallons/day)" Binding="{Binding IndustrialDemand, StringFormat={}{0:N2}}">
                                                 <DataGridTextColumn.ElementStyle>
                                                     <Style TargetType="TextBlock">
                                                         <Setter Property="ToolTip" Value="Industrial = Demand × Industrial %"/>
                                                     </Style>
                                                 </DataGridTextColumn.ElementStyle>
                                             </DataGridTextColumn>
-                                            <DataGridTextColumn Header="Agricultural" Binding="{Binding AgriculturalDemand, StringFormat={}{0:N2}}">
+                                            <DataGridTextColumn Header="Agricultural (gallons/day)" Binding="{Binding AgriculturalDemand, StringFormat={}{0:N2}}">
                                                 <DataGridTextColumn.ElementStyle>
                                                     <Style TargetType="TextBlock">
                                                         <Setter Property="ToolTip" Value="Agricultural = Demand × Agricultural %"/>
                                                     </Style>
                                                 </DataGridTextColumn.ElementStyle>
                                             </DataGridTextColumn>
-                                            <DataGridTextColumn Header="Adjusted" Binding="{Binding AdjustedDemand, StringFormat={}{0:N2}}">
+                                            <DataGridTextColumn Header="Adjusted (gallons/day)" Binding="{Binding AdjustedDemand, StringFormat={}{0:N2}}">
                                                 <DataGridTextColumn.ElementStyle>
                                                     <Style TargetType="TextBlock">
                                                         <Setter Property="ToolTip" Value="Adjusted = Demand ÷ (1 - Losses %) × (1 - Improvements %)"/>


### PR DESCRIPTION
## Summary
- Pre-populate water demand sector percentages with default shares and copy baseline values into empty optimistic/pessimistic fields
- Add explicit units to the water demand forecast table headers for clearer reporting
- Provide reset commands and buttons for the Updated Cost tables so users can quickly clear their inputs

## Testing
- Unable to run `dotnet build` (dotnet CLI is not available in the environment)


------
https://chatgpt.com/codex/tasks/task_e_68ded18adb448330af34ad5e72f33110