### PR TITLE
Replace markdown viewer dependency with MdXaml

### DIFF
--- a/EconToolbox.Desktop.csproj
+++ b/EconToolbox.Desktop.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="ClosedXML" Version="0.104.0" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-    <PackageReference Include="Markdig.Wpf" Version="0.2.1" />
+    <PackageReference Include="MdXaml" Version="1.27.0" />
   </ItemGroup>
   <ItemGroup>
     <None Include="README.md">

--- a/Views/ReadMeView.xaml
+++ b/Views/ReadMeView.xaml
@@ -1,7 +1,7 @@
 <UserControl x:Class="EconToolbox.Desktop.Views.ReadMeView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:md="clr-namespace:Markdig.Wpf;assembly=Markdig.Wpf">
+             xmlns:md="clr-namespace:MdXaml;assembly=MdXaml">
     <Grid Background="Transparent">
         <Border Background="{StaticResource Brush.Surface}"
                 BorderBrush="{StaticResource Brush.Border}"
@@ -14,8 +14,7 @@
                                      HorizontalScrollBarVisibility="Disabled"
                                      Background="Transparent"
                                      Foreground="{StaticResource Brush.TextPrimary}"
-                                     FontSize="14"
-                                     LinkClicked="MarkdownViewer_OnLinkClicked"/>
+                                     FontSize="14"/>
         </Border>
     </Grid>
 </UserControl>

--- a/Views/ReadMeView.xaml.cs
+++ b/Views/ReadMeView.xaml.cs
@@ -1,7 +1,8 @@
 using System;
 using System.Diagnostics;
 using System.Windows.Controls;
-using Markdig.Wpf;
+using System.Windows.Documents;
+using System.Windows.Navigation;
 
 namespace EconToolbox.Desktop.Views
 {
@@ -10,18 +11,17 @@ namespace EconToolbox.Desktop.Views
         public ReadMeView()
         {
             InitializeComponent();
+
+            MarkdownViewer.AddHandler(Hyperlink.RequestNavigateEvent,
+                new RequestNavigateEventHandler(MarkdownViewer_OnRequestNavigate));
         }
 
-        private void MarkdownViewer_OnLinkClicked(object sender, LinkEventArgs e)
+        private void MarkdownViewer_OnRequestNavigate(object sender, RequestNavigateEventArgs e)
         {
-            if (string.IsNullOrWhiteSpace(e.Link))
-            {
-                return;
-            }
-
             try
             {
-                if (Uri.TryCreate(e.Link, UriKind.Absolute, out var uri))
+                var link = e.Uri?.AbsoluteUri ?? e.Uri?.ToString() ?? string.Empty;
+                if (!string.IsNullOrWhiteSpace(link) && Uri.TryCreate(link, UriKind.Absolute, out var uri))
                 {
                     Process.Start(new ProcessStartInfo(uri.AbsoluteUri) { UseShellExecute = true });
                 }
@@ -30,6 +30,8 @@ namespace EconToolbox.Desktop.Views
             {
                 // Swallow exceptions to avoid crashing the UI when a link cannot be opened.
             }
+
+            e.Handled = true;
         }
     }
 }


### PR DESCRIPTION
## Summary
- replace the unsupported Markdig.Wpf dependency with MdXaml
- update the README view to use MdXaml's MarkdownScrollViewer and handle hyperlink navigation via RequestNavigate

## Testing
- not run (dotnet CLI is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68e3fcab1c488330ad3e6690851abc4b