### PR TITLE
Add in-app README viewer tab

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -18,6 +18,7 @@ namespace EconToolbox.Desktop
                 {
                     services.AddSingleton<IExcelExportService, ExcelExportService>();
 
+                    services.AddSingleton<ReadMeViewModel>();
                     services.AddSingleton<EadViewModel>();
                     services.AddSingleton<AgricultureDepthDamageViewModel>();
                     services.AddSingleton<UpdatedCostViewModel>();

--- a/EconToolbox.Desktop.csproj
+++ b/EconToolbox.Desktop.csproj
@@ -14,5 +14,11 @@
     <PackageReference Include="ClosedXML" Version="0.104.0" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="Markdig.Wpf" Version="0.2.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="README.md">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -26,6 +26,9 @@
                 <DataTemplate DataType="{x:Type vm:EadViewModel}">
                     <views:EadView/>
                 </DataTemplate>
+                <DataTemplate DataType="{x:Type vm:ReadMeViewModel}">
+                    <views:ReadMeView/>
+                </DataTemplate>
                 <DataTemplate DataType="{x:Type vm:AgricultureDepthDamageViewModel}">
                     <views:AgricultureDepthDamageView/>
                 </DataTemplate>

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 This repository contains a Windows Presentation Foundation (WPF) desktop application that delivers a suite of economic analysis tools.
 The project targets **.NET 8**, embraces the Model-View-ViewModel (MVVM) pattern via [CommunityToolkit.Mvvm](https://learn.microsoft.com/windows/communitytoolkit/mvvm/introduction), and boots with a host-based dependency injection container powered by `Microsoft.Extensions.Hosting`.
 
+> 💡 **In-app documentation:** The full contents of this README are rendered directly inside the Economic Toolbox under the **Project README** tab so you can review setup guidance, module notes, and publishing steps without leaving the application.
+
 Key architectural highlights:
 
 - **Strongly typed MVVM infrastructure** – `ObservableObject`, source-generated commands, and validation helpers are available through the toolkit.

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -7,6 +7,7 @@ namespace EconToolbox.Desktop.ViewModels
 {
     public class MainViewModel : BaseViewModel
     {
+        public ReadMeViewModel ReadMe { get; }
         public EadViewModel Ead { get; }
         public AgricultureDepthDamageViewModel AgricultureDepthDamage { get; }
         public UpdatedCostViewModel UpdatedCost { get; }
@@ -53,6 +54,7 @@ namespace EconToolbox.Desktop.ViewModels
         private readonly IExcelExportService _excelExportService;
 
         public MainViewModel(
+            ReadMeViewModel readMe,
             EadViewModel ead,
             AgricultureDepthDamageViewModel agricultureDepthDamage,
             UpdatedCostViewModel updatedCost,
@@ -64,6 +66,7 @@ namespace EconToolbox.Desktop.ViewModels
             DrawingViewModel drawing,
             IExcelExportService excelExportService)
         {
+            ReadMe = readMe;
             Ead = ead;
             AgricultureDepthDamage = agricultureDepthDamage;
             UpdatedCost = updatedCost;
@@ -80,6 +83,24 @@ namespace EconToolbox.Desktop.ViewModels
 
             Modules = new List<ModuleDefinition>
             {
+                new ModuleDefinition(
+                    "Project README",
+                    "Review onboarding tips, module descriptions, and build instructions without leaving the toolbox.",
+                    new[]
+                    {
+                        "Browse the introduction to understand the toolkit's purpose and architecture.",
+                        "Follow the build and publish instructions before sharing the desktop app with teammates.",
+                        "Reference the calculator summaries to confirm which module fits your analysis need."
+                    },
+                    new[]
+                    {
+                        "Shows the repository's README rendered with headings, lists, and syntax highlighting.",
+                        "Keeps the latest project documentation available offline inside the application shell.",
+                        "Supports opening external links in your default browser for deeper references."
+                    },
+                    "Example: Quickly scan the packaging checklist before exporting deliverables for a stakeholder workshop.",
+                    ReadMe,
+                    null),
                 new ModuleDefinition(
                     "Expected Annual Damage (EAD)",
                     "Quantify how frequently damages occur by pairing exceedance probabilities with damage estimates.",

--- a/ViewModels/ReadMeViewModel.cs
+++ b/ViewModels/ReadMeViewModel.cs
@@ -1,0 +1,49 @@
+using System;
+using System.IO;
+
+namespace EconToolbox.Desktop.ViewModels
+{
+    public class ReadMeViewModel : BaseViewModel
+    {
+        private string _markdownContent = "Loading README...";
+
+        public string MarkdownContent
+        {
+            get => _markdownContent;
+            private set => SetProperty(ref _markdownContent, value);
+        }
+
+        public ReadMeViewModel()
+        {
+            LoadReadMe();
+        }
+
+        private void LoadReadMe()
+        {
+            try
+            {
+                var baseDirectory = AppContext.BaseDirectory;
+                var candidatePaths = new[]
+                {
+                    Path.Combine(baseDirectory, "README.md"),
+                    Path.Combine(baseDirectory, "..", "..", "..", "README.md")
+                };
+
+                foreach (var path in candidatePaths)
+                {
+                    if (File.Exists(path))
+                    {
+                        MarkdownContent = File.ReadAllText(path);
+                        return;
+                    }
+                }
+
+                MarkdownContent = "README.md could not be located in the application directory.";
+            }
+            catch (Exception ex)
+            {
+                MarkdownContent = $"Unable to load README.md: {ex.Message}";
+            }
+        }
+    }
+}

--- a/Views/ReadMeView.xaml
+++ b/Views/ReadMeView.xaml
@@ -1,0 +1,21 @@
+<UserControl x:Class="EconToolbox.Desktop.Views.ReadMeView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:md="clr-namespace:Markdig.Wpf;assembly=Markdig.Wpf">
+    <Grid Background="Transparent">
+        <Border Background="{StaticResource Brush.Surface}"
+                BorderBrush="{StaticResource Brush.Border}"
+                BorderThickness="1"
+                CornerRadius="12"
+                Padding="{StaticResource Padding.Section}">
+            <md:MarkdownScrollViewer x:Name="MarkdownViewer"
+                                     Markdown="{Binding MarkdownContent}"
+                                     VerticalScrollBarVisibility="Auto"
+                                     HorizontalScrollBarVisibility="Disabled"
+                                     Background="Transparent"
+                                     Foreground="{StaticResource Brush.TextPrimary}"
+                                     FontSize="14"
+                                     LinkClicked="MarkdownViewer_OnLinkClicked"/>
+        </Border>
+    </Grid>
+</UserControl>

--- a/Views/ReadMeView.xaml.cs
+++ b/Views/ReadMeView.xaml.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Diagnostics;
+using System.Windows.Controls;
+using Markdig.Wpf;
+
+namespace EconToolbox.Desktop.Views
+{
+    public partial class ReadMeView : UserControl
+    {
+        public ReadMeView()
+        {
+            InitializeComponent();
+        }
+
+        private void MarkdownViewer_OnLinkClicked(object sender, LinkEventArgs e)
+        {
+            if (string.IsNullOrWhiteSpace(e.Link))
+            {
+                return;
+            }
+
+            try
+            {
+                if (Uri.TryCreate(e.Link, UriKind.Absolute, out var uri))
+                {
+                    Process.Start(new ProcessStartInfo(uri.AbsoluteUri) { UseShellExecute = true });
+                }
+            }
+            catch
+            {
+                // Swallow exceptions to avoid crashing the UI when a link cannot be opened.
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated Project README module backed by a Markdown viewer so documentation is accessible inside the app
- register the new view model, view, and dependencies while surfacing the tab in the existing module collection
- copy the README into the build output and note the in-app documentation availability directly in the markdown file

## Testing
- dotnet build *(fails: `dotnet` command is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e3f98cf3b483309397a0cfe19a8073