### PR TITLE
Fix annualizer row removal and table sizing

### DIFF
--- a/Views/AnnualizerView.xaml
+++ b/Views/AnnualizerView.xaml
@@ -212,8 +212,9 @@
                                                             Style="{StaticResource Button.ActionSecondaryCompact}"
                                                             Margin="0,0,0,8"/>
                                                 </WrapPanel>
-                                                <DataGrid ItemsSource="{Binding AnnualBenefitEntries}"
-                                                          SelectedItem="{Binding SelectedAnnualBenefitEntry, Mode=TwoWay}"
+                                                <DataGrid x:Name="AnnualBenefitsDataGrid"
+                                                          ItemsSource="{Binding AnnualBenefitEntries}"
+                                                          SelectedItem="{Binding SelectedAnnualBenefitEntry, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                                           AutoGenerateColumns="False"
                                                           CanUserAddRows="False"
                                                           CanUserDeleteRows="False"
@@ -221,8 +222,10 @@
                                                           Margin="0,0,0,8"
                                                           ColumnWidth="*"
                                                           HorizontalAlignment="Stretch"
-                                                          Height="180"
-                                                          MinHeight="180">
+                                                          MinHeight="180"
+                                                          SelectionMode="Single"
+                                                          SelectionUnit="FullRow"
+                                                          IsSynchronizedWithCurrentItem="True">
                                                     <DataGrid.Columns>
                                                         <DataGridCheckBoxColumn Header="Include"
                                                                                 Binding="{Binding IncludeInTotal, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
@@ -302,8 +305,9 @@
                                                             Style="{StaticResource Button.ActionSecondaryCompact}"
                                                             Margin="0,0,0,8"/>
                                                 </WrapPanel>
-                                                <DataGrid ItemsSource="{Binding AnnualCostUpdateEntries}"
-                                                          SelectedItem="{Binding SelectedAnnualCostUpdateEntry, Mode=TwoWay}"
+                                                <DataGrid x:Name="CostUpdatesDataGrid"
+                                                          ItemsSource="{Binding AnnualCostUpdateEntries}"
+                                                          SelectedItem="{Binding SelectedAnnualCostUpdateEntry, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                                           AutoGenerateColumns="False"
                                                           CanUserAddRows="False"
                                                           CanUserDeleteRows="False"
@@ -311,8 +315,10 @@
                                                           Margin="0,0,0,8"
                                                           ColumnWidth="*"
                                                           HorizontalAlignment="Stretch"
-                                                          Height="180"
-                                                          MinHeight="180">
+                                                          MinHeight="180"
+                                                          SelectionMode="Single"
+                                                          SelectionUnit="FullRow"
+                                                          IsSynchronizedWithCurrentItem="True">
                                                     <DataGrid.Columns>
                                                         <DataGridTextColumn Header="Cost"
                                                                             Binding="{Binding Cost, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource CurrencyConverter}}"


### PR DESCRIPTION
### Motivation
- The `Remove Selected Row` buttons for the Annual Benefits and Cost Updates tables were not reliably removing the selected row because the DataGrids used fixed selection behavior and the `SelectedItem` updates were not being flushed to the view model immediately. 
- The tables used a fixed `Height="180"` which forced internal scrolling and prevented the cards from growing with added rows, reducing usability.

### Description
- Updated `Views/AnnualizerView.xaml` to set `SelectedItem` bindings to `Mode=TwoWay, UpdateSourceTrigger=PropertyChanged` so the view model receives selection changes immediately for removal commands. 
- Configured both DataGrids with `SelectionMode="Single"`, `SelectionUnit="FullRow"`, and `IsSynchronizedWithCurrentItem="True"` to ensure remove actions target the intended row. 
- Removed the fixed `Height="180"` while keeping `MinHeight="180"` so the DataGrids and their containing cards can expand as rows are added, reducing internal scrolling. 
- Added `x:Name` attributes (`AnnualBenefitsDataGrid` and `CostUpdatesDataGrid`) to the grids to make future UI logic or testing easier.

### Testing
- Attempted `dotnet build EconToolbox.Desktop.csproj` but it could not be executed in this environment because `dotnet` is not installed, so a full compile was not run. 
- Attempted `dotnet test EconToolbox.Desktop.Tests/EconToolbox.Desktop.Tests.csproj --no-restore` but it could not be executed in this environment because `dotnet` is not installed, so automated tests were not run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc18d5b38483309be7bf45f8c39dd8)